### PR TITLE
docs: 翻訳 rebase 時の preserve list を CONTRIBUTING.md に追加（Phase 2 step 29、step 28 補強）

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -287,6 +287,30 @@ step 22 の自動 subtree pull PR が来た時、翻訳済み skill が変更さ
 4. **`/simplify` を 2 周**
 5. **PR**：別 PR として作成、auto PR とは独立した commit に
 
+### rebase 時に保持すべき uzustack 独自 fix
+
+uzustack の翻訳版には、gstack 上流にない uzustack 独自の fix が含まれている場合がある。subtree pull は `_upstream/gstack/` 配下しか触らないので物理的に上書きされないが、上記「rebase 作業」で翻訳版を上流差分に合わせて書き直す時に、AI / 人間 reviewer が **誤って revert する risk** がある。以下を **必ず維持** する：
+
+#### `careful` skill（PR #24 で導入）
+
+| fix | 理由 | 場所 |
+|---|---|---|
+| `${CLAUDE_SKILL_DIR}` → `$CLAUDE_PROJECT_DIR/.claude/skills/<skill>/bin/...` | Claude Code 公式 env var に揃える（gstack の `${CLAUDE_SKILL_DIR}` は独自拡張で空文字列に展開され、hook script が見つからない） | `careful/SKILL.md.tmpl` の `hooks: command` |
+| hook output JSON を `hookSpecificOutput` で wrap、`message` → `permissionDecisionReason` | Claude Code 現行 hook 仕様（gstack 旧 format `{"permissionDecision":"ask","message":"..."}` は無視される） | `careful/bin/check-careful.sh` の出力部 |
+| sed regex で `\s+` → `[[:space:]]+` | BSD sed (macOS) は `\s` 非対応で safe exception の RM_ARGS strip が失敗する。POSIX `[[:space:]]+` で macOS / Linux 両対応 | `careful/bin/check-careful.sh` の sed |
+| WARN メッセージ日本語化（`危険:` prefix） | uzustack 全体の言語感整合（SKILL.md.tmpl と statusMessage は日本語、warning だけ英語は不整合） | `careful/bin/check-careful.sh` の WARN 文字列 8 種 |
+
+#### Phase 4 以降の hook 持ち skill 翻訳時の規範
+
+新しい hook 持ち skill（`freeze`、hook 化された `investigate` 等）を翻訳する時も、上記 4 種類の fix パターンを **最初から** 適用すること：
+
+1. **hook command path**：YAML frontmatter の `hooks.PreToolUse[].hooks[].command` で `$CLAUDE_PROJECT_DIR/.claude/skills/<skill>/bin/...` を使う（gstack 原文の `${CLAUDE_SKILL_DIR}` は使わない）
+2. **hook output JSON format**：bin script の出力は `hookSpecificOutput` で wrap、message field は `permissionDecisionReason`
+3. **sed regex の互換性**：bin script 内の sed で `\s` を使わず POSIX `[[:space:]]+` を使う
+4. **user-facing メッセージ**：WARN、status、説明文等は日本語化（uzustack 全体の言語感に揃える）
+
+これにより Phase 4 で同じ修正集積をやり直さずに済む。
+
 ### bulk rebase（翻訳済み skill が ≥3 件になったら）
 
 複数の翻訳済み skill が同じ自動 PR で上流更新を受けた場合、1 件ずつではなく月次 batch でまとめて rebase する運用も検討します（将来の改善ポイント）。今は 1 件のみなので個別対応で十分。


### PR DESCRIPTION
## Summary

- CONTRIBUTING.md の「翻訳ガイド > rebase の手順」直後に、新サブセクション `### rebase 時に保持すべき uzustack 独自 fix` を追加
- careful skill 固有の 4 fixes（#24 で導入）を表形式で具体記載
- Phase 4 以降の hook 持ち skill 翻訳時に最初から適用すべき 4 つのパターンを明示

## 動機

#24（step 28）で uzustack の `careful` skill に **gstack 上流にない uzustack 独自の 4 fixes** を導入：

1. hook command path：`${CLAUDE_SKILL_DIR}` → `$CLAUDE_PROJECT_DIR/.claude/skills/<skill>/bin/...`（Claude Code 公式 env var）
2. hook output JSON：`hookSpecificOutput` で wrap、`message` → `permissionDecisionReason`（Claude Code 現行仕様）
3. sed regex：`\s+` → `[[:space:]]+`（BSD sed 互換）
4. WARN メッセージ日本語化（`危険:` prefix）

これらは subtree pull で物理的に上書きされない構造（`_upstream/gstack/` 配下しか触らない）だが、月 1 自動 PR 後の手動 rebase 時に AI / 人間 reviewer が誤って revert する risk がある。

CONTRIBUTING.md に preserve list を **明示** することで、忘却 risk を完全回避し、Phase 4 hook 群の翻訳時にも同じ規範を最初から適用する。

## 追加内容

- careful 固有の preserve list（fix / 理由 / 場所の 3 列表、4 行）
- Phase 4 以降の汎用規範（4 項目の bullet）

## Test plan

- [ ] CONTRIBUTING.md を読んで「rebase の手順」直後に preserve list が見えるか確認
- [ ] preserve list の表が正しく rendering されるか
- [ ] CI（`.github/workflows/skill-docs.yml`）が pass

## スコープ外

- gstack に upstream PR を投げる判断（#24 議論で C 案採用、現運用維持）
- Phase 4 hook 群の実装
- preserve list の機械的検証（lint 等）

Closes #25