### PR TITLE
feat: end user 向け setup スクリプトを追加（Phase 2 step 19）

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ cd ~/path/to/your-project
 ~/.claude/skills/uzustack/setup
 ```
 
-これで `.claude/settings.json` と `.claude/CLAUDE.md` に skill 呼び出し設定が追加され、`.claude/skills/uzustack/` から uzustack が見えるようになります。
+これで `<your-project>/.claude/skills/<skill>/SKILL.md` 配下に uzustack の各スキルが symlink として配置され、Claude Code から呼び出せるようになります。
+
+> 📝 **現在のスコープ**：`./setup` は `.claude/skills/` への symlink 配備のみ行います。`.claude/settings.json` / `.claude/CLAUDE.md` への自動追記は Phase 3 以降で対応予定（既存ファイルは破壊しません）。
 
 ### 3. Claude Code でスキルを呼ぶ
 
@@ -98,9 +100,9 @@ uzustack は **3 つの場所** に分散して動作します：
 <your-project>/                       ← Claude Code を起動する場所
 ├── CLAUDE.md                          ← プロジェクト固有の文脈
 ├── .claude/
-│   ├── settings.json                  ← ./setup で追加
-│   ├── CLAUDE.md                      ← skill を呼び出す設定
-│   └── skills/                        ← Claude Code が skill を探索するディレクトリ（フラット配置）
+│   ├── settings.json                  ← （あれば既存のまま。setup では触らない）
+│   ├── CLAUDE.md                      ← （あれば既存のまま。setup では触らない）
+│   └── skills/                        ← ./setup が管理（フラット配置で skill を symlink）
 │       ├── investigate/               ← Type 1: uzustack 由来の翻訳スキル
 │       │   └── SKILL.md
 │       ├── obsidian-audit-tac/        ← Type 2: 個人固有スキル（OSS 非公開、各ユーザー固有）

--- a/setup
+++ b/setup
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# uzustack setup — install uzustack skills into the current project's .claude/skills/.
+#
+# Usage:
+#   cd <your-project>
+#   ~/.claude/skills/uzustack/setup
+#
+# Phase 1 scope: symlink uzustack の各 skill を <project>/.claude/skills/<skill>/SKILL.md へ展開する。
+# settings.json / CLAUDE.md には触れない（Phase 3 以降で機構取り込みと一緒に着手予定）。
+#
+# Maintainers should use bin/dev-setup instead — it links the dev clone in place
+# without requiring a separate ~/.claude/skills/uzustack/ install.
+
+set -euo pipefail
+shopt -s nullglob
+
+UZUSTACK_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+PROJECT_DIR="$(pwd -P)"
+
+if [[ "$UZUSTACK_DIR" == "$PROJECT_DIR" ]]; then
+  echo "Error: setup is meant for end users to install into their own project." >&2
+  echo "  You appear to be inside the uzustack repo itself." >&2
+  echo "  Maintainers: use bin/dev-setup instead." >&2
+  echo "  End users: cd to your own project, then re-run this script." >&2
+  exit 1
+fi
+
+SKILLS_DIR="$PROJECT_DIR/.claude/skills"
+mkdir -p "$SKILLS_DIR"
+
+# Keep in sync with EXCLUDE in bin/dev-setup and scripts/gen-skill-docs.ts.
+EXCLUDE=(_upstream scripts bin node_modules dist build .claude .git .github)
+
+linked=()
+already=()
+skipped=()
+
+for skill_dir in "$UZUSTACK_DIR"/*/; do
+  skill_name="${skill_dir%/}"
+  skill_name="${skill_name##*/}"
+
+  excluded=0
+  for ex in "${EXCLUDE[@]}"; do
+    if [[ "$skill_name" == "$ex" ]]; then
+      excluded=1
+      break
+    fi
+  done
+  (( excluded )) && continue
+
+  [[ -f "$skill_dir/SKILL.md" ]] || continue
+
+  target_dir="$SKILLS_DIR/$skill_name"
+  target_link="$target_dir/SKILL.md"
+  expected_target="${skill_dir%/}/SKILL.md"
+
+  if [[ -L "$target_link" && "$(readlink "$target_link")" == "$expected_target" ]]; then
+    already+=("$skill_name")
+    continue
+  fi
+
+  if [[ -L "$target_dir" ]]; then
+    rm "$target_dir"
+  elif [[ -L "$target_link" ]]; then
+    rm "$target_link"
+  elif [[ -d "$target_dir" ]]; then
+    echo "  warn: $target_dir exists and is not managed by uzustack — skipped" >&2
+    skipped+=("$skill_name")
+    continue
+  fi
+
+  mkdir -p "$target_dir"
+  ln -snf "$expected_target" "$target_link"
+  linked+=("$skill_name")
+done
+
+echo ""
+echo "uzustack setup complete in $PROJECT_DIR/.claude/skills/"
+if (( ${#linked[@]} > 0 )); then
+  echo "  Linked:         ${linked[*]}"
+fi
+if (( ${#already[@]} > 0 )); then
+  echo "  Already linked: ${already[*]}"
+fi
+if (( ${#skipped[@]} > 0 )); then
+  echo "  Skipped:        ${skipped[*]}"
+fi
+
+if (( ${#linked[@]} == 0 && ${#already[@]} == 0 && ${#skipped[@]} == 0 )); then
+  echo "  warn: no uzustack skills found at $UZUSTACK_DIR" >&2
+fi

--- a/setup
+++ b/setup
@@ -29,7 +29,8 @@ SKILLS_DIR="$PROJECT_DIR/.claude/skills"
 mkdir -p "$SKILLS_DIR"
 
 # Keep in sync with EXCLUDE in bin/dev-setup and scripts/gen-skill-docs.ts.
-EXCLUDE=(_upstream scripts bin node_modules dist build .claude .git .github)
+# .claude / .git / .github are dotfile dirs and already excluded by the */ glob.
+EXCLUDE=(_upstream scripts bin node_modules dist build)
 
 linked=()
 already=()
@@ -39,15 +40,7 @@ for skill_dir in "$UZUSTACK_DIR"/*/; do
   skill_name="${skill_dir%/}"
   skill_name="${skill_name##*/}"
 
-  excluded=0
-  for ex in "${EXCLUDE[@]}"; do
-    if [[ "$skill_name" == "$ex" ]]; then
-      excluded=1
-      break
-    fi
-  done
-  (( excluded )) && continue
-
+  [[ " ${EXCLUDE[*]} " == *" $skill_name "* ]] && continue
   [[ -f "$skill_dir/SKILL.md" ]] || continue
 
   target_dir="$SKILLS_DIR/$skill_name"
@@ -59,11 +52,17 @@ for skill_dir in "$UZUSTACK_DIR"/*/; do
     continue
   fi
 
+  # Replace stale uzustack-managed entries; refuse to touch user-managed real dirs.
   if [[ -L "$target_dir" ]]; then
+    # Legacy: whole-dir symlink from earlier uzustack layouts.
+    echo "  warn: replacing legacy directory symlink at $target_dir" >&2
     rm "$target_dir"
   elif [[ -L "$target_link" ]]; then
+    # Stale SKILL.md symlink (e.g., uzustack moved, or user pointed it elsewhere).
+    echo "  warn: replacing existing SKILL.md symlink at $target_link (was $(readlink "$target_link"))" >&2
     rm "$target_link"
   elif [[ -d "$target_dir" ]]; then
+    # User-managed directory (Type 2 skill etc.) — leave alone.
     echo "  warn: $target_dir exists and is not managed by uzustack — skipped" >&2
     skipped+=("$skill_name")
     continue


### PR DESCRIPTION
## Summary

- 任意のプロジェクトで叩ける end user 向け `setup` スクリプトを uzustack repo top に追加
- Phase 1 スコープとして **symlink 配備のみ**。`.claude/settings.json` / `.claude/CLAUDE.md` には触らない（Phase 3 以降で対応）
- README の Quick Start・Architecture を symlink-only スコープに合わせて更新

## Smoke test 結果（ローカル一時ディレクトリ）

| ケース | 結果 |
|---|---|
| 新規プロジェクトで初回実行 | `Linked: investigate` ・SKILL.md symlink が正しく作成 |
| 同じディレクトリで再実行（冪等性） | `Already linked: investigate`・no-op |
| 既存 real dir 衝突（uzustack 管理外） | `Skipped: investigate`・user content を破壊せず |
| uzustack repo 内で実行 | error で抜ける・`bin/dev-setup を使え` と案内 |

## Test plan（merge 前にメンテナー側で確認）

- [ ] uzustack repo 外の自前プロジェクトで `./setup` を叩き、Claude Code から `/investigate` 等が呼べることを確認
- [ ] そのプロジェクトの既存 `.claude/settings.json` / `.claude/CLAUDE.md` が一切変更されていないことを確認
- [ ] README Quick Start のコピペで動作することを実機確認

## 持ち越し（Phase 3 以降、別 issue 化予定）

- `.claude/settings.json` への uzustack 用 permission / hook 自動追加
- `.claude/CLAUDE.md` への uzustack 利用ヒントの追記

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)