### PR TITLE
feat: bin 配置の最小 prototype（uzustack-config / uzustack-slug）— Phase 3 step-32

### DIFF
--- a/bin/uzustack-config
+++ b/bin/uzustack-config
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# uzustack-config — read/write ~/.uzustack/config.yaml
+#
+# Usage:
+#   uzustack-config get <key>          — read a config value (falls back to DEFAULTS)
+#   uzustack-config set <key> <value>  — write a config value
+#   uzustack-config list               — show all config (values + defaults)
+#   uzustack-config defaults           — show just the defaults table
+#
+# Env overrides (for testing):
+#   UZUSTACK_HOME     — override ~/.uzustack state directory (aligns with writer scripts)
+set -euo pipefail
+
+STATE_DIR="${UZUSTACK_HOME:-$HOME/.uzustack}"
+CONFIG_FILE="$STATE_DIR/config.yaml"
+
+# Annotated header for new config files. Written once on first `set`.
+# Default semantics: DEFAULTS table below is the canonical source. Header text
+# is documentation that must stay in sync with DEFAULTS.
+CONFIG_HEADER='# uzustack configuration — edit freely, changes take effect on next skill run.
+# Docs: https://github.com/uzumaki-inc/uzustack
+#
+# ─── Behavior ────────────────────────────────────────────────────────
+# proactive: true           # Auto-invoke skills when your request matches one.
+#                           # Set to false to only run skills you type explicitly.
+#
+# routing_declined: false   # Set to true to skip the CLAUDE.md routing injection
+#                           # prompt. Set back to false to be asked again.
+#
+# ─── Telemetry ───────────────────────────────────────────────────────
+# telemetry: off            # off | anonymous | community
+#                           #   off       — no data sent, no local analytics (default)
+#                           #   anonymous — counter only, no device ID
+#                           #   community — usage data + stable device ID
+#
+# ─── Updates ─────────────────────────────────────────────────────────
+# auto_upgrade: false       # true = silently upgrade on session start
+# update_check: true        # false = suppress version check notifications
+#
+# ─── Skill naming ────────────────────────────────────────────────────
+# skill_prefix: false       # true = namespace skills as /uzustack-qa, /uzustack-ship
+#                           # false = short names /qa, /ship
+#
+# ─── Checkpoint ──────────────────────────────────────────────────────
+# checkpoint_mode: explicit # explicit | continuous
+#                           #   explicit   — commit only when you run /ship or /checkpoint
+#                           #   continuous — auto-commit after each significant change
+#                           #                with WIP: prefix + [uzustack-context] body
+#
+# checkpoint_push: false    # true = push WIP commits to remote as you go
+#                           # false = keep WIP commits local only (default)
+#                           # Pushing can trigger CI/deploy hooks — opt in carefully.
+#
+# ─── Writing style (V1) ──────────────────────────────────────────────
+# explain_level: default    # default = jargon-glossed, outcome-framed prose
+#                           #           (V1 default — more accessible for everyone)
+#                           # terse   = V0 prose style, no glosses, no outcome-framing layer
+#                           #           (for power users who know the terms)
+#                           # Unknown values default to "default" with a warning.
+#                           # See docs/designs/PLAN_TUNING_V1.md for rationale.
+#
+# ─── GBrain sync (v1.7+) ─────────────────────────────────────────────
+# gbrain_sync_mode: off     # off | artifacts-only | full
+#                           #   off            — no sync (default)
+#                           #   artifacts-only — sync plans/designs/retros/learnings only
+#                           #                    (skip behavioral data: question-log,
+#                           #                    developer-profile, timeline)
+#                           #   full           — sync everything allowlisted
+#                           # Set by the first-run privacy stop-gate. See docs/gbrain-sync.md.
+#
+# gbrain_sync_mode_prompted: false
+#                           # Set to true once the privacy gate has asked the user.
+#                           # Flip back to false to be re-prompted.
+#
+# ─── Advanced ────────────────────────────────────────────────────────
+# codex_reviews: enabled    # disabled = skip Codex adversarial reviews in /ship
+# uzustack_contributor: false # true = file field reports when uzustack misbehaves
+# skip_eng_review: false    # true = skip eng review gate in /ship (not recommended)
+#
+# ─── Workspace-aware ship ────────────────────────────────────────────
+# workspace_root: $HOME/conductor/workspaces  # Where /ship looks for sibling
+#                           # Conductor worktrees when picking a VERSION slot.
+#                           # Set to "null" to disable sibling scanning entirely.
+#                           # Non-Conductor users can point this at any directory
+#                           # that holds parallel worktrees of the same repo.
+#
+'
+
+# DEFAULTS table — canonical default values for known keys.
+# `get <key>` returns DEFAULTS[key] when the key is absent from the config file
+# AND the env override is not set. Keep in sync with the CONFIG_HEADER comments.
+lookup_default() {
+  case "$1" in
+    proactive) echo "true" ;;
+    routing_declined) echo "false" ;;
+    telemetry) echo "off" ;;
+    auto_upgrade) echo "false" ;;
+    update_check) echo "true" ;;
+    skill_prefix) echo "false" ;;
+    checkpoint_mode) echo "explicit" ;;
+    checkpoint_push) echo "false" ;;
+    codex_reviews) echo "enabled" ;;
+    uzustack_contributor) echo "false" ;;
+    skip_eng_review) echo "false" ;;
+    workspace_root) echo "$HOME/conductor/workspaces" ;;
+    cross_project_learnings) echo "" ;; # intentionally empty → unset triggers first-time prompt
+    gbrain_sync_mode) echo "off" ;;
+    gbrain_sync_mode_prompted) echo "false" ;;
+    *) echo "" ;;
+  esac
+}
+
+case "${1:-}" in
+  get)
+    KEY="${2:?Usage: uzustack-config get <key>}"
+    # Validate key (alphanumeric + underscore only)
+    if ! printf '%s' "$KEY" | grep -qE '^[a-zA-Z0-9_]+$'; then
+      echo "Error: key must contain only alphanumeric characters and underscores" >&2
+      exit 1
+    fi
+    VALUE=$(grep -E "^${KEY}:" "$CONFIG_FILE" 2>/dev/null | tail -1 | awk '{print $2}' | tr -d '[:space:]' || true)
+    if [ -z "$VALUE" ]; then
+      VALUE=$(lookup_default "$KEY")
+    fi
+    printf '%s' "$VALUE"
+    ;;
+  set)
+    KEY="${2:?Usage: uzustack-config set <key> <value>}"
+    VALUE="${3:?Usage: uzustack-config set <key> <value>}"
+    # Validate key (alphanumeric + underscore only)
+    if ! printf '%s' "$KEY" | grep -qE '^[a-zA-Z0-9_]+$'; then
+      echo "Error: key must contain only alphanumeric characters and underscores" >&2
+      exit 1
+    fi
+    # V1: whitelist values for keys with closed value domains. Unknown values warn + default.
+    if [ "$KEY" = "explain_level" ] && [ "$VALUE" != "default" ] && [ "$VALUE" != "terse" ]; then
+      echo "Warning: explain_level '$VALUE' not recognized. Valid values: default, terse. Using default." >&2
+      VALUE="default"
+    fi
+    if [ "$KEY" = "gbrain_sync_mode" ] && [ "$VALUE" != "off" ] && [ "$VALUE" != "artifacts-only" ] && [ "$VALUE" != "full" ]; then
+      echo "Warning: gbrain_sync_mode '$VALUE' not recognized. Valid values: off, artifacts-only, full. Using off." >&2
+      VALUE="off"
+    fi
+    mkdir -p "$STATE_DIR"
+    # Write annotated header on first creation
+    if [ ! -f "$CONFIG_FILE" ]; then
+      printf '%s' "$CONFIG_HEADER" > "$CONFIG_FILE"
+    fi
+    # Escape sed special chars in value and drop embedded newlines
+    ESC_VALUE="$(printf '%s' "$VALUE" | head -1 | sed 's/[&/\]/\\&/g')"
+    if grep -qE "^${KEY}:" "$CONFIG_FILE" 2>/dev/null; then
+      # Portable in-place edit (BSD sed uses -i '', GNU sed uses -i without arg)
+      _tmpfile="$(mktemp "${CONFIG_FILE}.XXXXXX")"
+      sed "/^${KEY}:/s/.*/${KEY}: ${ESC_VALUE}/" "$CONFIG_FILE" > "$_tmpfile" && mv "$_tmpfile" "$CONFIG_FILE"
+    else
+      echo "${KEY}: ${VALUE}" >> "$CONFIG_FILE"
+    fi
+    # Auto-relink skills when prefix setting changes (skip during setup to avoid recursive call)
+    if [ "$KEY" = "skill_prefix" ] && [ -z "${UZUSTACK_SETUP_RUNNING:-}" ]; then
+      UZUSTACK_RELINK="$(dirname "$0")/uzustack-relink"
+      [ -x "$UZUSTACK_RELINK" ] && "$UZUSTACK_RELINK" || true
+    fi
+    ;;
+  list)
+    if [ -f "$CONFIG_FILE" ]; then
+      cat "$CONFIG_FILE"
+    fi
+    echo ""
+    echo "# ─── Active values (including defaults for unset keys) ───"
+    for KEY in proactive routing_declined telemetry auto_upgrade update_check \
+               skill_prefix checkpoint_mode checkpoint_push codex_reviews \
+               uzustack_contributor skip_eng_review workspace_root \
+               gbrain_sync_mode gbrain_sync_mode_prompted; do
+      VALUE=$(grep -E "^${KEY}:" "$CONFIG_FILE" 2>/dev/null | tail -1 | awk '{print $2}' | tr -d '[:space:]' || true)
+      SOURCE="default"
+      if [ -n "$VALUE" ]; then
+        SOURCE="set"
+      else
+        VALUE=$(lookup_default "$KEY")
+      fi
+      printf '  %-24s %s (%s)\n' "$KEY:" "$VALUE" "$SOURCE"
+    done
+    ;;
+  defaults)
+    echo "# uzustack-config defaults"
+    for KEY in proactive routing_declined telemetry auto_upgrade update_check \
+               skill_prefix checkpoint_mode checkpoint_push codex_reviews \
+               uzustack_contributor skip_eng_review workspace_root \
+               gbrain_sync_mode gbrain_sync_mode_prompted; do
+      printf '  %-24s %s\n' "$KEY:" "$(lookup_default "$KEY")"
+    done
+    ;;
+  *)
+    echo "Usage: uzustack-config {get|set|list|defaults} [key] [value]"
+    exit 1
+    ;;
+esac

--- a/bin/uzustack-slug
+++ b/bin/uzustack-slug
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# uzustack-slug — output project slug and sanitized branch name
+# Usage: eval "$(uzustack-slug)"  → sets SLUG and BRANCH variables
+# Or:    uzustack-slug            → prints SLUG=... and BRANCH=... lines
+#
+# Security: output is sanitized to [a-zA-Z0-9._-] only, preventing
+# shell injection when consumed via source or eval.
+set -euo pipefail
+
+CACHE_DIR="$HOME/.uzustack/slug-cache"
+PROJECT_DIR="$(pwd)"
+# Encode absolute path as cache key: /Users/j/foo → _Users_j_foo
+CACHE_KEY=$(printf '%s' "$PROJECT_DIR" | tr '/' '_')
+CACHE_FILE="${CACHE_DIR}/${CACHE_KEY}"
+
+# 1. Try cached slug first (guarantees consistency across sessions)
+if [[ -f "$CACHE_FILE" ]]; then
+  SLUG=$(cat "$CACHE_FILE")
+fi
+
+# 2. If no cache, compute from git remote (separated from pipeline to avoid
+#    pipefail swallowing the error and producing an empty slug)
+if [[ -z "${SLUG:-}" ]]; then
+  REMOTE_URL=$(git remote get-url origin 2>/dev/null) || REMOTE_URL=""
+  if [[ -n "$REMOTE_URL" ]]; then
+    RAW_SLUG=$(printf '%s' "$REMOTE_URL" | sed 's|.*[:/]\([^/]*/[^/]*\)\.git$|\1|;s|.*[:/]\([^/]*/[^/]*\)$|\1|' | tr '/' '-')
+    SLUG=$(printf '%s' "$RAW_SLUG" | tr -cd 'a-zA-Z0-9._-')
+  fi
+fi
+
+# 3. Fallback to basename only when there's truly no git remote configured
+SLUG="${SLUG:-$(basename "$PWD" | tr -cd 'a-zA-Z0-9._-')}"
+
+# 4. Cache the slug for future sessions (atomic write, fail silently)
+if [[ -n "$SLUG" ]]; then
+  mkdir -p "$CACHE_DIR" 2>/dev/null || true
+  CACHE_TMP=$(mktemp "$CACHE_DIR/.slug-XXXXXX" 2>/dev/null) || CACHE_TMP=""
+  if [[ -n "$CACHE_TMP" ]]; then
+    printf '%s' "$SLUG" > "$CACHE_TMP" && mv "$CACHE_TMP" "$CACHE_FILE" 2>/dev/null || rm -f "$CACHE_TMP" 2>/dev/null
+  fi
+fi
+
+RAW_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || RAW_BRANCH=""
+BRANCH=$(printf '%s' "${RAW_BRANCH:-}" | tr -cd 'a-zA-Z0-9._-')
+BRANCH="${BRANCH:-unknown}"
+echo "SLUG=$SLUG"
+echo "BRANCH=$BRANCH"


### PR DESCRIPTION
Closes #29

## Summary

Phase 3 = "runtime 完璧実装" 方針（2026-04-27 確定）の最初の実装。gstack の `bin/` 約 50 個を `uzustack-*` に機械翻訳する前に、**`uzustack-config` と `uzustack-slug` の 2 個で完成形の型を実証**する。型が決まれば残り 48 個の翻訳は判断ゼロの機械作業になる。

## Changes

- `bin/uzustack-config`（197 行）: 設定の KV ストア（`~/.uzustack/config.yaml`、get / set / list / defaults）
- `bin/uzustack-slug`（47 行）: プロジェクト識別子の生成（git remote → SLUG、`~/.uzustack/slug-cache/` への atomic write、3 段階 fallback）
- bisect 単位で 2 commit に分割

## 確定した型（残り 48 個の翻訳が機械作業になる前提）

| # | 論点 | 確定内容 |
|---|---|---|
| 5 | 状態ディレクトリ | `$HOME/.uzustack/`（gstack の `~/.gstack/` と対称） |
| 4 | 環境変数 | `UZUSTACK_HOME` 一本（legacy alias なし） |
| 1 | ディレクトリ構造 | `bin/` 直下フラット |
| 2 | 命名 | `uzustack-` prefix + hyphen 区切り |
| 3 | shebang | `#!/usr/bin/env bash` + `set -euo pipefail` |
| 6 | 共通 lib | prototype では作らない、step-37 で判断 |
| 7 | パス置換ルール | prototype 範囲だけ先行確定、step-33 で正式化 |

詳細は step-32 子ノートの「型確定（2026-04-27）」セクション参照。

## 動作確認（20 項目すべて PASS）

### uzustack-config（13 項目）
- DEFAULTS fallback、set/get、CONFIG_HEADER 書き込み
- whitelist validation（`explain_level` / `gbrain_sync_mode` の不正値 → 既定値 + warn）
- `list` のソース表示、`defaults` サブコマンド
- key validation（不正 key → エラー + exit 1）
- 自由 key（DEFAULTS 外）の set/get
- `UZUSTACK_HOME` env override の isolation
- 既存 key の上書き（sed in-place edit、portable BSD/GNU 両対応）
- `uzustack-relink` 未存在時の fail silently（設計通り）
- set 引数欠落のエラー処理

### uzustack-slug（7 項目）
- `SLUG=uzumaki-inc-uzustack` `BRANCH=...` 出力
- `eval` が shell 変数を populate
- cache 書き込み（atomic write、tmp + mv）
- cache が git remote より優先される
- cache 削除後の再計算
- git remote 無いディレクトリで basename fallback
- BRANCH サニタイズ（スラッシュ除去、shell injection 防止）

## SLUG 計算 + 既存データ移行

gstack-slug の 3 段階 fallback（cache → git remote → basename）を完全踏襲。本リポジトリでは `SLUG=uzumaki-inc-uzustack` を返す。

先行実装で `~/.uzustack/projects/uzustack/` 配下に保存されていた checkpoint 1 件を、新 SLUG に整合する `~/.uzustack/projects/uzumaki-inc-uzustack/` に手動 `mv` で移行済み（α 案）。

## Out of scope

- 残り bin の翻訳（後続 step-35〜39）
- voice / CONFIG_HEADER の日本語化（step-33）
- DEFAULTS table の意味論変更（step-37）
- コンパイル binary 系（browse / design）の build pipeline（step-37〜39）

## Test plan

- [ ] `git checkout feature/step-32-bin-prototype` 後、`./bin/uzustack-config get telemetry` が `off` を返す
- [ ] `./bin/uzustack-slug` が `SLUG=uzumaki-inc-uzustack` `BRANCH=featurestep-32-bin-prototype` を返す
- [ ] `eval "$(./bin/uzustack-slug)"` で `$SLUG` が shell に展開される
- [ ] `~/.uzustack/projects/uzumaki-inc-uzustack/checkpoints/` に既存 checkpoint が retain されている
- [ ] gstack-config / gstack-slug との挙動差異がないこと（legacy alias の `GSTACK_STATE_DIR` 削除 + key 名 `gstack_contributor` → `uzustack_contributor` 以外は同等）

🤖 Generated with [Claude Code](https://claude.com/claude-code)