### PR TITLE
feat: bin/dev-teardown に引数あり版（外部プロジェクト対応）を追加（Phase 2 step 25）

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ bin/dev-setup ~/path/to/your-project
 
 任意の外部プロジェクト（例：自前の開発リポジトリ）の `.claude/skills/<skill>/SKILL.md` を uzustack repo 配下の各 skill への symlink として展開。実プロジェクトで開発中の skill をテストする用途。存在しないパスを渡すと error で exit。
 
-> 💡 **teardown**：モード A は `bin/dev-teardown` で一括削除。モード B は当面手動で `rm -rf <project>/.claude/skills/<skill>/` を実施（dev-teardown 引数あり版は別 issue で予定）。
+> 💡 **teardown**：モード A は `bin/dev-teardown`、モード B は `bin/dev-teardown ~/path/to/your-project` で対応（uzustack 由来 symlink のみ削除、ユーザー独自 skill は保護されます）。
 
 > 💡 **end user 向けの正式 install は `./setup`** を使います（`bin/dev-setup` はメンテナー向けの開発用）。
 

--- a/bin/dev-teardown
+++ b/bin/dev-teardown
@@ -1,16 +1,31 @@
 #!/usr/bin/env bash
-# uzustack dev mode teardown: remove flat-expanded skill dirs from .claude/skills/.
-# Only removes entries whose SKILL.md symlink points inside the repo
+# uzustack dev mode teardown: remove flat-expanded skill dirs from <target>/.claude/skills/.
+# Only removes entries whose SKILL.md symlink points inside the uzustack repo
 # (i.e. created by dev-setup; foreign skills under .claude/skills/ are preserved).
 #
-# Usage: bin/dev-teardown
+# Usage:
+#   bin/dev-teardown                    # mode A: tear down self (uzustack repo)
+#   bin/dev-teardown <path-to-project>  # mode B: tear down external project
 set -euo pipefail
 shopt -s nullglob
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-CLAUDE_SKILLS="$REPO_ROOT/.claude/skills"
 
-[[ -d "$CLAUDE_SKILLS" ]] || { echo "No dev mode active."; exit 0; }
+if (( $# > 0 )); then
+  TARGET_DIR="$1"
+  if [[ ! -d "$TARGET_DIR" ]]; then
+    echo "Error: target directory not found: $TARGET_DIR" >&2
+    echo "  bin/dev-teardown expects an existing project directory as the first argument." >&2
+    exit 1
+  fi
+  TARGET_DIR="$(cd "$TARGET_DIR" && pwd -P)"
+else
+  TARGET_DIR="$REPO_ROOT"
+fi
+
+CLAUDE_SKILLS="$TARGET_DIR/.claude/skills"
+
+[[ -d "$CLAUDE_SKILLS" ]] || { echo "No dev mode active in $TARGET_DIR."; exit 0; }
 
 removed=()
 
@@ -25,10 +40,11 @@ for entry in "$CLAUDE_SKILLS"/*/; do
 done
 
 rmdir "$CLAUDE_SKILLS" 2>/dev/null || true
-rmdir "$REPO_ROOT/.claude" 2>/dev/null || true
+rmdir "$TARGET_DIR/.claude" 2>/dev/null || true
 
 if (( ${#removed[@]} > 0 )); then
-  echo "Removed: ${removed[*]}"
+  echo "Removed from $CLAUDE_SKILLS:"
+  echo "  ${removed[*]}"
 else
-  echo "No dev-mode symlinks found."
+  echo "No dev-mode symlinks found in $TARGET_DIR."
 fi


### PR DESCRIPTION
## Summary

- step 20（PR #10）の \`bin/dev-setup\` 引数あり版に対称な \`bin/dev-teardown\` 引数あり版を実装
- CONTRIBUTING.md の teardown 言及を「モード B も dev-teardown 引数あり版で対応」に更新（step 22 で書いた「手動 rm」フォールバックを置換）

## Smoke test 結果（ローカル一時ディレクトリ）

| ケース | 結果 |
|---|---|
| 引数なし regression（self-teardown） | `Removed: investigate`、settings.local.json は維持 |
| 引数あり 新規（外部 dir） | 外部 dir の `.claude/skills/` cleanup 成功、空なら `.claude/` 自体も削除 |
| 存在しないパス | error & exit code 1 |
| ユーザー独自 skill 保護 | 別 user skill `my-own-skill` を混ぜた状態で teardown → uzustack 由来のみ削除、user content 健在 |
| 相対パス引数の絶対パス解決 | `(cd "\$arg" && pwd -P)` 経由で正規化、teardown 成功 |

## Test plan（merge 前にメンテナー側で確認）

- [ ] 自前の実プロジェクトで \`bin/dev-setup ~/path\` → \`bin/dev-teardown ~/path\` の往復を実行し、`.claude/skills/` が完全に元に戻ることを確認
- [ ] 引数なし \`bin/dev-teardown\` が従来と同じ挙動であることを確認

## スコープ外

- dev-setup / dev-teardown の 1 ファイル統合（YAGNI、2 ファイル分離で十分）

## 関連

- step 20（PR #10）：dev-setup 引数あり版（本 PR の対称）
- step 22（PR #14）：自動 subtree pull 運用開始
- 引数なし版：#4

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)