### PR TITLE
feat: bin/dev-setup と bin/dev-teardown を追加（Phase 1 step 14）

### DIFF
--- a/bin/dev-setup
+++ b/bin/dev-setup
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# uzustack dev mode: flat-expand repo-top skill dirs into .claude/skills/<skill>/.
+# Claude Code only discovers .claude/skills/<name>/SKILL.md (no nesting).
+#
+# Usage:
+#   bin/dev-setup       # set up
+#   bin/dev-teardown    # remove
+set -euo pipefail
+shopt -s nullglob
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+if [[ ! -d "$REPO_ROOT/node_modules" ]]; then
+  echo "Installing dependencies..."
+  bun install --cwd "$REPO_ROOT"
+fi
+
+mkdir -p "$REPO_ROOT/.claude/skills"
+
+# Keep in sync with EXCLUDE in scripts/gen-skill-docs.ts
+EXCLUDE=(_upstream scripts bin node_modules dist build)
+
+linked=()
+for skill_dir in "$REPO_ROOT"/*/; do
+  skill_name="${skill_dir%/}"
+  skill_name="${skill_name##*/}"
+  [[ " ${EXCLUDE[*]} " == *" $skill_name "* ]] && continue
+  [[ -f "$skill_dir/SKILL.md" ]] || continue
+
+  target="$REPO_ROOT/.claude/skills/$skill_name"
+
+  if [[ -L "$target" ]]; then
+    rm "$target"
+  elif [[ -d "$target" ]]; then
+    if [[ -L "$target/SKILL.md" ]]; then
+      rm -rf "$target"
+    else
+      echo "Error: $target is a real directory with non-symlink SKILL.md." >&2
+      echo "Remove it manually before running dev-setup." >&2
+      exit 1
+    fi
+  fi
+
+  mkdir -p "$target"
+  ln -s "${skill_dir%/}/SKILL.md" "$target/SKILL.md"
+  linked+=("$skill_name")
+done
+
+if (( ${#linked[@]} > 0 )); then
+  echo "Dev mode active. Linked skills: ${linked[*]}"
+else
+  echo "Dev mode active. (No skills found at repo top yet.)"
+fi
+echo "  $REPO_ROOT/.claude/skills/"
+echo "To tear down: bin/dev-teardown"

--- a/bin/dev-teardown
+++ b/bin/dev-teardown
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# uzustack dev mode teardown: remove flat-expanded skill dirs from .claude/skills/.
+# Only removes entries whose SKILL.md symlink points inside the repo
+# (i.e. created by dev-setup; foreign skills under .claude/skills/ are preserved).
+#
+# Usage: bin/dev-teardown
+set -euo pipefail
+shopt -s nullglob
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CLAUDE_SKILLS="$REPO_ROOT/.claude/skills"
+
+[[ -d "$CLAUDE_SKILLS" ]] || { echo "No dev mode active."; exit 0; }
+
+removed=()
+
+for entry in "$CLAUDE_SKILLS"/*/; do
+  entry="${entry%/}"
+  name="${entry##*/}"
+  link_target="$(readlink "$entry/SKILL.md" 2>/dev/null || true)"
+  if [[ "$link_target" == "$REPO_ROOT"/* ]]; then
+    rm -rf "$entry"
+    removed+=("$name")
+  fi
+done
+
+rmdir "$CLAUDE_SKILLS" 2>/dev/null || true
+rmdir "$REPO_ROOT/.claude" 2>/dev/null || true
+
+if (( ${#removed[@]} > 0 )); then
+  echo "Removed: ${removed[*]}"
+else
+  echo "No dev-mode symlinks found."
+fi


### PR DESCRIPTION
## Summary

Phase 1 step 14：メンテナー向け dev mode スクリプト。`~/src/uzustack/` 内で Claude Code を起動して開発中の skill を即テストできるよう、repo top の skill ディレクトリを `.claude/skills/<skill>/` に flat 展開します。

### 背景

- Claude Code の skill discovery 仕様：`.claude/skills/<name>/SKILL.md` のみ認識、深いネスト不可（Phase 0c で対応済み）
- repo top のスキルが直接ロードされないため、symlink で展開する必要がある
- gstack の `link_claude_skill_dirs` ロジックを uzustack 版に簡素化

### 変更内容

新規 2 ファイル（実行可能）：
- `bin/dev-setup`（55 行）
- `bin/dev-teardown`（34 行）

### 設計判断

- **self-symlink は作らない**（X1 採用、2026-04-26 合意）：uzustack には root SKILL.md がなく `/uzustack` メタコマンドも存在しないため、Phase 1 段階では機能を持たない
- **EXCLUDE は `gen-skill-docs.ts` と整合**：`_upstream`、`scripts`、`bin`、`node_modules`、`dist`、`build`、および dotfile（`shopt -s nullglob` + glob）
- **dev-teardown の safety filter**：SKILL.md symlink が `$REPO_ROOT` 配下を指すエントリのみ削除（foreign symlink や personal skill を保護）

### 動作確認

- `bash -n` で syntax check 両方 OK
- dummy skill end-to-end：dev-setup → `Linked skills: testskill`、symlink target 綺麗 → dev-teardown → `Removed: testskill` → クリーンアップ
- safety filter：foreign symlink (`/tmp/somewhere-else` を指す) を含む `.claude/skills/foreign/` を作成 → dev-teardown が無視して foreign を保持

### /simplify

2 周回：
- 1 周目（安全度向上）：`set -euo pipefail`、`shopt -s nullglob`、readlink safety filter、EXCLUDE 配列化、`[ ]` → `[[ ]]`、`basename` → `${var##*/}`、`bun install --cwd`、sync コメント
- 2 周目（構造整理）：dev-teardown ループ変数の正規化（`${entry%/}` 三重出現 → 0 回）、`linked=()` を mutable accumulator として分離、`case` → `[[ ]]`

### 関連

- 個人 Obsidian vault `uzustack草案.md` の step 14（2026-04-26 X1 採用更新）
- 後続 PR：`feature/translate-investigate`（Phase 1 step 15、investigate/ 翻訳）

> 📝 **CI について**：本 PR は `bin/` のみの変更で、CI（Skill Docs Freshness）の path filter 対象外。CI はトリガーされません（設計通り、bin/ は skill freshness と無関係なため）。

## Test plan

- [x] `bash -n` で syntax check
- [x] dummy skill で flat 展開 / クリーンアップ検証
- [x] foreign symlink で safety filter 検証
- [ ] main へ squash merge、--delete-branch
