### PR TITLE
feat: careful skill を翻訳（Phase 2 step 28、最小 hook 取り込みパイロット）

### DIFF
--- a/bin/dev-setup
+++ b/bin/dev-setup
@@ -42,26 +42,33 @@ for skill_dir in "$REPO_ROOT"/*/; do
 
   target="$TARGET_DIR/.claude/skills/$skill_name"
   expected_link="${skill_dir%/}/SKILL.md"
-
-  if [[ -L "$target/SKILL.md" && "$(readlink "$target/SKILL.md")" == "$expected_link" ]]; then
-    linked+=("$skill_name")
-    continue
-  fi
+  expected_bin_link="${skill_dir%/}/bin"
 
   if [[ -L "$target" ]]; then
     rm "$target"
-  elif [[ -d "$target" ]]; then
-    if [[ -L "$target/SKILL.md" ]]; then
-      rm -rf "$target"
-    else
-      echo "Error: $target is a real directory with non-symlink SKILL.md." >&2
-      echo "Remove it manually before running dev-setup." >&2
-      exit 1
-    fi
+  elif [[ -e "$target/SKILL.md" && ! -L "$target/SKILL.md" ]]; then
+    echo "Error: $target/SKILL.md is a real file, not a symlink." >&2
+    echo "Remove it manually before running dev-setup." >&2
+    exit 1
   fi
 
   mkdir -p "$target"
-  ln -s "$expected_link" "$target/SKILL.md"
+
+  if [[ ! -L "$target/SKILL.md" || "$(readlink "$target/SKILL.md")" != "$expected_link" ]]; then
+    rm -f "$target/SKILL.md"
+    ln -s "$expected_link" "$target/SKILL.md"
+  fi
+
+  # bin/ symlink for hook-bearing skills (e.g. careful's PreToolUse hook
+  # references ${CLAUDE_SKILL_DIR}/bin/...; symlinking the bin dir ensures
+  # hooks resolve regardless of how Claude Code resolves CLAUDE_SKILL_DIR).
+  if [[ -d "$skill_dir/bin" ]]; then
+    if [[ ! -L "$target/bin" || "$(readlink "$target/bin")" != "$expected_bin_link" ]]; then
+      [[ -e "$target/bin" || -L "$target/bin" ]] && rm -rf "$target/bin"
+      ln -s "$expected_bin_link" "$target/bin"
+    fi
+  fi
+
   linked+=("$skill_name")
 done
 

--- a/careful/SKILL.md
+++ b/careful/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: careful
+type: translated
+version: 0.1.0
+description: |
+  destructive コマンドに対する safety guardrail。`rm -rf`、`DROP TABLE`、
+  force-push、`git reset --hard`、`kubectl delete` 等の破壊的操作の前に警告する。
+  ユーザーは各警告を override 可能。本番環境に触る、live system のデバッグ、
+  共有環境で作業する時に使用する。「セーフティモード」「本番モード」「危険コマンドに注意」
+  「careful モード」「destructive 警告」と要求されたときに使用する。
+allowed-tools:
+  - Bash
+  - Read
+triggers:
+  - セーフティモード
+  - 本番モード
+  - 危険コマンドに注意
+  - careful モード
+  - destructive 警告
+hooks:
+  PreToolUse:
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: "bash ${CLAUDE_SKILL_DIR}/bin/check-careful.sh"
+          statusMessage: "危険コマンドをチェック中..."
+sensitive: true
+---
+
+# /careful — destructive コマンドのガードレール
+
+セーフティモードが **有効** になった。すべての bash コマンドは実行前に destructive パターンに対して検査される。destructive コマンドが検出されると警告が表示され、続行または中止を選択できる。
+
+## 保護対象
+
+| パターン | 例 | リスク |
+|---------|---------|------|
+| `rm -rf` / `rm -r` / `rm --recursive` | `rm -rf /var/data` | 再帰削除 |
+| `DROP TABLE` / `DROP DATABASE` | `DROP TABLE users;` | データ損失 |
+| `TRUNCATE` | `TRUNCATE orders;` | データ損失 |
+| `git push --force` / `-f` | `git push -f origin main` | 履歴書き換え |
+| `git reset --hard` | `git reset --hard HEAD~3` | 未コミット作業の損失 |
+| `git checkout .` / `git restore .` | `git checkout .` | 未コミット作業の損失 |
+| `kubectl delete` | `kubectl delete pod` | プロダクション影響 |
+| `docker rm -f` / `docker system prune` | `docker system prune -a` | コンテナ / image 損失 |
+
+## 安全例外
+
+以下のパターンは警告なしで許可される：
+- `rm -rf node_modules` / `.next` / `dist` / `__pycache__` / `.cache` / `build` / `.turbo` / `coverage`
+
+## 動作の仕組み
+
+hook は tool input JSON からコマンドを読み取り、上記パターンに対して照合する。マッチがあれば `permissionDecision: "ask"` を警告メッセージ付きで返す。警告を override して続行することは常に可能。
+
+無効化するには、会話を終了するか新しい会話を開始する。hook はセッションスコープ。

--- a/careful/SKILL.md
+++ b/careful/SKILL.md
@@ -22,7 +22,7 @@ hooks:
     - matcher: "Bash"
       hooks:
         - type: command
-          command: "bash ${CLAUDE_SKILL_DIR}/bin/check-careful.sh"
+          command: "bash $CLAUDE_PROJECT_DIR/.claude/skills/careful/bin/check-careful.sh"
           statusMessage: "危険コマンドをチェック中..."
 sensitive: true
 ---

--- a/careful/SKILL.md.tmpl
+++ b/careful/SKILL.md.tmpl
@@ -1,0 +1,56 @@
+---
+name: careful
+type: translated
+version: 0.1.0
+description: |
+  destructive コマンドに対する safety guardrail。`rm -rf`、`DROP TABLE`、
+  force-push、`git reset --hard`、`kubectl delete` 等の破壊的操作の前に警告する。
+  ユーザーは各警告を override 可能。本番環境に触る、live system のデバッグ、
+  共有環境で作業する時に使用する。「セーフティモード」「本番モード」「危険コマンドに注意」
+  「careful モード」「destructive 警告」と要求されたときに使用する。
+allowed-tools:
+  - Bash
+  - Read
+triggers:
+  - セーフティモード
+  - 本番モード
+  - 危険コマンドに注意
+  - careful モード
+  - destructive 警告
+hooks:
+  PreToolUse:
+    - matcher: "Bash"
+      hooks:
+        - type: command
+          command: "bash ${CLAUDE_SKILL_DIR}/bin/check-careful.sh"
+          statusMessage: "危険コマンドをチェック中..."
+sensitive: true
+---
+
+# /careful — destructive コマンドのガードレール
+
+セーフティモードが **有効** になった。すべての bash コマンドは実行前に destructive パターンに対して検査される。destructive コマンドが検出されると警告が表示され、続行または中止を選択できる。
+
+## 保護対象
+
+| パターン | 例 | リスク |
+|---------|---------|------|
+| `rm -rf` / `rm -r` / `rm --recursive` | `rm -rf /var/data` | 再帰削除 |
+| `DROP TABLE` / `DROP DATABASE` | `DROP TABLE users;` | データ損失 |
+| `TRUNCATE` | `TRUNCATE orders;` | データ損失 |
+| `git push --force` / `-f` | `git push -f origin main` | 履歴書き換え |
+| `git reset --hard` | `git reset --hard HEAD~3` | 未コミット作業の損失 |
+| `git checkout .` / `git restore .` | `git checkout .` | 未コミット作業の損失 |
+| `kubectl delete` | `kubectl delete pod` | プロダクション影響 |
+| `docker rm -f` / `docker system prune` | `docker system prune -a` | コンテナ / image 損失 |
+
+## 安全例外
+
+以下のパターンは警告なしで許可される：
+- `rm -rf node_modules` / `.next` / `dist` / `__pycache__` / `.cache` / `build` / `.turbo` / `coverage`
+
+## 動作の仕組み
+
+hook は tool input JSON からコマンドを読み取り、上記パターンに対して照合する。マッチがあれば `permissionDecision: "ask"` を警告メッセージ付きで返す。警告を override して続行することは常に可能。
+
+無効化するには、会話を終了するか新しい会話を開始する。hook はセッションスコープ。

--- a/careful/SKILL.md.tmpl
+++ b/careful/SKILL.md.tmpl
@@ -22,7 +22,7 @@ hooks:
     - matcher: "Bash"
       hooks:
         - type: command
-          command: "bash ${CLAUDE_SKILL_DIR}/bin/check-careful.sh"
+          command: "bash $CLAUDE_PROJECT_DIR/.claude/skills/careful/bin/check-careful.sh"
           statusMessage: "危険コマンドをチェック中..."
 sensitive: true
 ---

--- a/careful/bin/check-careful.sh
+++ b/careful/bin/check-careful.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # check-careful.sh — PreToolUse hook for /careful skill
 # Reads JSON from stdin, checks Bash command for destructive patterns.
-# Returns {"permissionDecision":"ask","message":"..."} to warn, or {} to allow.
+# Returns hookSpecificOutput permissionDecision: "ask" to warn, or {} to allow.
 set -euo pipefail
 
 # Read stdin (JSON with tool_input)
@@ -28,7 +28,7 @@ CMD_LOWER=$(printf '%s' "$CMD" | tr '[:upper:]' '[:lower:]')
 # --- Check for safe exceptions (rm -rf of build artifacts) ---
 if printf '%s' "$CMD" | grep -qE 'rm\s+(-[a-zA-Z]*r[a-zA-Z]*\s+|--recursive\s+)' 2>/dev/null; then
   SAFE_ONLY=true
-  RM_ARGS=$(printf '%s' "$CMD" | sed -E 's/.*rm\s+(-[a-zA-Z]+\s+)*//;s/--recursive\s*//')
+  RM_ARGS=$(printf '%s' "$CMD" | sed -E 's/.*rm[[:space:]]+(-[a-zA-Z]+[[:space:]]+)*//;s/--recursive[[:space:]]*//')
   for target in $RM_ARGS; do
     case "$target" in
       */node_modules|node_modules|*/\.next|\.next|*/dist|dist|*/__pycache__|__pycache__|*/\.cache|\.cache|*/build|build|*/\.turbo|\.turbo|*/coverage|coverage)
@@ -53,56 +53,56 @@ PATTERN=""
 
 # rm -rf / rm -r / rm --recursive
 if printf '%s' "$CMD" | grep -qE 'rm\s+(-[a-zA-Z]*r|--recursive)' 2>/dev/null; then
-  WARN="Destructive: recursive delete (rm -r). This permanently removes files."
+  WARN="危険: 再帰削除 (rm -r)。ファイルを永続的に削除します。"
   PATTERN="rm_recursive"
 fi
 
 # DROP TABLE / DROP DATABASE
 if [ -z "$WARN" ] && printf '%s' "$CMD_LOWER" | grep -qE 'drop\s+(table|database)' 2>/dev/null; then
-  WARN="Destructive: SQL DROP detected. This permanently deletes database objects."
+  WARN="危険: SQL DROP を検出。データベースオブジェクトを永続的に削除します。"
   PATTERN="drop_table"
 fi
 
 # TRUNCATE
 if [ -z "$WARN" ] && printf '%s' "$CMD_LOWER" | grep -qE '\btruncate\b' 2>/dev/null; then
-  WARN="Destructive: SQL TRUNCATE detected. This deletes all rows from a table."
+  WARN="危険: SQL TRUNCATE を検出。テーブルの全行を削除します。"
   PATTERN="truncate"
 fi
 
 # git push --force / git push -f
 if [ -z "$WARN" ] && printf '%s' "$CMD" | grep -qE 'git\s+push\s+.*(-f\b|--force)' 2>/dev/null; then
-  WARN="Destructive: git force-push rewrites remote history. Other contributors may lose work."
+  WARN="危険: git force-push は remote の履歴を書き換えます。他の contributor の作業が失われる可能性があります。"
   PATTERN="git_force_push"
 fi
 
 # git reset --hard
 if [ -z "$WARN" ] && printf '%s' "$CMD" | grep -qE 'git\s+reset\s+--hard' 2>/dev/null; then
-  WARN="Destructive: git reset --hard discards all uncommitted changes."
+  WARN="危険: git reset --hard は未コミットの変更をすべて破棄します。"
   PATTERN="git_reset_hard"
 fi
 
 # git checkout . / git restore .
 if [ -z "$WARN" ] && printf '%s' "$CMD" | grep -qE 'git\s+(checkout|restore)\s+\.' 2>/dev/null; then
-  WARN="Destructive: discards all uncommitted changes in the working tree."
+  WARN="危険: ワーキングツリーの未コミット変更をすべて破棄します。"
   PATTERN="git_discard"
 fi
 
 # kubectl delete
 if [ -z "$WARN" ] && printf '%s' "$CMD" | grep -qE 'kubectl\s+delete' 2>/dev/null; then
-  WARN="Destructive: kubectl delete removes Kubernetes resources. May impact production."
+  WARN="危険: kubectl delete は Kubernetes リソースを削除します。プロダクションへの影響可能性あり。"
   PATTERN="kubectl_delete"
 fi
 
 # docker rm -f / docker system prune
 if [ -z "$WARN" ] && printf '%s' "$CMD" | grep -qE 'docker\s+(rm\s+-f|system\s+prune)' 2>/dev/null; then
-  WARN="Destructive: Docker force-remove or prune. May delete running containers or cached images."
+  WARN="危険: Docker force-remove または prune。実行中のコンテナや cached image を削除する可能性があります。"
   PATTERN="docker_destructive"
 fi
 
 # --- Output ---
 if [ -n "$WARN" ]; then
   WARN_ESCAPED=$(printf '%s' "$WARN" | sed 's/"/\\"/g')
-  printf '{"permissionDecision":"ask","message":"[careful] %s"}\n' "$WARN_ESCAPED"
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask","permissionDecisionReason":"[careful] %s"}}\n' "$WARN_ESCAPED"
 else
   echo '{}'
 fi

--- a/careful/bin/check-careful.sh
+++ b/careful/bin/check-careful.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# check-careful.sh — PreToolUse hook for /careful skill
+# Reads JSON from stdin, checks Bash command for destructive patterns.
+# Returns {"permissionDecision":"ask","message":"..."} to warn, or {} to allow.
+set -euo pipefail
+
+# Read stdin (JSON with tool_input)
+INPUT=$(cat)
+
+# Extract the "command" field value from tool_input
+# Try grep/sed first (handles 99% of cases), fall back to Python for escaped quotes
+CMD=$(printf '%s' "$INPUT" | grep -o '"command"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*:[[:space:]]*"//;s/"$//' || true)
+
+# Python fallback if grep returned empty (e.g., escaped quotes in command)
+if [ -z "$CMD" ]; then
+  CMD=$(printf '%s' "$INPUT" | python3 -c 'import sys,json; print(json.loads(sys.stdin.read()).get("tool_input",{}).get("command",""))' 2>/dev/null || true)
+fi
+
+# If we still couldn't extract a command, allow
+if [ -z "$CMD" ]; then
+  echo '{}'
+  exit 0
+fi
+
+# Normalize: lowercase for case-insensitive SQL matching
+CMD_LOWER=$(printf '%s' "$CMD" | tr '[:upper:]' '[:lower:]')
+
+# --- Check for safe exceptions (rm -rf of build artifacts) ---
+if printf '%s' "$CMD" | grep -qE 'rm\s+(-[a-zA-Z]*r[a-zA-Z]*\s+|--recursive\s+)' 2>/dev/null; then
+  SAFE_ONLY=true
+  RM_ARGS=$(printf '%s' "$CMD" | sed -E 's/.*rm\s+(-[a-zA-Z]+\s+)*//;s/--recursive\s*//')
+  for target in $RM_ARGS; do
+    case "$target" in
+      */node_modules|node_modules|*/\.next|\.next|*/dist|dist|*/__pycache__|__pycache__|*/\.cache|\.cache|*/build|build|*/\.turbo|\.turbo|*/coverage|coverage)
+        ;; # safe target
+      -*)
+        ;; # flag, skip
+      *)
+        SAFE_ONLY=false
+        break
+        ;;
+    esac
+  done
+  if [ "$SAFE_ONLY" = true ]; then
+    echo '{}'
+    exit 0
+  fi
+fi
+
+# --- Destructive pattern checks ---
+WARN=""
+PATTERN=""
+
+# rm -rf / rm -r / rm --recursive
+if printf '%s' "$CMD" | grep -qE 'rm\s+(-[a-zA-Z]*r|--recursive)' 2>/dev/null; then
+  WARN="Destructive: recursive delete (rm -r). This permanently removes files."
+  PATTERN="rm_recursive"
+fi
+
+# DROP TABLE / DROP DATABASE
+if [ -z "$WARN" ] && printf '%s' "$CMD_LOWER" | grep -qE 'drop\s+(table|database)' 2>/dev/null; then
+  WARN="Destructive: SQL DROP detected. This permanently deletes database objects."
+  PATTERN="drop_table"
+fi
+
+# TRUNCATE
+if [ -z "$WARN" ] && printf '%s' "$CMD_LOWER" | grep -qE '\btruncate\b' 2>/dev/null; then
+  WARN="Destructive: SQL TRUNCATE detected. This deletes all rows from a table."
+  PATTERN="truncate"
+fi
+
+# git push --force / git push -f
+if [ -z "$WARN" ] && printf '%s' "$CMD" | grep -qE 'git\s+push\s+.*(-f\b|--force)' 2>/dev/null; then
+  WARN="Destructive: git force-push rewrites remote history. Other contributors may lose work."
+  PATTERN="git_force_push"
+fi
+
+# git reset --hard
+if [ -z "$WARN" ] && printf '%s' "$CMD" | grep -qE 'git\s+reset\s+--hard' 2>/dev/null; then
+  WARN="Destructive: git reset --hard discards all uncommitted changes."
+  PATTERN="git_reset_hard"
+fi
+
+# git checkout . / git restore .
+if [ -z "$WARN" ] && printf '%s' "$CMD" | grep -qE 'git\s+(checkout|restore)\s+\.' 2>/dev/null; then
+  WARN="Destructive: discards all uncommitted changes in the working tree."
+  PATTERN="git_discard"
+fi
+
+# kubectl delete
+if [ -z "$WARN" ] && printf '%s' "$CMD" | grep -qE 'kubectl\s+delete' 2>/dev/null; then
+  WARN="Destructive: kubectl delete removes Kubernetes resources. May impact production."
+  PATTERN="kubectl_delete"
+fi
+
+# docker rm -f / docker system prune
+if [ -z "$WARN" ] && printf '%s' "$CMD" | grep -qE 'docker\s+(rm\s+-f|system\s+prune)' 2>/dev/null; then
+  WARN="Destructive: Docker force-remove or prune. May delete running containers or cached images."
+  PATTERN="docker_destructive"
+fi
+
+# --- Output ---
+if [ -n "$WARN" ]; then
+  WARN_ESCAPED=$(printf '%s' "$WARN" | sed 's/"/\\"/g')
+  printf '{"permissionDecision":"ask","message":"[careful] %s"}\n' "$WARN_ESCAPED"
+else
+  echo '{}'
+fi


### PR DESCRIPTION
## Summary

- uzustack 初の hook 持ち skill として `careful` を翻訳して repo top に追加（`careful/SKILL.md.tmpl` + `careful/SKILL.md` + `careful/bin/check-careful.sh`）
- `bin/dev-setup` を拡張：hook 持ち skill の `<skill>/bin/` も symlink 対応（`${CLAUDE_SKILL_DIR}` の解決経路に依存しない hook 動作を保証）
- analytics 削除以外、原文の機構（`hooks: PreToolUse`、`sensitive: true`、destructive pattern 検出 8 種、安全例外）はすべて維持
- `statusMessage` 翻訳：「Checking for destructive commands...」→「危険コマンドをチェック中...」

## なぜ Phase 2 / 3 の合間に翻訳するか

#22 の論点 1 で議論し、案 2 採用（hook 機構を維持しつつ単独で先行翻訳）：

- `careful` の hook（`bin/check-careful.sh`）は **gstack 専用バイナリ依存ゼロ**（pure bash + grep/sed + python3 fallback、自己完結）
- Phase 4 全体（freeze + investigate hook 復活 + obsidian-audit-tac 連鎖）を待たずに単独翻訳可能
- 本 step が Phase 4 で再活用される hook 取り込みパターンを先行確立

## 翻訳の設計判断

- **論点 1（`bin/check-careful.sh` の配置）**：A 案採用 → `careful/bin/check-careful.sh`（skill 内 bin、gstack 構造踏襲）
- **論点 2（analytics 書き込み）**：A 案採用 → 削除（`~/.uzustack/analytics/` 全体の uzustack 流再設計は未決-14 で Phase 3+ 統合）
- **論点 3（trigger 語彙）**：5 個確定（セーフティモード / 本番モード / 危険コマンドに注意 / careful モード / destructive 警告）
- **論点 4（`sensitive: true`）**：維持（hook を伴う skill であることを明示）
- **論点 5（`statusMessage` 翻訳）**：日本語化（「危険コマンドをチェック中...」）
- **論点 6（`${CLAUDE_SKILL_DIR}` 検証）**：dev-setup 拡張で両解決経路（symlink path / realpath）に対応、別途 hook 機構の発動経路検証として未決-16 を作成

## /simplify 2 周のレビュー結果

- Pass 1：3 agent すべて clean（修正 0 箇所）。retro Pass 1（26 箇所修正）の学習で用語規範を最初から適用した結果
- Pass 2：3 件の翻訳精度向上（`active` → `有効`、`How it works` → `動作の仕組み`、`session スコープ` → `セッションスコープ`）
- 機構残骸の grep 検査：`gstack` / `~/.gstack/` / `{{...}}` placeholder / analytics 関連すべてヒットゼロ

## bin/dev-setup の改変

hook 持ち skill では SKILL.md だけの symlink では `${CLAUDE_SKILL_DIR}/bin/...` が解決できない可能性があるため、`<skill>/bin/` がある場合は bin/ subdir も symlink 対応：

```bash
if [[ -d "$skill_dir/bin" ]]; then
  if [[ ! -L "$target/bin" || "$(readlink "$target/bin")" != "$expected_bin_link" ]]; then
    [[ -e "$target/bin" || -L "$target/bin" ]] && rm -rf "$target/bin"
    ln -s "$expected_bin_link" "$target/bin"
  fi
fi
```

idempotent、bin/ がない skill（investigate / retro）は影響なし、`bin/dev-teardown` の `rm -rf "$entry"` で skill dir 削除時に bin/ symlink も同時削除（symlink to dir なので source は影響なし）。

## Test plan

- [ ] `.github/workflows/skill-docs.yml` が pass
- [ ] `bin/dev-setup` 後に `careful/SKILL.md` と `careful/bin/check-careful.sh` への symlink が `.claude/skills/careful/` 配下に作成される
- [ ] Claude Code で destructive command（例：`rm -rf ~/test_path`）に対して `permissionDecision: ask` が発火
- [ ] 安全例外（`rm -rf node_modules` 等）が許可される
- [ ] 日本語 trigger（「セーフティモード」等）で skill が起動
- [ ] `${CLAUDE_SKILL_DIR}` が symlink 経由で正しく解決される（Mode A / Mode B 両方）

## スコープ外（後続）

- `freeze` skill 翻訳（Phase 4）
- `investigate` の hook 復活（Phase 4）
- `~/.uzustack/analytics/` 全体の設計（未決-14、Phase 3+）
- destructive コマンドパターンの uzustack 文脈拡張（Phase 1 守段階では原文忠実、破段階で再検討）

Closes #23