### PR TITLE
fix: bin/dev-setup の冪等性違反を修正（step 17 副産物）

### DIFF
--- a/bin/dev-setup
+++ b/bin/dev-setup
@@ -28,11 +28,16 @@ for skill_dir in "$REPO_ROOT"/*/; do
   [[ -f "$skill_dir/SKILL.md" ]] || continue
 
   target="$REPO_ROOT/.claude/skills/$skill_name"
+  expected_link="${skill_dir%/}/SKILL.md"
 
   if [[ -L "$target" ]]; then
     rm "$target"
   elif [[ -d "$target" ]]; then
     if [[ -L "$target/SKILL.md" ]]; then
+      if [[ "$(readlink "$target/SKILL.md")" == "$expected_link" ]]; then
+        linked+=("$skill_name")
+        continue
+      fi
       rm -rf "$target"
     else
       echo "Error: $target is a real directory with non-symlink SKILL.md." >&2
@@ -42,7 +47,7 @@ for skill_dir in "$REPO_ROOT"/*/; do
   fi
 
   mkdir -p "$target"
-  ln -s "${skill_dir%/}/SKILL.md" "$target/SKILL.md"
+  ln -s "$expected_link" "$target/SKILL.md"
   linked+=("$skill_name")
 done
 

--- a/bin/dev-setup
+++ b/bin/dev-setup
@@ -30,14 +30,15 @@ for skill_dir in "$REPO_ROOT"/*/; do
   target="$REPO_ROOT/.claude/skills/$skill_name"
   expected_link="${skill_dir%/}/SKILL.md"
 
+  if [[ -L "$target/SKILL.md" && "$(readlink "$target/SKILL.md")" == "$expected_link" ]]; then
+    linked+=("$skill_name")
+    continue
+  fi
+
   if [[ -L "$target" ]]; then
     rm "$target"
   elif [[ -d "$target" ]]; then
     if [[ -L "$target/SKILL.md" ]]; then
-      if [[ "$(readlink "$target/SKILL.md")" == "$expected_link" ]]; then
-        linked+=("$skill_name")
-        continue
-      fi
       rm -rf "$target"
     else
       echo "Error: $target is a real directory with non-symlink SKILL.md." >&2


### PR DESCRIPTION
## Summary

- step 17（`/investigate` skill を実題材に投入）で発見した `bin/dev-setup` の冪等性違反を修正
- target が「real dir + 中の SKILL.md が期待 symlink target」の場合、`rm -rf` + 再作成ではなく no-op で `continue` する guard 句をループ冒頭に追加
- これまで再実行ごとに target dir と SKILL.md の inode が両方更新され、target 配下に他者が置いた補助ファイルが破壊されていた

## 検証

手動再現テスト（フェーズ 5 / DEBUG REPORT 通り）：

| 項目 | 修正前 | 修正後 |
|---|---|---|
| dir-inode 不変 | FAIL | PASS |
| link-inode 不変 | FAIL | PASS |
| sidecar 残存 | FAIL（DESTROYED） | PASS |
| teardown も整合 | — | PASS |

## simplify

- 1 周目（4634c4c）: ネスト 3 段 → 2 段、guard 句として冒頭に flatten
- 2 周目: clean（3 agent 全て）

## 背景：外形冪等と操作冪等

「最終状態が同じ」と「中間で何も触らない」は別物。後者を満たさないと、target 配下の他者ファイル破壊・watcher 偽陽性・無駄な IO といった副作用が滲む。step 14 の `/simplify` レビュー観点には「冪等性 (state vs operation)」が無かったため、今回見落とした。

## Test plan

- [x] 修正前の再現スクリプトで bug を確認
- [x] 修正後に同スクリプトで全 PASS
- [x] `bin/dev-teardown` との対称性が崩れていない
- [x] CI（Skill Docs Freshness）green 確認 ― path filter 対象外（`bin/` は freshness と無関係）なので no-op pass の想定

🤖 Generated with [Claude Code](https://claude.com/claude-code)