### PR TITLE
Phase 3 step-33B: setup を gstack 構造で完璧複製（環境準備 + 4 host 向け処理 + bun script 呼び出し点）

### DIFF
--- a/setup
+++ b/setup
@@ -1,90 +1,1059 @@
 #!/usr/bin/env bash
-# uzustack setup — install uzustack skills into the current project's .claude/skills/.
+# uzustack setup — register skills with Claude Code / Codex / Kiro / Factory / OpenCode
 #
-# Usage:
-#   cd <your-project>
-#   ~/.claude/skills/uzustack/setup
-#
-# Phase 1 scope: symlink uzustack の各 skill を <project>/.claude/skills/<skill>/SKILL.md へ展開する。
-# settings.json / CLAUDE.md には触れない（Phase 3 以降で機構取り込みと一緒に着手予定）。
-#
-# Maintainers should use bin/dev-setup instead — it links the dev clone in place
-# without requiring a separate ~/.claude/skills/uzustack/ install.
+# Phase 3 step-33B: gstack/setup（1011 行）の構造を完璧複製したもの。
+# 文字列置換は CONTRIBUTING.md「翻訳の置換ルール表 v1」に従う。
+# uzustack 未翻訳の bin / skill / file への参照は元 gstack の `[ -x ... ]` /
+# `[ -f ... ]` / `[ -d ... ]` ガードで自然に no-op になる。それで足りない
+# `bun run XXX` 呼び出しと browse / Playwright 関連の処理は、setup 冒頭で
+# 1 度だけ定義する境界（_has_bun_script / HAS_BROWSE）で guard する。
+# 「これは入れる、これは外す」の都度判断は導入しない（Phase 3 規律：
+# 判断を 1 度集中、以降ゼロで機械的に手を動かし続ける）。
+# bin 翻訳が step-35〜39 で進むと、該当処理が自動的に有効化される。
+# step-42 で全体動作確認する。
 
-set -euo pipefail
-shopt -s nullglob
+set -e
+umask 077  # Restrict new files to owner-only (0o600 files, 0o700 dirs)
 
-UZUSTACK_DIR="$(cd "$(dirname "$0")" && pwd -P)"
-PROJECT_DIR="$(pwd -P)"
-
-if [[ "$UZUSTACK_DIR" == "$PROJECT_DIR" ]]; then
-  echo "Error: setup is meant for end users to install into their own project." >&2
-  echo "  You appear to be inside the uzustack repo itself." >&2
-  echo "  Maintainers: use bin/dev-setup instead." >&2
-  echo "  End users: cd to your own project, then re-run this script." >&2
+if ! command -v bun >/dev/null 2>&1; then
+  echo "Error: bun is required but not installed." >&2
+  echo "Install with checksum verification:" >&2
+  echo '  BUN_VERSION="1.3.10"' >&2
+  echo '  tmpfile=$(mktemp)' >&2
+  echo '  curl -fsSL "https://bun.sh/install" -o "$tmpfile"' >&2
+  echo '  echo "Verify checksum before running: shasum -a 256 $tmpfile"' >&2
+  echo '  BUN_VERSION="$BUN_VERSION" bash "$tmpfile" && rm "$tmpfile"' >&2
   exit 1
 fi
 
-SKILLS_DIR="$PROJECT_DIR/.claude/skills"
-mkdir -p "$SKILLS_DIR"
+INSTALL_UZUSTACK_DIR="$(cd "$(dirname "$0")" && pwd)"
+SOURCE_UZUSTACK_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+INSTALL_SKILLS_DIR="$(dirname "$INSTALL_UZUSTACK_DIR")"
+BROWSE_BIN="$SOURCE_UZUSTACK_DIR/browse/dist/browse"
+CODEX_SKILLS="$HOME/.codex/skills"
+CODEX_UZUSTACK="$CODEX_SKILLS/uzustack"
+FACTORY_SKILLS="$HOME/.factory/skills"
+FACTORY_UZUSTACK="$FACTORY_SKILLS/uzustack"
+OPENCODE_SKILLS="$HOME/.config/opencode/skills"
+OPENCODE_UZUSTACK="$OPENCODE_SKILLS/uzustack"
 
-# Keep in sync with EXCLUDE in bin/dev-setup and scripts/gen-skill-docs.ts.
-# .claude / .git / .github are dotfile dirs and already excluded by the */ glob.
-EXCLUDE=(_upstream scripts bin node_modules dist build)
+IS_WINDOWS=0
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*|Windows_NT) IS_WINDOWS=1 ;;
+esac
 
-linked=()
-already=()
-skipped=()
+# ─── Boundary guards (uzustack 固有、Phase 3 規律で 1 度だけ定義) ──────
+# `bun run <script>` を呼ぶ前にこの helper で package.json への登録を確認する。
+# これにより未翻訳の bun script（build / gen:skill-docs --host XXX 等）は静かに
+# skip され、script 追加と同時に自動的に有効化される。
+_has_bun_script() {
+  local script_name="$1"
+  [ -f "$SOURCE_UZUSTACK_DIR/package.json" ] && grep -q "\"$script_name\"" "$SOURCE_UZUSTACK_DIR/package.json"
+}
 
-for skill_dir in "$UZUSTACK_DIR"/*/; do
-  skill_name="${skill_dir%/}"
-  skill_name="${skill_name##*/}"
+# browse / Playwright / codesign / coreutils 関連は、uzustack に browse/ ディレクトリ
+# が無い間は 1 段ブロックで guard する。browse 翻訳と同時に自動的に有効化される。
+HAS_BROWSE=0
+if [ -d "$SOURCE_UZUSTACK_DIR/browse" ]; then
+  HAS_BROWSE=1
+fi
 
-  [[ " ${EXCLUDE[*]} " == *" $skill_name "* ]] && continue
-  [[ -f "$skill_dir/SKILL.md" ]] || continue
+# ─── Quiet mode helper ────────────────────────────────────────
+QUIET=0
+log() { [ "$QUIET" -eq 0 ] && echo "$@" || true; }
 
-  target_dir="$SKILLS_DIR/$skill_name"
-  target_link="$target_dir/SKILL.md"
-  expected_target="${skill_dir%/}/SKILL.md"
-
-  if [[ -L "$target_link" && "$(readlink "$target_link")" == "$expected_target" ]]; then
-    already+=("$skill_name")
-    continue
-  fi
-
-  # Replace stale uzustack-managed entries; refuse to touch user-managed real dirs.
-  if [[ -L "$target_dir" ]]; then
-    # Legacy: whole-dir symlink from earlier uzustack layouts.
-    echo "  warn: replacing legacy directory symlink at $target_dir" >&2
-    rm "$target_dir"
-  elif [[ -L "$target_link" ]]; then
-    # Stale SKILL.md symlink (e.g., uzustack moved, or user pointed it elsewhere).
-    echo "  warn: replacing existing SKILL.md symlink at $target_link (was $(readlink "$target_link"))" >&2
-    rm "$target_link"
-  elif [[ -d "$target_dir" ]]; then
-    # User-managed directory (Type 2 skill etc.) — leave alone.
-    echo "  warn: $target_dir exists and is not managed by uzustack — skipped" >&2
-    skipped+=("$skill_name")
-    continue
-  fi
-
-  mkdir -p "$target_dir"
-  ln -snf "$expected_target" "$target_link"
-  linked+=("$skill_name")
+# ─── Parse flags ──────────────────────────────────────────────
+HOST="claude"
+LOCAL_INSTALL=0
+SKILL_PREFIX=1
+SKILL_PREFIX_FLAG=0
+TEAM_MODE=0
+NO_TEAM_MODE=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --host) [ -z "$2" ] && echo "Missing value for --host (expected claude, codex, kiro, factory, opencode, openclaw, hermes, gbrain, or auto)" >&2 && exit 1; HOST="$2"; shift 2 ;;
+    --host=*) HOST="${1#--host=}"; shift ;;
+    --local) LOCAL_INSTALL=1; shift ;;
+    --prefix)    SKILL_PREFIX=1; SKILL_PREFIX_FLAG=1; shift ;;
+    --no-prefix) SKILL_PREFIX=0; SKILL_PREFIX_FLAG=1; shift ;;
+    --team)    TEAM_MODE=1; shift ;;
+    --no-team) NO_TEAM_MODE=1; shift ;;
+    -q|--quiet) QUIET=1; shift ;;
+    *) shift ;;
+  esac
 done
 
-echo ""
-echo "uzustack setup complete in $PROJECT_DIR/.claude/skills/"
-if (( ${#linked[@]} > 0 )); then
-  echo "  Linked:         ${linked[*]}"
-fi
-if (( ${#already[@]} > 0 )); then
-  echo "  Already linked: ${already[*]}"
-fi
-if (( ${#skipped[@]} > 0 )); then
-  echo "  Skipped:        ${skipped[*]}"
+case "$HOST" in
+  claude|codex|kiro|factory|opencode|auto) ;;
+  openclaw)
+    echo ""
+    echo "OpenClaw integration uses a different model — OpenClaw spawns Claude Code"
+    echo "sessions natively via ACP. uzustack provides methodology artifacts, not a"
+    echo "full skill installation."
+    echo ""
+    echo "To integrate uzustack with OpenClaw:"
+    echo "  1. Tell your OpenClaw agent: 'install uzustack for openclaw'"
+    echo "  2. Or generate artifacts: bun run gen:skill-docs --host openclaw"
+    echo "  3. See docs/OPENCLAW.md for the full architecture"
+    echo ""
+    exit 0 ;;
+  hermes)
+    echo ""
+    echo "Hermes integration uses the same model as OpenClaw — Hermes spawns"
+    echo "Claude Code sessions, and uzustack provides methodology artifacts."
+    echo ""
+    echo "To integrate uzustack with Hermes:"
+    echo "  1. Tell your Hermes agent: 'install uzustack for hermes'"
+    echo "  2. Or generate artifacts: bun run gen:skill-docs --host hermes"
+    echo ""
+    exit 0 ;;
+  gbrain)
+    echo ""
+    echo "GBrain is a mod for uzustack — it makes coding skills brain-aware."
+    echo "GBrain generates brain-enhanced skill variants that search your brain"
+    echo "for context before starting and save results after finishing."
+    echo ""
+    echo "To generate brain-aware skills:"
+    echo "  bun run gen:skill-docs --host gbrain"
+    echo ""
+    echo "GBrain setup and brain skills ship from the GBrain repo."
+    echo ""
+    exit 0 ;;
+  *) echo "Unknown --host value: $HOST (expected claude, codex, kiro, factory, opencode, openclaw, hermes, gbrain, or auto)" >&2; exit 1 ;;
+esac
+
+# ─── Resolve skill prefix preference ─────────────────────────
+# Priority: CLI flag > saved config > interactive prompt (or flat default for non-TTY)
+UZUSTACK_CONFIG="$SOURCE_UZUSTACK_DIR/bin/uzustack-config"
+export UZUSTACK_SETUP_RUNNING=1  # Prevent uzustack-config post-set hook from triggering relink mid-setup
+if [ "$SKILL_PREFIX_FLAG" -eq 0 ]; then
+  _saved_prefix="$("$UZUSTACK_CONFIG" get skill_prefix 2>/dev/null || true)"
+  if [ "$_saved_prefix" = "true" ]; then
+    SKILL_PREFIX=1
+  elif [ "$_saved_prefix" = "false" ]; then
+    SKILL_PREFIX=0
+  else
+    # No saved preference — prompt interactively (or default flat for non-TTY/quiet)
+    if [ "$QUIET" -eq 1 ]; then
+      SKILL_PREFIX=0
+    elif [ -t 0 ]; then
+      echo ""
+      echo "Skill naming: how should uzustack skills appear?"
+      echo ""
+      echo "  1) Short names: /qa, /ship, /review"
+      echo "     Recommended. Clean and fast to type."
+      echo ""
+      echo "  2) Namespaced: /uzustack-qa, /uzustack-ship, /uzustack-review"
+      echo "     Use this if you run other skill packs alongside uzustack to avoid conflicts."
+      echo ""
+      printf "Choice [1/2] (default: 1, auto-selects in 10s): "
+      read -t 10 -r _prefix_choice </dev/tty 2>/dev/null || _prefix_choice=""
+      case "$_prefix_choice" in
+        2) SKILL_PREFIX=1 ;;
+        *) SKILL_PREFIX=0 ;;
+      esac
+    else
+      SKILL_PREFIX=0
+    fi
+    # Save the choice for future runs
+    "$UZUSTACK_CONFIG" set skill_prefix "$([ "$SKILL_PREFIX" -eq 1 ] && echo true || echo false)" 2>/dev/null || true
+  fi
+else
+  # Flag was passed explicitly — persist the choice
+  "$UZUSTACK_CONFIG" set skill_prefix "$([ "$SKILL_PREFIX" -eq 1 ] && echo true || echo false)" 2>/dev/null || true
 fi
 
-if (( ${#linked[@]} == 0 && ${#already[@]} == 0 && ${#skipped[@]} == 0 )); then
-  echo "  warn: no uzustack skills found at $UZUSTACK_DIR" >&2
+# --local: install to .claude/skills/ in the current working directory (deprecated)
+if [ "$LOCAL_INSTALL" -eq 1 ]; then
+  echo "Warning: --local is deprecated. Use global install + --team instead." >&2
+  echo "  See: https://github.com/uzumaki-inc/uzustack#team-mode" >&2
+  if [ "$HOST" = "codex" ]; then
+    echo "Error: --local is only supported for Claude Code (not Codex)." >&2
+    exit 1
+  fi
+  INSTALL_SKILLS_DIR="$(pwd)/.claude/skills"
+  mkdir -p "$INSTALL_SKILLS_DIR"
+  HOST="claude"
+  INSTALL_CODEX=0
+fi
+
+# For auto: detect which agents are installed
+INSTALL_CLAUDE=0
+INSTALL_CODEX=0
+INSTALL_KIRO=0
+INSTALL_FACTORY=0
+INSTALL_OPENCODE=0
+if [ "$HOST" = "auto" ]; then
+  command -v claude >/dev/null 2>&1 && INSTALL_CLAUDE=1
+  command -v codex >/dev/null 2>&1 && INSTALL_CODEX=1
+  command -v kiro-cli >/dev/null 2>&1 && INSTALL_KIRO=1
+  command -v droid >/dev/null 2>&1 && INSTALL_FACTORY=1
+  command -v opencode >/dev/null 2>&1 && INSTALL_OPENCODE=1
+  # If none found, default to claude
+  if [ "$INSTALL_CLAUDE" -eq 0 ] && [ "$INSTALL_CODEX" -eq 0 ] && [ "$INSTALL_KIRO" -eq 0 ] && [ "$INSTALL_FACTORY" -eq 0 ] && [ "$INSTALL_OPENCODE" -eq 0 ]; then
+    INSTALL_CLAUDE=1
+  fi
+elif [ "$HOST" = "claude" ]; then
+  INSTALL_CLAUDE=1
+elif [ "$HOST" = "codex" ]; then
+  INSTALL_CODEX=1
+elif [ "$HOST" = "kiro" ]; then
+  INSTALL_KIRO=1
+elif [ "$HOST" = "factory" ]; then
+  INSTALL_FACTORY=1
+elif [ "$HOST" = "opencode" ]; then
+  INSTALL_OPENCODE=1
+fi
+
+migrate_direct_codex_install() {
+  local uzustack_dir="$1"
+  local codex_uzustack="$2"
+  local migrated_dir="$HOME/.uzustack/repos/uzustack"
+
+  [ "$uzustack_dir" = "$codex_uzustack" ] || return 0
+  [ -L "$uzustack_dir" ] && return 0
+
+  mkdir -p "$(dirname "$migrated_dir")"
+  if [ -e "$migrated_dir" ] && [ "$migrated_dir" != "$uzustack_dir" ]; then
+    echo "uzustack setup failed: direct Codex install detected at $uzustack_dir" >&2
+    echo "A migrated repo already exists at $migrated_dir; move one of them aside and rerun setup." >&2
+    exit 1
+  fi
+
+  log "Migrating direct Codex install to $migrated_dir to avoid duplicate skill discovery..."
+  mv "$uzustack_dir" "$migrated_dir"
+  SOURCE_UZUSTACK_DIR="$migrated_dir"
+  INSTALL_UZUSTACK_DIR="$migrated_dir"
+  INSTALL_SKILLS_DIR="$(dirname "$INSTALL_UZUSTACK_DIR")"
+  BROWSE_BIN="$SOURCE_UZUSTACK_DIR/browse/dist/browse"
+}
+
+if [ "$INSTALL_CODEX" -eq 1 ]; then
+  migrate_direct_codex_install "$SOURCE_UZUSTACK_DIR" "$CODEX_UZUSTACK"
+fi
+
+ensure_playwright_browser() {
+  if [ "$IS_WINDOWS" -eq 1 ]; then
+    # On Windows, Bun can't launch Chromium due to broken pipe handling
+    # (oven-sh/bun#4253). Use Node.js to verify Chromium works instead.
+    (
+      cd "$SOURCE_UZUSTACK_DIR"
+      node -e "const { chromium } = require('playwright'); (async () => { const b = await chromium.launch(); await b.close(); })()" 2>/dev/null
+    )
+  else
+    (
+      cd "$SOURCE_UZUSTACK_DIR"
+      bun --eval 'import { chromium } from "playwright"; const browser = await chromium.launch(); await browser.close();'
+    ) >/dev/null 2>&1
+  fi
+}
+
+# 1. Build browse binary if needed (smart rebuild: stale sources, package.json, lock)
+if [ "$HAS_BROWSE" -eq 1 ]; then
+  NEEDS_BUILD=0
+  if [ ! -x "$BROWSE_BIN" ]; then
+    NEEDS_BUILD=1
+  elif [ -n "$(find "$SOURCE_UZUSTACK_DIR/browse/src" -type f -newer "$BROWSE_BIN" -print -quit 2>/dev/null)" ]; then
+    NEEDS_BUILD=1
+  elif [ "$SOURCE_UZUSTACK_DIR/package.json" -nt "$BROWSE_BIN" ]; then
+    NEEDS_BUILD=1
+  elif [ -f "$SOURCE_UZUSTACK_DIR/bun.lock" ] && [ "$SOURCE_UZUSTACK_DIR/bun.lock" -nt "$BROWSE_BIN" ]; then
+    NEEDS_BUILD=1
+  fi
+
+  if [ "$NEEDS_BUILD" -eq 1 ] && _has_bun_script build; then
+    log "Building browse binary..."
+    (
+      cd "$SOURCE_UZUSTACK_DIR"
+      bun install --frozen-lockfile 2>/dev/null || bun install
+      bun run build
+    )
+    # Safety net: write .version if build script didn't (e.g., git not available during build)
+    if [ ! -f "$SOURCE_UZUSTACK_DIR/browse/dist/.version" ]; then
+      git -C "$SOURCE_UZUSTACK_DIR" rev-parse HEAD > "$SOURCE_UZUSTACK_DIR/browse/dist/.version" 2>/dev/null || true
+    fi
+
+    # macOS Apple Silicon: ad-hoc codesign compiled binaries.
+    # Bun's --compile can produce a corrupt or linker-only code signature that
+    # macOS kills with SIGKILL (exit 137). The two-step remove+re-sign is
+    # required because a naive `codesign -s - -f` fails when the existing
+    # signature block is corrupt. This is idempotent and costs <1s.
+    # See: https://github.com/garrytan/gstack/issues/997
+    if [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "arm64" ]; then
+      for _bin in browse/dist/browse browse/dist/find-browse design/dist/design make-pdf/dist/pdf bin/uzustack-global-discover; do
+        _bin_path="$SOURCE_UZUSTACK_DIR/$_bin"
+        [ -f "$_bin_path" ] && [ -x "$_bin_path" ] || continue
+        codesign --remove-signature "$_bin_path" 2>/dev/null || true
+        if ! codesign -s - -f "$_bin_path" 2>/dev/null; then
+          log "warning: codesign failed for $_bin (binary may not run on Apple Silicon)"
+        fi
+      done
+    fi
+
+    # macOS: install coreutils for `gtimeout` (Codex hang protection in /codex + /autoplan).
+    # macOS ships BSD `timeout`-less; Homebrew's coreutils installs GNU timeout as
+    # `gtimeout` to avoid shadowing BSD utilities. The /codex and /autoplan skills
+    # fall back to unwrapped codex invocations when neither is available — this
+    # auto-install upgrades them to hang-protected where possible.
+    # Skip entirely with UZUSTACK_SKIP_COREUTILS=1 (CI, managed machines, offline envs).
+    if [ "$(uname -s)" = "Darwin" ] && [ "${UZUSTACK_SKIP_COREUTILS:-0}" != "1" ]; then
+      if ! command -v gtimeout >/dev/null 2>&1 && ! command -v timeout >/dev/null 2>&1; then
+        if command -v brew >/dev/null 2>&1; then
+          log "Installing coreutils for Codex hang protection (set UZUSTACK_SKIP_COREUTILS=1 to skip)..."
+          brew install coreutils >/dev/null 2>&1 || log "warning: brew install coreutils failed; /codex will run without hang protection"
+        else
+          log "warning: Homebrew not found. /codex will run without hang protection. Install coreutils manually or set UZUSTACK_SKIP_COREUTILS=1."
+        fi
+      fi
+    fi
+  fi
+
+  if [ ! -x "$BROWSE_BIN" ] && _has_bun_script build; then
+    echo "uzustack setup failed: browse binary missing at $BROWSE_BIN" >&2
+    exit 1
+  fi
+fi
+
+# 1b. Generate .agents/ Codex skill docs — always regenerate to prevent stale descriptions.
+# .agents/ is no longer committed — generated at setup time from .tmpl templates.
+# bun run build already does this, but we need it when NEEDS_BUILD=0 (binary is fresh).
+# Always regenerate: generation is fast (<2s) and mtime-based staleness checks are fragile
+# (miss stale files when timestamps match after clone/checkout/upgrade).
+AGENTS_DIR="$SOURCE_UZUSTACK_DIR/.agents/skills"
+NEEDS_AGENTS_GEN=1
+
+if [ "$NEEDS_AGENTS_GEN" -eq 1 ] && [ "${NEEDS_BUILD:-0}" -eq 0 ] && _has_bun_script "gen:skill-docs"; then
+  log "Generating .agents/ skill docs..."
+  (
+    cd "$SOURCE_UZUSTACK_DIR"
+    bun install --frozen-lockfile 2>/dev/null || bun install
+    bun run gen:skill-docs --host codex
+  )
+fi
+
+# 1c. Generate .factory/ Factory Droid skill docs
+if [ "$INSTALL_FACTORY" -eq 1 ] && [ "${NEEDS_BUILD:-0}" -eq 0 ] && _has_bun_script "gen:skill-docs"; then
+  log "Generating .factory/ skill docs..."
+  (
+    cd "$SOURCE_UZUSTACK_DIR"
+    bun install --frozen-lockfile 2>/dev/null || bun install
+    bun run gen:skill-docs --host factory
+  )
+fi
+
+# 1d. Generate .opencode/ OpenCode skill docs
+if [ "$INSTALL_OPENCODE" -eq 1 ] && [ "${NEEDS_BUILD:-0}" -eq 0 ] && _has_bun_script "gen:skill-docs"; then
+  log "Generating .opencode/ skill docs..."
+  (
+    cd "$SOURCE_UZUSTACK_DIR"
+    bun install --frozen-lockfile 2>/dev/null || bun install
+    bun run gen:skill-docs --host opencode
+  )
+fi
+
+# 2. Ensure Playwright's Chromium is available
+if [ "$HAS_BROWSE" -eq 1 ]; then
+  if ! ensure_playwright_browser; then
+    echo "Installing Playwright Chromium..."
+    (
+      cd "$SOURCE_UZUSTACK_DIR"
+      bunx playwright install chromium
+    )
+
+    if [ "$IS_WINDOWS" -eq 1 ]; then
+      # On Windows, Node.js launches Chromium (not Bun — see oven-sh/bun#4253).
+      # Ensure playwright is importable by Node from the uzustack directory.
+      if ! command -v node >/dev/null 2>&1; then
+        echo "uzustack setup failed: Node.js is required on Windows (Bun cannot launch Chromium due to a pipe bug)" >&2
+        echo "  Install Node.js: https://nodejs.org/" >&2
+        exit 1
+      fi
+      echo "Windows detected — verifying Node.js can load Playwright..."
+      (
+        cd "$SOURCE_UZUSTACK_DIR"
+        # Bun's node_modules already has playwright; verify Node can require it
+        node -e "require('playwright')" 2>/dev/null || npm install --no-save playwright
+        # @ngrok/ngrok is externalized in server-node.mjs and resolved at runtime.
+        # Verify the platform-specific native binary is installed so /pair-agent
+        # tunnels don't fail later with a cryptic module-not-found error.
+        node -e "require('@ngrok/ngrok')" 2>/dev/null || npm install --no-save @ngrok/ngrok
+      )
+    fi
+  fi
+
+  if ! ensure_playwright_browser; then
+    if [ "$IS_WINDOWS" -eq 1 ]; then
+      echo "uzustack setup failed: Playwright Chromium could not be launched via Node.js" >&2
+      echo "  This is a known issue with Bun on Windows (oven-sh/bun#4253)." >&2
+      echo "  Ensure Node.js is installed and 'node -e \"require('playwright')\"' works." >&2
+    else
+      echo "uzustack setup failed: Playwright Chromium could not be launched" >&2
+    fi
+    exit 1
+  fi
+fi
+
+# 3. Ensure ~/.uzustack global state directory exists
+mkdir -p "$HOME/.uzustack/projects"
+
+# ─── Helper: link Claude skill subdirectories into a skills parent directory ──
+# Creates real directories (not symlinks) at the top level with a SKILL.md symlink
+# inside. This ensures Claude discovers them as top-level skills, not nested under
+# uzustack/ (which would auto-prefix them as uzustack-*).
+# When SKILL_PREFIX=1, directories are prefixed with "uzustack-".
+# Use --no-prefix to restore flat names.
+link_claude_skill_dirs() {
+  local uzustack_dir="$1"
+  local skills_dir="$2"
+  local linked=()
+  for skill_dir in "$uzustack_dir"/*/; do
+    if [ -f "$skill_dir/SKILL.md" ]; then
+      dir_name="$(basename "$skill_dir")"
+      # Skip node_modules
+      [ "$dir_name" = "node_modules" ] && continue
+      # Use frontmatter name: if present (e.g., run-tests/ with name: test → symlink as "test")
+      skill_name=$(grep -m1 '^name:' "$skill_dir/SKILL.md" 2>/dev/null | sed 's/^name:[[:space:]]*//' | tr -d '[:space:]')
+      [ -z "$skill_name" ] && skill_name="$dir_name"
+      # Apply uzustack- prefix unless --no-prefix or already prefixed
+      if [ "$SKILL_PREFIX" -eq 1 ]; then
+        case "$skill_name" in
+          uzustack-*) link_name="$skill_name" ;;
+          *)        link_name="uzustack-$skill_name" ;;
+        esac
+      else
+        link_name="$skill_name"
+      fi
+      target="$skills_dir/$link_name"
+      # Upgrade old directory symlinks to real directories
+      if [ -L "$target" ]; then
+        rm -f "$target"
+      fi
+      # Create real directory with symlinked SKILL.md (absolute path)
+      # Use mkdir -p unconditionally (idempotent) to avoid TOCTOU race
+      mkdir -p "$target"
+      # Validate target isn't a symlink before creating the link
+      if [ -L "$target/SKILL.md" ]; then rm "$target/SKILL.md"; fi
+      ln -snf "$uzustack_dir/$dir_name/SKILL.md" "$target/SKILL.md"
+      linked+=("$link_name")
+    fi
+  done
+  if [ ${#linked[@]} -gt 0 ]; then
+    echo "  linked skills: ${linked[*]}"
+  fi
+}
+
+# ─── Helper: remove old unprefixed Claude skill entries ───────────────────────
+# Migration: when switching from flat names to uzustack- prefixed names,
+# clean up stale symlinks or directories that point into the uzustack directory.
+cleanup_old_claude_symlinks() {
+  local uzustack_dir="$1"
+  local skills_dir="$2"
+  local removed=()
+  for skill_dir in "$uzustack_dir"/*/; do
+    if [ -f "$skill_dir/SKILL.md" ]; then
+      skill_name="$(basename "$skill_dir")"
+      [ "$skill_name" = "node_modules" ] && continue
+      # Skip already-prefixed dirs (uzustack-upgrade) — no old symlink to clean
+      case "$skill_name" in uzustack-*) continue ;; esac
+      old_target="$skills_dir/$skill_name"
+      # Remove directory symlinks pointing into uzustack/
+      if [ -L "$old_target" ]; then
+        link_dest="$(readlink "$old_target" 2>/dev/null || true)"
+        case "$link_dest" in
+          uzustack/*|*/uzustack/*)
+            rm -f "$old_target"
+            removed+=("$skill_name")
+            ;;
+        esac
+      # Remove real directories with symlinked SKILL.md pointing into uzustack/
+      elif [ -d "$old_target" ] && [ -L "$old_target/SKILL.md" ]; then
+        link_dest="$(readlink "$old_target/SKILL.md" 2>/dev/null || true)"
+        case "$link_dest" in
+          *uzustack*)
+            rm -rf "$old_target"
+            removed+=("$skill_name")
+            ;;
+        esac
+      fi
+    fi
+  done
+  if [ ${#removed[@]} -gt 0 ]; then
+    echo "  cleaned up old entries: ${removed[*]}"
+  fi
+}
+
+# ─── Helper: remove old prefixed Claude skill entries ─────────────────────────
+# Reverse migration: when switching from uzustack- prefixed names to flat names,
+# clean up stale uzustack-* symlinks or directories that point into the uzustack directory.
+cleanup_prefixed_claude_symlinks() {
+  local uzustack_dir="$1"
+  local skills_dir="$2"
+  local removed=()
+  for skill_dir in "$uzustack_dir"/*/; do
+    if [ -f "$skill_dir/SKILL.md" ]; then
+      skill_name="$(basename "$skill_dir")"
+      [ "$skill_name" = "node_modules" ] && continue
+      # Only clean up prefixed entries for dirs that AREN'T already prefixed
+      # (e.g., remove uzustack-qa but NOT uzustack-upgrade which is the real dir name)
+      case "$skill_name" in uzustack-*) continue ;; esac
+      prefixed_target="$skills_dir/uzustack-$skill_name"
+      # Remove directory symlinks pointing into uzustack/
+      if [ -L "$prefixed_target" ]; then
+        link_dest="$(readlink "$prefixed_target" 2>/dev/null || true)"
+        case "$link_dest" in
+          uzustack/*|*/uzustack/*)
+            rm -f "$prefixed_target"
+            removed+=("uzustack-$skill_name")
+            ;;
+        esac
+      # Remove real directories with symlinked SKILL.md pointing into uzustack/
+      elif [ -d "$prefixed_target" ] && [ -L "$prefixed_target/SKILL.md" ]; then
+        link_dest="$(readlink "$prefixed_target/SKILL.md" 2>/dev/null || true)"
+        case "$link_dest" in
+          *uzustack*)
+            rm -rf "$prefixed_target"
+            removed+=("uzustack-$skill_name")
+            ;;
+        esac
+      fi
+    fi
+  done
+  if [ ${#removed[@]} -gt 0 ]; then
+    echo "  cleaned up prefixed entries: ${removed[*]}"
+  fi
+}
+
+# ─── Helper: link generated Codex skills into a skills parent directory ──
+# Installs from .agents/skills/uzustack-* (the generated Codex-format skills)
+# instead of source dirs (which have Claude paths).
+link_codex_skill_dirs() {
+  local uzustack_dir="$1"
+  local skills_dir="$2"
+  local agents_dir="$uzustack_dir/.agents/skills"
+  local linked=()
+
+  if [ ! -d "$agents_dir" ] && _has_bun_script "gen:skill-docs"; then
+    echo "  Generating .agents/ skill docs..."
+    ( cd "$uzustack_dir" && bun run gen:skill-docs --host codex )
+  fi
+
+  if [ ! -d "$agents_dir" ]; then
+    echo "  warning: .agents/skills/ generation failed — run 'bun run gen:skill-docs --host codex' manually" >&2
+    return 1
+  fi
+
+  for skill_dir in "$agents_dir"/uzustack*/; do
+    if [ -f "$skill_dir/SKILL.md" ]; then
+      skill_name="$(basename "$skill_dir")"
+      # Skip the sidecar directory — it contains runtime asset symlinks (bin/,
+      # browse/), not a skill. Linking it would overwrite the root uzustack
+      # symlink that Step 5 already pointed at the repo root.
+      [ "$skill_name" = "uzustack" ] && continue
+      target="$skills_dir/$skill_name"
+      # Create or update symlink
+      if [ -L "$target" ] || [ ! -e "$target" ]; then
+        ln -snf "$skill_dir" "$target"
+        linked+=("$skill_name")
+      fi
+    fi
+  done
+  if [ ${#linked[@]} -gt 0 ]; then
+    echo "  linked skills: ${linked[*]}"
+  fi
+}
+
+# ─── Helper: create .agents/skills/uzustack/ sidecar symlinks ──────────
+# Codex/Gemini/Cursor read skills from .agents/skills/. We link runtime
+# assets (bin/, browse/dist/, review/, qa/, etc.) so skill templates can
+# resolve paths like $SKILL_ROOT/review/design-checklist.md.
+create_agents_sidecar() {
+  local repo_root="$1"
+  local agents_uzustack="$repo_root/.agents/skills/uzustack"
+  mkdir -p "$agents_uzustack"
+
+  # Sidecar directories that skills reference at runtime
+  for asset in bin browse review qa; do
+    local src="$SOURCE_UZUSTACK_DIR/$asset"
+    local dst="$agents_uzustack/$asset"
+    if [ -d "$src" ] || [ -f "$src" ]; then
+      if [ -L "$dst" ] || [ ! -e "$dst" ]; then
+        ln -snf "$src" "$dst"
+      fi
+    fi
+  done
+
+  # Sidecar files that skills reference at runtime
+  for file in ETHOS.md; do
+    local src="$SOURCE_UZUSTACK_DIR/$file"
+    local dst="$agents_uzustack/$file"
+    if [ -f "$src" ]; then
+      if [ -L "$dst" ] || [ ! -e "$dst" ]; then
+        ln -snf "$src" "$dst"
+      fi
+    fi
+  done
+}
+
+# ─── Helper: create a minimal ~/.codex/skills/uzustack runtime root ───────────
+# Codex scans ~/.codex/skills recursively. Exposing the whole repo here causes
+# duplicate skills because source SKILL.md files and generated Codex skills are
+# both discoverable. Keep this directory limited to runtime assets + root skill.
+create_codex_runtime_root() {
+  local uzustack_dir="$1"
+  local codex_uzustack="$2"
+  local agents_dir="$uzustack_dir/.agents/skills"
+
+  if [ -L "$codex_uzustack" ]; then
+    rm -f "$codex_uzustack"
+  elif [ -d "$codex_uzustack" ] && [ "$codex_uzustack" != "$uzustack_dir" ]; then
+    # Old direct installs left a real directory here with stale source skills.
+    # Remove it so we start fresh with only the minimal runtime assets.
+    rm -rf "$codex_uzustack"
+  fi
+
+  mkdir -p "$codex_uzustack" "$codex_uzustack/browse" "$codex_uzustack/uzustack-upgrade" "$codex_uzustack/review"
+
+  if [ -f "$agents_dir/uzustack/SKILL.md" ]; then
+    ln -snf "$agents_dir/uzustack/SKILL.md" "$codex_uzustack/SKILL.md"
+  fi
+  if [ -d "$uzustack_dir/bin" ]; then
+    ln -snf "$uzustack_dir/bin" "$codex_uzustack/bin"
+  fi
+  if [ -d "$uzustack_dir/browse/dist" ]; then
+    ln -snf "$uzustack_dir/browse/dist" "$codex_uzustack/browse/dist"
+  fi
+  if [ -d "$uzustack_dir/browse/bin" ]; then
+    ln -snf "$uzustack_dir/browse/bin" "$codex_uzustack/browse/bin"
+  fi
+  if [ -f "$agents_dir/uzustack-upgrade/SKILL.md" ]; then
+    ln -snf "$agents_dir/uzustack-upgrade/SKILL.md" "$codex_uzustack/uzustack-upgrade/SKILL.md"
+  fi
+  # Review runtime assets (individual files, NOT the whole review/ dir which has SKILL.md)
+  for f in checklist.md design-checklist.md greptile-triage.md TODOS-format.md; do
+    if [ -f "$uzustack_dir/review/$f" ]; then
+      ln -snf "$uzustack_dir/review/$f" "$codex_uzustack/review/$f"
+    fi
+  done
+  # ETHOS.md — referenced by "Search Before Building" in all skill preambles
+  if [ -f "$uzustack_dir/ETHOS.md" ]; then
+    ln -snf "$uzustack_dir/ETHOS.md" "$codex_uzustack/ETHOS.md"
+  fi
+}
+
+create_factory_runtime_root() {
+  local uzustack_dir="$1"
+  local factory_uzustack="$2"
+  local factory_dir="$uzustack_dir/.factory/skills"
+
+  if [ -L "$factory_uzustack" ]; then
+    rm -f "$factory_uzustack"
+  elif [ -d "$factory_uzustack" ] && [ "$factory_uzustack" != "$uzustack_dir" ]; then
+    rm -rf "$factory_uzustack"
+  fi
+
+  mkdir -p "$factory_uzustack" "$factory_uzustack/browse" "$factory_uzustack/uzustack-upgrade" "$factory_uzustack/review"
+
+  if [ -f "$factory_dir/uzustack/SKILL.md" ]; then
+    ln -snf "$factory_dir/uzustack/SKILL.md" "$factory_uzustack/SKILL.md"
+  fi
+  if [ -d "$uzustack_dir/bin" ]; then
+    ln -snf "$uzustack_dir/bin" "$factory_uzustack/bin"
+  fi
+  if [ -d "$uzustack_dir/browse/dist" ]; then
+    ln -snf "$uzustack_dir/browse/dist" "$factory_uzustack/browse/dist"
+  fi
+  if [ -d "$uzustack_dir/browse/bin" ]; then
+    ln -snf "$uzustack_dir/browse/bin" "$factory_uzustack/browse/bin"
+  fi
+  if [ -f "$factory_dir/uzustack-upgrade/SKILL.md" ]; then
+    ln -snf "$factory_dir/uzustack-upgrade/SKILL.md" "$factory_uzustack/uzustack-upgrade/SKILL.md"
+  fi
+  for f in checklist.md design-checklist.md greptile-triage.md TODOS-format.md; do
+    if [ -f "$uzustack_dir/review/$f" ]; then
+      ln -snf "$uzustack_dir/review/$f" "$factory_uzustack/review/$f"
+    fi
+  done
+  if [ -f "$uzustack_dir/ETHOS.md" ]; then
+    ln -snf "$uzustack_dir/ETHOS.md" "$factory_uzustack/ETHOS.md"
+  fi
+}
+
+create_opencode_runtime_root() {
+  local uzustack_dir="$1"
+  local opencode_uzustack="$2"
+  local opencode_dir="$uzustack_dir/.opencode/skills"
+
+  if [ -L "$opencode_uzustack" ]; then
+    rm -f "$opencode_uzustack"
+  elif [ -d "$opencode_uzustack" ] && [ "$opencode_uzustack" != "$uzustack_dir" ]; then
+    rm -rf "$opencode_uzustack"
+  fi
+
+  mkdir -p "$opencode_uzustack" "$opencode_uzustack/browse" "$opencode_uzustack/design" "$opencode_uzustack/uzustack-upgrade" "$opencode_uzustack/review" "$opencode_uzustack/qa" "$opencode_uzustack/plan-devex-review"
+
+  if [ -f "$opencode_dir/uzustack/SKILL.md" ]; then
+    ln -snf "$opencode_dir/uzustack/SKILL.md" "$opencode_uzustack/SKILL.md"
+  fi
+  if [ -d "$uzustack_dir/bin" ]; then
+    ln -snf "$uzustack_dir/bin" "$opencode_uzustack/bin"
+  fi
+  if [ -d "$uzustack_dir/browse/dist" ]; then
+    ln -snf "$uzustack_dir/browse/dist" "$opencode_uzustack/browse/dist"
+  fi
+  if [ -d "$uzustack_dir/browse/bin" ]; then
+    ln -snf "$uzustack_dir/browse/bin" "$opencode_uzustack/browse/bin"
+  fi
+  if [ -d "$uzustack_dir/design/dist" ]; then
+    ln -snf "$uzustack_dir/design/dist" "$opencode_uzustack/design/dist"
+  fi
+  if [ -f "$opencode_dir/uzustack-upgrade/SKILL.md" ]; then
+    ln -snf "$opencode_dir/uzustack-upgrade/SKILL.md" "$opencode_uzustack/uzustack-upgrade/SKILL.md"
+  fi
+  for f in checklist.md design-checklist.md greptile-triage.md TODOS-format.md; do
+    if [ -f "$uzustack_dir/review/$f" ]; then
+      ln -snf "$uzustack_dir/review/$f" "$opencode_uzustack/review/$f"
+    fi
+  done
+  if [ -d "$uzustack_dir/review/specialists" ]; then
+    ln -snf "$uzustack_dir/review/specialists" "$opencode_uzustack/review/specialists"
+  fi
+  if [ -d "$uzustack_dir/qa/templates" ]; then
+    ln -snf "$uzustack_dir/qa/templates" "$opencode_uzustack/qa/templates"
+  fi
+  if [ -d "$uzustack_dir/qa/references" ]; then
+    ln -snf "$uzustack_dir/qa/references" "$opencode_uzustack/qa/references"
+  fi
+  if [ -f "$uzustack_dir/plan-devex-review/dx-hall-of-fame.md" ]; then
+    ln -snf "$uzustack_dir/plan-devex-review/dx-hall-of-fame.md" "$opencode_uzustack/plan-devex-review/dx-hall-of-fame.md"
+  fi
+  if [ -f "$uzustack_dir/ETHOS.md" ]; then
+    ln -snf "$uzustack_dir/ETHOS.md" "$opencode_uzustack/ETHOS.md"
+  fi
+}
+
+link_factory_skill_dirs() {
+  local uzustack_dir="$1"
+  local skills_dir="$2"
+  local factory_dir="$uzustack_dir/.factory/skills"
+  local linked=()
+
+  if [ ! -d "$factory_dir" ] && _has_bun_script "gen:skill-docs"; then
+    echo "  Generating .factory/ skill docs..."
+    ( cd "$uzustack_dir" && bun run gen:skill-docs --host factory )
+  fi
+
+  if [ ! -d "$factory_dir" ]; then
+    echo "  warning: .factory/skills/ generation failed — run 'bun run gen:skill-docs --host factory' manually" >&2
+    return 1
+  fi
+
+  for skill_dir in "$factory_dir"/uzustack*/; do
+    if [ -f "$skill_dir/SKILL.md" ]; then
+      skill_name="$(basename "$skill_dir")"
+      [ "$skill_name" = "uzustack" ] && continue
+      target="$skills_dir/$skill_name"
+      if [ -L "$target" ] || [ ! -e "$target" ]; then
+        ln -snf "$skill_dir" "$target"
+        linked+=("$skill_name")
+      fi
+    fi
+  done
+  if [ ${#linked[@]} -gt 0 ]; then
+    echo "  linked skills: ${linked[*]}"
+  fi
+}
+
+link_opencode_skill_dirs() {
+  local uzustack_dir="$1"
+  local skills_dir="$2"
+  local opencode_dir="$uzustack_dir/.opencode/skills"
+  local linked=()
+
+  if [ ! -d "$opencode_dir" ] && _has_bun_script "gen:skill-docs"; then
+    echo "  Generating .opencode/ skill docs..."
+    ( cd "$uzustack_dir" && bun run gen:skill-docs --host opencode )
+  fi
+
+  if [ ! -d "$opencode_dir" ]; then
+    echo "  warning: .opencode/skills/ generation failed — run 'bun run gen:skill-docs --host opencode' manually" >&2
+    return 1
+  fi
+
+  for skill_dir in "$opencode_dir"/uzustack*/; do
+    if [ -f "$skill_dir/SKILL.md" ]; then
+      skill_name="$(basename "$skill_dir")"
+      [ "$skill_name" = "uzustack" ] && continue
+      target="$skills_dir/$skill_name"
+      if [ -L "$target" ] || [ ! -e "$target" ]; then
+        ln -snf "$skill_dir" "$target"
+        linked+=("$skill_name")
+      fi
+    fi
+  done
+  if [ ${#linked[@]} -gt 0 ]; then
+    echo "  linked skills: ${linked[*]}"
+  fi
+}
+
+# 4. Install for Claude (default)
+SKILLS_BASENAME="$(basename "$INSTALL_SKILLS_DIR")"
+SKILLS_PARENT_BASENAME="$(basename "$(dirname "$INSTALL_SKILLS_DIR")")"
+CODEX_REPO_LOCAL=0
+if [ "$SKILLS_BASENAME" = "skills" ] && [ "$SKILLS_PARENT_BASENAME" = ".agents" ]; then
+  CODEX_REPO_LOCAL=1
+fi
+
+if [ "$INSTALL_CLAUDE" -eq 1 ]; then
+  if [ "$SKILLS_BASENAME" = "skills" ]; then
+    # Clean up stale symlinks from the opposite prefix mode
+    if [ "$SKILL_PREFIX" -eq 1 ]; then
+      cleanup_old_claude_symlinks "$SOURCE_UZUSTACK_DIR" "$INSTALL_SKILLS_DIR"
+    else
+      cleanup_prefixed_claude_symlinks "$SOURCE_UZUSTACK_DIR" "$INSTALL_SKILLS_DIR"
+    fi
+    # Patch name: fields BEFORE creating symlinks so link_claude_skill_dirs
+    # reads the correct (patched) name: values for symlink naming
+    if [ -x "$SOURCE_UZUSTACK_DIR/bin/uzustack-patch-names" ]; then
+      "$SOURCE_UZUSTACK_DIR/bin/uzustack-patch-names" "$SOURCE_UZUSTACK_DIR" "$SKILL_PREFIX"
+    fi
+    link_claude_skill_dirs "$SOURCE_UZUSTACK_DIR" "$INSTALL_SKILLS_DIR"
+    # Self-healing: re-run uzustack-relink to ensure name: fields and directory
+    # names are consistent with the config. This catches cases where an interrupted
+    # setup, stale git state, or gen:skill-docs left name: fields out of sync.
+    UZUSTACK_RELINK="$SOURCE_UZUSTACK_DIR/bin/uzustack-relink"
+    if [ -x "$UZUSTACK_RELINK" ]; then
+      UZUSTACK_SKILLS_DIR="$INSTALL_SKILLS_DIR" UZUSTACK_INSTALL_DIR="$SOURCE_UZUSTACK_DIR" "$UZUSTACK_RELINK" >/dev/null 2>&1 || true
+    fi
+    # Backwards-compat alias: /connect-chrome → /open-uzustack-browser
+    _OGB_LINK="$INSTALL_SKILLS_DIR/connect-chrome"
+    if [ "$SKILL_PREFIX" -eq 1 ]; then
+      _OGB_LINK="$INSTALL_SKILLS_DIR/uzustack-connect-chrome"
+    fi
+    if [ -d "$SOURCE_UZUSTACK_DIR/open-uzustack-browser" ]; then
+      if [ -L "$_OGB_LINK" ] || [ ! -e "$_OGB_LINK" ]; then
+        ln -snf "uzustack/open-uzustack-browser" "$_OGB_LINK"
+      fi
+    fi
+    if [ "$LOCAL_INSTALL" -eq 1 ]; then
+      log "uzustack ready (project-local)."
+      log "  skills: $INSTALL_SKILLS_DIR"
+    else
+      log "uzustack ready (claude)."
+    fi
+    [ "$HAS_BROWSE" -eq 1 ] && log "  browse: $BROWSE_BIN"
+  else
+    # Not inside a skills/ directory — symlink into ~/.claude/skills/ and retry
+    CLAUDE_SKILLS_DIR="$HOME/.claude/skills"
+    CLAUDE_UZUSTACK_LINK="$CLAUDE_SKILLS_DIR/uzustack"
+    mkdir -p "$CLAUDE_SKILLS_DIR"
+    ln -snf "$SOURCE_UZUSTACK_DIR" "$CLAUDE_UZUSTACK_LINK"
+    log "  symlinked $CLAUDE_UZUSTACK_LINK -> $SOURCE_UZUSTACK_DIR"
+    INSTALL_SKILLS_DIR="$CLAUDE_SKILLS_DIR"
+    INSTALL_UZUSTACK_DIR="$CLAUDE_UZUSTACK_LINK"
+    # Clean up stale symlinks from the opposite prefix mode
+    if [ "$SKILL_PREFIX" -eq 1 ]; then
+      cleanup_old_claude_symlinks "$SOURCE_UZUSTACK_DIR" "$INSTALL_SKILLS_DIR"
+    else
+      cleanup_prefixed_claude_symlinks "$SOURCE_UZUSTACK_DIR" "$INSTALL_SKILLS_DIR"
+    fi
+    if [ -x "$SOURCE_UZUSTACK_DIR/bin/uzustack-patch-names" ]; then
+      "$SOURCE_UZUSTACK_DIR/bin/uzustack-patch-names" "$SOURCE_UZUSTACK_DIR" "$SKILL_PREFIX"
+    fi
+    link_claude_skill_dirs "$SOURCE_UZUSTACK_DIR" "$INSTALL_SKILLS_DIR"
+    UZUSTACK_RELINK="$SOURCE_UZUSTACK_DIR/bin/uzustack-relink"
+    if [ -x "$UZUSTACK_RELINK" ]; then
+      UZUSTACK_SKILLS_DIR="$INSTALL_SKILLS_DIR" UZUSTACK_INSTALL_DIR="$SOURCE_UZUSTACK_DIR" "$UZUSTACK_RELINK" >/dev/null 2>&1 || true
+    fi
+    _OGB_LINK="$INSTALL_SKILLS_DIR/connect-chrome"
+    if [ "$SKILL_PREFIX" -eq 1 ]; then
+      _OGB_LINK="$INSTALL_SKILLS_DIR/uzustack-connect-chrome"
+    fi
+    if [ -d "$SOURCE_UZUSTACK_DIR/open-uzustack-browser" ]; then
+      if [ -L "$_OGB_LINK" ] || [ ! -e "$_OGB_LINK" ]; then
+        ln -snf "uzustack/open-uzustack-browser" "$_OGB_LINK"
+      fi
+    fi
+    log "uzustack ready (claude)."
+    [ "$HAS_BROWSE" -eq 1 ] && log "  browse: $BROWSE_BIN"
+  fi
+fi
+
+# 5. Install for Codex
+if [ "$INSTALL_CODEX" -eq 1 ]; then
+  if [ "$CODEX_REPO_LOCAL" -eq 1 ]; then
+    CODEX_SKILLS="$INSTALL_SKILLS_DIR"
+    CODEX_UZUSTACK="$INSTALL_UZUSTACK_DIR"
+  fi
+  mkdir -p "$CODEX_SKILLS"
+
+  # Skip runtime root creation for repo-local installs — the checkout IS the runtime root.
+  # create_codex_runtime_root would create self-referential symlinks (bin → bin, etc.).
+  if [ "$CODEX_REPO_LOCAL" -eq 0 ]; then
+    create_codex_runtime_root "$SOURCE_UZUSTACK_DIR" "$CODEX_UZUSTACK"
+  fi
+  # Install generated Codex-format skills (not Claude source dirs)
+  link_codex_skill_dirs "$SOURCE_UZUSTACK_DIR" "$CODEX_SKILLS"
+
+  log "uzustack ready (codex)."
+  [ "$HAS_BROWSE" -eq 1 ] && log "  browse: $BROWSE_BIN"
+  log "  codex skills: $CODEX_SKILLS"
+fi
+
+# 6. Install for Kiro CLI (copy from .agents/skills, rewrite paths)
+if [ "$INSTALL_KIRO" -eq 1 ]; then
+  KIRO_SKILLS="$HOME/.kiro/skills"
+  AGENTS_DIR="$SOURCE_UZUSTACK_DIR/.agents/skills"
+  mkdir -p "$KIRO_SKILLS"
+
+  # Create uzustack dir with symlinks for runtime assets, copy+sed for SKILL.md
+  KIRO_UZUSTACK="$KIRO_SKILLS/uzustack"
+  # Remove old whole-dir symlink from previous installs
+  [ -L "$KIRO_UZUSTACK" ] && rm -f "$KIRO_UZUSTACK"
+  mkdir -p "$KIRO_UZUSTACK" "$KIRO_UZUSTACK/browse" "$KIRO_UZUSTACK/uzustack-upgrade" "$KIRO_UZUSTACK/review"
+  if [ -d "$SOURCE_UZUSTACK_DIR/bin" ]; then
+    ln -snf "$SOURCE_UZUSTACK_DIR/bin" "$KIRO_UZUSTACK/bin"
+  fi
+  if [ -d "$SOURCE_UZUSTACK_DIR/browse/dist" ]; then
+    ln -snf "$SOURCE_UZUSTACK_DIR/browse/dist" "$KIRO_UZUSTACK/browse/dist"
+  fi
+  if [ -d "$SOURCE_UZUSTACK_DIR/browse/bin" ]; then
+    ln -snf "$SOURCE_UZUSTACK_DIR/browse/bin" "$KIRO_UZUSTACK/browse/bin"
+  fi
+  # ETHOS.md — referenced by "Search Before Building" in all skill preambles
+  if [ -f "$SOURCE_UZUSTACK_DIR/ETHOS.md" ]; then
+    ln -snf "$SOURCE_UZUSTACK_DIR/ETHOS.md" "$KIRO_UZUSTACK/ETHOS.md"
+  fi
+  # uzustack-upgrade skill
+  if [ -f "$AGENTS_DIR/uzustack-upgrade/SKILL.md" ]; then
+    ln -snf "$AGENTS_DIR/uzustack-upgrade/SKILL.md" "$KIRO_UZUSTACK/uzustack-upgrade/SKILL.md"
+  fi
+  # Review runtime assets (individual files, not whole dir)
+  for f in checklist.md design-checklist.md greptile-triage.md TODOS-format.md; do
+    if [ -f "$SOURCE_UZUSTACK_DIR/review/$f" ]; then
+      ln -snf "$SOURCE_UZUSTACK_DIR/review/$f" "$KIRO_UZUSTACK/review/$f"
+    fi
+  done
+
+  # Rewrite root SKILL.md paths for Kiro
+  if [ -f "$SOURCE_UZUSTACK_DIR/SKILL.md" ]; then
+    sed -e "s|~/.claude/skills/uzustack|~/.kiro/skills/uzustack|g" \
+        -e "s|\.claude/skills/uzustack|.kiro/skills/uzustack|g" \
+        -e "s|\.claude/skills|.kiro/skills|g" \
+        "$SOURCE_UZUSTACK_DIR/SKILL.md" > "$KIRO_UZUSTACK/SKILL.md"
+  fi
+
+  if [ ! -d "$AGENTS_DIR" ]; then
+    echo "  warning: no .agents/skills/ directory found — run 'bun run build' first" >&2
+  else
+    for skill_dir in "$AGENTS_DIR"/uzustack*/; do
+      [ -f "$skill_dir/SKILL.md" ] || continue
+      skill_name="$(basename "$skill_dir")"
+      target_dir="$KIRO_SKILLS/$skill_name"
+      mkdir -p "$target_dir"
+      # Generated Codex skills use $HOME/.codex (not ~/), plus $UZUSTACK_ROOT variables.
+      # Rewrite the default UZUSTACK_ROOT value and any remaining literal paths.
+      sed -e 's|\$HOME/.codex/skills/uzustack|$HOME/.kiro/skills/uzustack|g' \
+          -e "s|~/.codex/skills/uzustack|~/.kiro/skills/uzustack|g" \
+          -e "s|~/.claude/skills/uzustack|~/.kiro/skills/uzustack|g" \
+          "$skill_dir/SKILL.md" > "$target_dir/SKILL.md"
+    done
+    echo "uzustack ready (kiro)."
+    [ "$HAS_BROWSE" -eq 1 ] && echo "  browse: $BROWSE_BIN"
+    echo "  kiro skills: $KIRO_SKILLS"
+  fi
+fi
+
+# 6b. Install for Factory Droid
+if [ "$INSTALL_FACTORY" -eq 1 ]; then
+  mkdir -p "$FACTORY_SKILLS"
+  create_factory_runtime_root "$SOURCE_UZUSTACK_DIR" "$FACTORY_UZUSTACK"
+  link_factory_skill_dirs "$SOURCE_UZUSTACK_DIR" "$FACTORY_SKILLS"
+  echo "uzustack ready (factory)."
+  [ "$HAS_BROWSE" -eq 1 ] && echo "  browse: $BROWSE_BIN"
+  echo "  factory skills: $FACTORY_SKILLS"
+fi
+
+# 6c. Install for OpenCode
+if [ "$INSTALL_OPENCODE" -eq 1 ]; then
+  mkdir -p "$OPENCODE_SKILLS"
+  create_opencode_runtime_root "$SOURCE_UZUSTACK_DIR" "$OPENCODE_UZUSTACK"
+  link_opencode_skill_dirs "$SOURCE_UZUSTACK_DIR" "$OPENCODE_SKILLS"
+  echo "uzustack ready (opencode)."
+  [ "$HAS_BROWSE" -eq 1 ] && echo "  browse: $BROWSE_BIN"
+  echo "  opencode skills: $OPENCODE_SKILLS"
+fi
+
+# 7. Create .agents/ sidecar symlinks for the real Codex skill target.
+# The root Codex skill ends up pointing at $SOURCE_UZUSTACK_DIR/.agents/skills/uzustack,
+# so the runtime assets must live there for both global and repo-local installs.
+if [ "$INSTALL_CODEX" -eq 1 ]; then
+  create_agents_sidecar "$SOURCE_UZUSTACK_DIR"
+fi
+
+# 8. Run pending version migrations
+# Migrations handle state fixes that ./setup alone can't cover (stale config,
+# orphaned files, directory structure changes). Each migration is idempotent.
+MIGRATIONS_DIR="$SOURCE_UZUSTACK_DIR/uzustack-upgrade/migrations"
+CURRENT_VERSION=$(cat "$SOURCE_UZUSTACK_DIR/VERSION" 2>/dev/null || echo "unknown")
+LAST_SETUP_VERSION=$(cat "$HOME/.uzustack/.last-setup-version" 2>/dev/null || echo "0.0.0.0")
+if [ -d "$MIGRATIONS_DIR" ] && [ "$CURRENT_VERSION" != "unknown" ] && [ "$LAST_SETUP_VERSION" != "$CURRENT_VERSION" ]; then
+  # Fresh install (no marker file) — skip migrations, just write marker
+  if [ ! -f "$HOME/.uzustack/.last-setup-version" ]; then
+    : # fall through to marker write below
+  else
+    find "$MIGRATIONS_DIR" -maxdepth 1 -name 'v*.sh' -type f 2>/dev/null | sort -V | while IFS= read -r migration; do
+      m_ver="$(basename "$migration" .sh | sed 's/^v//')"
+      # Run if migration is newer than last setup version AND not newer than current version
+      if [ "$(printf '%s\n%s' "$LAST_SETUP_VERSION" "$m_ver" | sort -V | head -1)" = "$LAST_SETUP_VERSION" ] && [ "$LAST_SETUP_VERSION" != "$m_ver" ] \
+         && [ "$(printf '%s\n%s' "$m_ver" "$CURRENT_VERSION" | sort -V | tail -1)" = "$CURRENT_VERSION" ]; then
+        echo "  running migration $m_ver..."
+        bash "$migration" || echo "  warning: migration $m_ver had errors (non-fatal)"
+      fi
+    done
+  fi
+fi
+mkdir -p "$HOME/.uzustack"
+if [ "$CURRENT_VERSION" != "unknown" ]; then
+  echo "$CURRENT_VERSION" > "$HOME/.uzustack/.last-setup-version"
+fi
+
+# 9. First-time welcome + legacy cleanup
+if [ ! -f "$HOME/.uzustack/.welcome-seen" ]; then
+  log "  Welcome! Run /uzustack-upgrade anytime to stay current."
+  touch "$HOME/.uzustack/.welcome-seen"
+fi
+rm -f /tmp/uzustack-latest-version
+
+# 10. Team mode: register/unregister SessionStart hook
+SETTINGS_HOOK="$SOURCE_UZUSTACK_DIR/bin/uzustack-settings-hook"
+HOOK_CMD="$SOURCE_UZUSTACK_DIR/bin/uzustack-session-update"
+
+if [ "$TEAM_MODE" -eq 1 ]; then
+  "$UZUSTACK_CONFIG" set auto_upgrade true 2>/dev/null || true
+  "$UZUSTACK_CONFIG" set team_mode true 2>/dev/null || true
+
+  # Register SessionStart hook in Claude Code settings
+  if [ -x "$SETTINGS_HOOK" ]; then
+    "$SETTINGS_HOOK" add "$HOOK_CMD" 2>/dev/null || true
+  fi
+
+  log ""
+  log "Team mode enabled: uzustack will auto-update at the start of each Claude Code session."
+  log "  Hook: $HOOK_CMD"
+  log "  To disable: ./setup --no-team"
+  log ""
+  log "Bootstrap your repo:"
+  log "  cd <your-repo> && $SOURCE_UZUSTACK_DIR/bin/uzustack-team-init required"
+fi
+
+if [ "$NO_TEAM_MODE" -eq 1 ]; then
+  "$UZUSTACK_CONFIG" set auto_upgrade false 2>/dev/null || true
+  "$UZUSTACK_CONFIG" set team_mode false 2>/dev/null || true
+
+  # Remove SessionStart hook from Claude Code settings
+  if [ -x "$SETTINGS_HOOK" ]; then
+    "$SETTINGS_HOOK" remove "$HOOK_CMD" 2>/dev/null || true
+  fi
+
+  log "Team mode disabled: auto-update hook removed."
 fi


### PR DESCRIPTION
## Summary

- gstack の `./setup`（1011 行）を文字列置換ベースで線形移植し、uzustack の `setup` を 1059 行の完璧複製版に置き換え
- Phase 3 規律「最初に境界を一度集中して決め切る」に従い、未翻訳依存への処理は削除せず構造として残す
- `_has_bun_script` / `HAS_BROWSE` の境界 guard と元 gstack の `[ -x ... ]` / `[ -f ... ]` ガードで、未翻訳依存は自然に no-op になる
- bin 翻訳が step-35〜39 で進むと、該当処理が**自動的に有効化**される（追加開発不要）

## 主要変更

- host 引数解析（claude / codex / kiro / factory / opencode / openclaw / hermes / gbrain / auto）
- skill_prefix の保存と prompt
- `~/.uzustack/projects/$SLUG/` の mkdir + 初期 config 値の書き込み呼び出し点
- bin への symlink（end user 側 `~/.claude/skills/uzustack/bin/`）
- Codex / Factory Droid / OpenCode / Kiro 向け runtime root 作成と SKILL.md パス書き換え
- `bun run gen:skill-docs --host XXX` の呼び出し点（中身は次 step で .tmpl ベース改修）
- team mode の SessionStart hook 登録

## ガード境界（Phase 3 規律「都度判断ゼロ」のため 1 度だけ定義）

- `_has_bun_script <name>`：`bun run <name>` 呼び出しの前に package.json への登録を確認
- `HAS_BROWSE=1`：`browse/` ディレクトリが存在する場合のみ Playwright / codesign / coreutils 系を実行
- 未翻訳 bin への呼び出し（uzustack-patch-names / uzustack-relink / uzustack-settings-hook 等）は元 gstack 由来の `[ -x ... ]` パターンに乗る

## voice 翻案

- 固有名詞（OpenClaw / Hermes / GBrain / Codex / Kiro / Factory Droid）は原文保持
- メッセージ内の `gstack` のみ `uzustack` に機械置換
- 来歴コメント（gstack issue #997、bun issue #4253）は原文保持

## 完了基準（issue #33 より）

- [x] `./setup` 構文 OK（`bash -n` 通過）
- [x] gstack `./setup` の構造が完璧複製されている（4 host 分含む）
- [x] 各 host 向け bun script 呼び出し点が存在し、未登録 script は guard で skip される
- [x] default 動作で他 host が誤って activate されないこと（INSTALL_CLAUDE のみ default で 1）
- [x] `~/.uzustack/projects/$SLUG/` 生成の実走確認 → step-42 で end user 環境を模擬して検証
- [x] bin symlink の実走確認 → step-42 で

## Test plan

- [x] `bash -n setup` で構文チェック通過
- [x] `./setup --host openclaw` / `--host hermes` / `--host gbrain` の informational ブランチが exit 0 で uzustack 表記のメッセージを出す
- [x] `--host XXX` 不正値で exit 1
- [x] step-42 で end user 環境を模擬した完走確認

Closes #33