### PR TITLE
chore: scaffold build environment for skill-docs

### DIFF
--- a/.github/workflows/skill-docs.yml
+++ b/.github/workflows/skill-docs.yml
@@ -1,0 +1,40 @@
+name: Skill Docs Freshness
+
+# 論点 4 合意：CI 対象は skills/translated/ と skills/native/ のみ。
+# _upstream/gstack/ は subtree として本家 gstack の責任範囲なので除外する。
+# これにより上流の壊れで uzustack の CI が赤くなる構造的負債を回避する。
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'skills/translated/**'
+      - 'skills/native/**'
+      - 'scripts/**'
+      - 'package.json'
+      - 'bun.lock'
+      - '.github/workflows/skill-docs.yml'
+  pull_request:
+    paths:
+      - 'skills/translated/**'
+      - 'skills/native/**'
+      - 'scripts/**'
+      - 'package.json'
+      - 'bun.lock'
+      - '.github/workflows/skill-docs.yml'
+
+jobs:
+  check-freshness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
+      - name: Regenerate SKILL.md files
+        run: bun run gen:skill-docs
+      - name: Verify SKILL.md files are fresh
+        run: |
+          git diff --exit-code -- skills/translated/ skills/native/ || {
+            echo "::error::Generated SKILL.md files are stale. Run: bun run gen:skill-docs"
+            exit 1
+          }

--- a/.github/workflows/skill-docs.yml
+++ b/.github/workflows/skill-docs.yml
@@ -1,8 +1,7 @@
 name: Skill Docs Freshness
 
-# 論点 4 合意：CI 対象は skills/translated/ と skills/native/ のみ。
-# _upstream/gstack/ は subtree として本家 gstack の責任範囲なので除外する。
-# これにより上流の壊れで uzustack の CI が赤くなる構造的負債を回避する。
+# Scope: skills/{translated,native}/ only. _upstream/gstack/ is a subtree
+# owned by upstream gstack — excluded so upstream churn doesn't break our CI.
 
 on:
   push:
@@ -32,9 +31,9 @@ jobs:
       - run: bun install --frozen-lockfile
       - name: Regenerate SKILL.md files
         run: bun run gen:skill-docs
-      - name: Verify SKILL.md files are fresh
+      - name: Verify working tree is clean
         run: |
-          git diff --exit-code -- skills/translated/ skills/native/ || {
-            echo "::error::Generated SKILL.md files are stale. Run: bun run gen:skill-docs"
+          git diff --exit-code || {
+            echo "::error::Generated files are stale or gen:skill-docs wrote outside skills/. Run: bun run gen:skill-docs"
             exit 1
           }

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,21 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "uzustack",
+      "devDependencies": {
+        "@types/bun": "latest",
+      },
+    },
+  },
+  "packages": {
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+
+    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "uzustack",
+  "version": "0.1.0",
+  "private": true,
+  "description": "UZUMAKI 社の Claude Code スキル集（gstack subtree ベース、日本語化 + 経営者コンテキスト）",
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "gen:skill-docs": "bun run scripts/gen-skill-docs.ts"
+  },
+  "engines": {
+    "bun": ">=1.0.0"
+  },
+  "devDependencies": {
+    "@types/bun": "latest"
+  }
+}

--- a/scripts/gen-skill-docs.ts
+++ b/scripts/gen-skill-docs.ts
@@ -1,0 +1,71 @@
+#!/usr/bin/env bun
+/**
+ * uzustack: SKILL.md.tmpl から SKILL.md を生成する。
+ *
+ * 対象範囲（論点 2 / 論点 4 合意）：
+ *   skills/translated/<skill>/SKILL.md.tmpl  → skills/translated/<skill>/SKILL.md
+ *   skills/native/<skill>/SKILL.md.tmpl      → skills/native/<skill>/SKILL.md
+ *
+ * `_upstream/gstack/` は subtree として保持しているだけなので一切触らない。
+ *
+ * Phase 0b 段階では skills/translated/ も skills/native/ も空（.gitkeep のみ）。
+ * 「対象 0 件で exit 0」が期待動作。
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ROOT = path.resolve(import.meta.dir, '..');
+const SKILL_ROOTS = ['skills/translated', 'skills/native'] as const;
+
+interface GenerateResult {
+  generated: number;
+  skipped: number;
+  errors: string[];
+}
+
+function generateSkillDocs(rootDir: string): GenerateResult {
+  const result: GenerateResult = { generated: 0, skipped: 0, errors: [] };
+
+  for (const skillRoot of SKILL_ROOTS) {
+    const absRoot = path.join(rootDir, skillRoot);
+
+    if (!fs.existsSync(absRoot)) {
+      result.skipped++;
+      continue;
+    }
+
+    const entries = fs.readdirSync(absRoot, { withFileTypes: true });
+    const skillDirs = entries.filter(e => e.isDirectory() && !e.name.startsWith('.'));
+
+    for (const dir of skillDirs) {
+      const skillPath = path.join(absRoot, dir.name);
+      const relPath = path.relative(rootDir, skillPath);
+      const tmplPath = path.join(skillPath, 'SKILL.md.tmpl');
+      const outPath = path.join(skillPath, 'SKILL.md');
+
+      if (!fs.existsSync(tmplPath)) {
+        result.errors.push(`${relPath}/ has no SKILL.md.tmpl (uzustack rule: every skill must have one as the source of truth)`);
+        continue;
+      }
+
+      const content = fs.readFileSync(tmplPath, 'utf-8');
+      fs.writeFileSync(outPath, content);
+      result.generated++;
+    }
+  }
+
+  return result;
+}
+
+function main(): void {
+  const result = generateSkillDocs(ROOT);
+  const summary = `generated=${result.generated} skipped=${result.skipped} errors=${result.errors.length}`;
+  console.log(`[gen-skill-docs] ${summary}`);
+  for (const err of result.errors) {
+    console.error(`  - ${err}`);
+  }
+  process.exit(result.errors.length > 0 ? 1 : 0);
+}
+
+main();

--- a/scripts/gen-skill-docs.ts
+++ b/scripts/gen-skill-docs.ts
@@ -1,71 +1,44 @@
 #!/usr/bin/env bun
 /**
- * uzustack: SKILL.md.tmpl から SKILL.md を生成する。
+ * Generate SKILL.md from SKILL.md.tmpl under skills/{translated,native}/.
+ * Every skill directory must have a SKILL.md.tmpl as its source of truth;
+ * the .md is regenerated from it and freshness is verified in CI.
  *
- * 対象範囲（論点 2 / 論点 4 合意）：
- *   skills/translated/<skill>/SKILL.md.tmpl  → skills/translated/<skill>/SKILL.md
- *   skills/native/<skill>/SKILL.md.tmpl      → skills/native/<skill>/SKILL.md
- *
- * `_upstream/gstack/` は subtree として保持しているだけなので一切触らない。
- *
- * Phase 0b 段階では skills/translated/ も skills/native/ も空（.gitkeep のみ）。
- * 「対象 0 件で exit 0」が期待動作。
+ * _upstream/gstack/ is intentionally excluded — it's a subtree owned by
+ * upstream gstack and re-pulled wholesale on updates.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 const ROOT = path.resolve(import.meta.dir, '..');
 const SKILL_ROOTS = ['skills/translated', 'skills/native'] as const;
 
-interface GenerateResult {
-  generated: number;
-  skipped: number;
-  errors: string[];
-}
+const errors: string[] = [];
+let generated = 0;
 
-function generateSkillDocs(rootDir: string): GenerateResult {
-  const result: GenerateResult = { generated: 0, skipped: 0, errors: [] };
+for (const skillRoot of SKILL_ROOTS) {
+  const absRoot = path.join(ROOT, skillRoot);
+  if (!fs.existsSync(absRoot)) continue;
 
-  for (const skillRoot of SKILL_ROOTS) {
-    const absRoot = path.join(rootDir, skillRoot);
+  const entries = fs.readdirSync(absRoot, { withFileTypes: true });
+  const skillDirs = entries.filter(e => e.isDirectory() && !e.name.startsWith('.'));
 
-    if (!fs.existsSync(absRoot)) {
-      result.skipped++;
+  for (const dir of skillDirs) {
+    const skillPath = path.join(absRoot, dir.name);
+    const tmplPath = path.join(skillPath, 'SKILL.md.tmpl');
+    const outPath = path.join(skillPath, 'SKILL.md');
+
+    if (!fs.existsSync(tmplPath)) {
+      errors.push(`${path.relative(ROOT, skillPath)}/ has no SKILL.md.tmpl`);
       continue;
     }
 
-    const entries = fs.readdirSync(absRoot, { withFileTypes: true });
-    const skillDirs = entries.filter(e => e.isDirectory() && !e.name.startsWith('.'));
-
-    for (const dir of skillDirs) {
-      const skillPath = path.join(absRoot, dir.name);
-      const relPath = path.relative(rootDir, skillPath);
-      const tmplPath = path.join(skillPath, 'SKILL.md.tmpl');
-      const outPath = path.join(skillPath, 'SKILL.md');
-
-      if (!fs.existsSync(tmplPath)) {
-        result.errors.push(`${relPath}/ has no SKILL.md.tmpl (uzustack rule: every skill must have one as the source of truth)`);
-        continue;
-      }
-
-      const content = fs.readFileSync(tmplPath, 'utf-8');
-      fs.writeFileSync(outPath, content);
-      result.generated++;
-    }
+    fs.copyFileSync(tmplPath, outPath);
+    generated++;
   }
-
-  return result;
 }
 
-function main(): void {
-  const result = generateSkillDocs(ROOT);
-  const summary = `generated=${result.generated} skipped=${result.skipped} errors=${result.errors.length}`;
-  console.log(`[gen-skill-docs] ${summary}`);
-  for (const err of result.errors) {
-    console.error(`  - ${err}`);
-  }
-  process.exit(result.errors.length > 0 ? 1 : 0);
-}
-
-main();
+console.log(`[gen-skill-docs] generated=${generated} errors=${errors.length}`);
+for (const err of errors) console.error(`  - ${err}`);
+process.exit(errors.length > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
Phase 0b（ビルド環境整備）の最小スキャフォールド：
- `package.json` — bun プロジェクト最小定義（`gen:skill-docs` script のみ、依存は `@types/bun` のみ）
- `scripts/gen-skill-docs.ts` — `SKILL.md.tmpl` → `SKILL.md` ジェネレータ（`skills/{translated,native}/<skill>/` を 1 階層走査、`.tmpl` 不在は error）
- `.github/workflows/skill-docs.yml` — gen:skill-docs を再生成して `git diff --exit-code` で乖離検知
- `bun.lock` — `bun install` で生成

`_upstream/gstack/` は subtree なので CI 対象外（草案ノート 論点 1/2/4 合意）。`/simplify` を 2 周回して dead state・過剰抽象を削ぎ落としたので、`scripts/gen-skill-docs.ts` は最終 44 行。

## Test plan
- [x] ローカル `bun install` 成功
- [x] ローカル `bun run gen:skill-docs` が `[gen-skill-docs] generated=0 errors=0` で exit 0
- [x] この PR の Skill Docs Freshness CI ジョブが緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)