### PR TITLE
feat: bin/dev-setup に引数あり版（外部プロジェクト対応）を追加（Phase 2 step 20）

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ cd ~/src/uzustack
 bin/dev-setup
 ```
 
-`~/src/uzustack/.claude/skills/uzustack/` を repo root への自己 symlink として作成。これで **uzustack repo の中で Claude Code を起動** して、開発中の skill を即座にテストできます。
+`~/src/uzustack/.claude/skills/<skill>/SKILL.md` を各 skill への symlink として展開。これで **uzustack repo の中で Claude Code を起動** して、開発中の skill を即座にテストできます。
 
 #### モード B：引数あり（外部プロジェクトに開発中 symlink）
 
@@ -55,7 +55,9 @@ cd ~/src/uzustack
 bin/dev-setup ~/path/to/your-project
 ```
 
-任意の外部プロジェクト（例：自分の Obsidian vault や開発リポジトリ）の `.claude/skills/uzustack/` を `~/src/uzustack/` への symlink として作成。実プロジェクトで開発中の skill をテストする用途。
+任意の外部プロジェクト（例：自前の開発リポジトリ）の `.claude/skills/<skill>/SKILL.md` を uzustack repo 配下の各 skill への symlink として展開。実プロジェクトで開発中の skill をテストする用途。存在しないパスを渡すと error で exit。
+
+> 💡 **teardown**：モード A は `bin/dev-teardown` で一括削除。モード B は当面手動で `rm -rf <project>/.claude/skills/<skill>/` を実施（dev-teardown 引数あり版は別 issue で予定）。
 
 > 💡 **end user 向けの正式 install は `./setup`** を使います（`bin/dev-setup` はメンテナー向けの開発用）。
 

--- a/bin/dev-setup
+++ b/bin/dev-setup
@@ -1,23 +1,36 @@
 #!/usr/bin/env bash
-# uzustack dev mode: flat-expand repo-top skill dirs into .claude/skills/<skill>/.
+# uzustack dev mode: flat-expand repo-top skill dirs into <target>/.claude/skills/.
 # Claude Code only discovers .claude/skills/<name>/SKILL.md (no nesting).
 #
 # Usage:
-#   bin/dev-setup       # set up
-#   bin/dev-teardown    # remove
+#   bin/dev-setup                       # mode A: set up self (uzustack repo)
+#   bin/dev-setup <path-to-project>     # mode B: set up external project
+#   bin/dev-teardown                    # remove (self only; external is manual rm for now)
 set -euo pipefail
 shopt -s nullglob
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+if (( $# > 0 )); then
+  TARGET_DIR="$1"
+  if [[ ! -d "$TARGET_DIR" ]]; then
+    echo "Error: target directory not found: $TARGET_DIR" >&2
+    echo "  bin/dev-setup expects an existing project directory as the first argument." >&2
+    exit 1
+  fi
+  TARGET_DIR="$(cd "$TARGET_DIR" && pwd -P)"
+else
+  TARGET_DIR="$REPO_ROOT"
+fi
 
 if [[ ! -d "$REPO_ROOT/node_modules" ]]; then
   echo "Installing dependencies..."
   bun install --cwd "$REPO_ROOT"
 fi
 
-mkdir -p "$REPO_ROOT/.claude/skills"
+mkdir -p "$TARGET_DIR/.claude/skills"
 
-# Keep in sync with EXCLUDE in scripts/gen-skill-docs.ts
+# Keep in sync with EXCLUDE in setup and scripts/gen-skill-docs.ts.
 EXCLUDE=(_upstream scripts bin node_modules dist build)
 
 linked=()
@@ -27,7 +40,7 @@ for skill_dir in "$REPO_ROOT"/*/; do
   [[ " ${EXCLUDE[*]} " == *" $skill_name "* ]] && continue
   [[ -f "$skill_dir/SKILL.md" ]] || continue
 
-  target="$REPO_ROOT/.claude/skills/$skill_name"
+  target="$TARGET_DIR/.claude/skills/$skill_name"
   expected_link="${skill_dir%/}/SKILL.md"
 
   if [[ -L "$target/SKILL.md" && "$(readlink "$target/SKILL.md")" == "$expected_link" ]]; then
@@ -57,5 +70,9 @@ if (( ${#linked[@]} > 0 )); then
 else
   echo "Dev mode active. (No skills found at repo top yet.)"
 fi
-echo "  $REPO_ROOT/.claude/skills/"
-echo "To tear down: bin/dev-teardown"
+echo "  $TARGET_DIR/.claude/skills/"
+if [[ "$TARGET_DIR" == "$REPO_ROOT" ]]; then
+  echo "To tear down: bin/dev-teardown"
+else
+  echo "To tear down (manual for now): rm -rf \"$TARGET_DIR/.claude/skills/<skill>\""
+fi


### PR DESCRIPTION
## Summary

- `bin/dev-setup` を拡張し、第 1 引数として外部プロジェクトのパスを受け取れるようにした
- 引数なしの既存挙動は変更なし（regression なし）
- CONTRIBUTING.md の「モード A / モード B」セクションを Phase 0c 以降の flat layout 記述に修正

## Smoke test 結果（ローカル一時ディレクトリ）

| ケース | 結果 |
|---|---|
| 引数なし regression（self-symlink、既存挙動維持） | `Linked skills: investigate`、symlink target 不変 |
| 引数あり 新規 | `Linked skills: investigate`、外部 dir に絶対パス symlink 作成 |
| 引数あり 冪等性（再実行で no-op） | 同じ出力で再実行成功 |
| 存在しないパス | error & exit code 1 |
| 既存 real dir 衝突（non-symlink SKILL.md） | error & user content 保護 |
| 相対パス引数の絶対パス解決 | `pwd -P` 経由で絶対パスに正規化 |

## Test plan（merge 前にメンテナー側で確認）

- [ ] 自前の実プロジェクトで `bin/dev-setup ~/path/to/your-project` を実行し、Claude Code で `/investigate` 等が呼べることを確認
- [ ] 引数なし `bin/dev-setup` が従来と同じ挙動であることを確認（既存 self-symlink が破壊されない）
- [ ] 既存 \`.claude/skills/\` 配下のユーザー独自 skill（real dir）が触られないことを確認

## スコープ外（持ち越し）

- \`bin/dev-teardown\` の引数あり版 → 別 issue で起票予定（Phase 2、必要になったタイミングで着手）

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)