### PR TITLE
fix: context-save / context-restore で uzustack-slug bin から SLUG / BRANCH を取得するよう統一

### DIFF
--- a/context-restore/SKILL.md
+++ b/context-restore/SKILL.md
@@ -48,8 +48,8 @@ triggers:
 ### Step 1：保存済み context を探す
 
 ```bash
-SLUG=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || basename "$(pwd)")
-CHECKPOINT_DIR="$HOME/.uzustack/projects/$SLUG/checkpoints"
+eval "$(~/.claude/skills/uzustack/bin/uzustack-slug 2>/dev/null)" && mkdir -p ~/.uzustack/projects/$SLUG
+CHECKPOINT_DIR="${UZUSTACK_HOME:-$HOME/.uzustack}/projects/$SLUG/checkpoints"
 if [ ! -d "$CHECKPOINT_DIR" ]; then
   echo "NO_CHECKPOINTS"
 else

--- a/context-restore/SKILL.md.tmpl
+++ b/context-restore/SKILL.md.tmpl
@@ -48,8 +48,8 @@ triggers:
 ### Step 1：保存済み context を探す
 
 ```bash
-SLUG=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || basename "$(pwd)")
-CHECKPOINT_DIR="$HOME/.uzustack/projects/$SLUG/checkpoints"
+eval "$(~/.claude/skills/uzustack/bin/uzustack-slug 2>/dev/null)" && mkdir -p ~/.uzustack/projects/$SLUG
+CHECKPOINT_DIR="${UZUSTACK_HOME:-$HOME/.uzustack}/projects/$SLUG/checkpoints"
 if [ ! -d "$CHECKPOINT_DIR" ]; then
   echo "NO_CHECKPOINTS"
 else

--- a/context-save/SKILL.md
+++ b/context-save/SKILL.md
@@ -49,7 +49,7 @@ triggers:
 ### Step 1：state を集める
 
 ```bash
-SLUG=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || basename "$(pwd)")
+eval "$(~/.claude/skills/uzustack/bin/uzustack-slug 2>/dev/null)" && mkdir -p ~/.uzustack/projects/$SLUG
 ```
 
 現在の作業 state を収集する：
@@ -104,8 +104,8 @@ fi
 パスは bash 側で計算する（LLM プロンプトでは計算しない）。これによりユーザー指定タイトルが後続コマンドに shell metacharacter を注入できないようにする。サニタイズは allowlist 方式：`a-z 0-9 - .` のみ通す。
 
 ```bash
-SLUG=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || basename "$(pwd)")
-CHECKPOINT_DIR="$HOME/.uzustack/projects/$SLUG/checkpoints"
+eval "$(~/.claude/skills/uzustack/bin/uzustack-slug 2>/dev/null)" && mkdir -p ~/.uzustack/projects/$SLUG
+CHECKPOINT_DIR="${UZUSTACK_HOME:-$HOME/.uzustack}/projects/$SLUG/checkpoints"
 mkdir -p "$CHECKPOINT_DIR"
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 # bash 側でタイトルをサニタイズ。raw タイトルを $1 として渡す。
@@ -187,8 +187,8 @@ CONTEXT 保存完了
 ### Step 1：保存済み context を集める
 
 ```bash
-SLUG=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || basename "$(pwd)")
-CHECKPOINT_DIR="$HOME/.uzustack/projects/$SLUG/checkpoints"
+eval "$(~/.claude/skills/uzustack/bin/uzustack-slug 2>/dev/null)" && mkdir -p ~/.uzustack/projects/$SLUG
+CHECKPOINT_DIR="${UZUSTACK_HOME:-$HOME/.uzustack}/projects/$SLUG/checkpoints"
 if [ -d "$CHECKPOINT_DIR" ]; then
   echo "CHECKPOINT_DIR=$CHECKPOINT_DIR"
   # ls -1t ではなく find + sort を使う：ファイル名 YYYYMMDD-HHMMSS prefix が

--- a/context-save/SKILL.md.tmpl
+++ b/context-save/SKILL.md.tmpl
@@ -49,7 +49,7 @@ triggers:
 ### Step 1：state を集める
 
 ```bash
-SLUG=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || basename "$(pwd)")
+eval "$(~/.claude/skills/uzustack/bin/uzustack-slug 2>/dev/null)" && mkdir -p ~/.uzustack/projects/$SLUG
 ```
 
 現在の作業 state を収集する：
@@ -104,8 +104,8 @@ fi
 パスは bash 側で計算する（LLM プロンプトでは計算しない）。これによりユーザー指定タイトルが後続コマンドに shell metacharacter を注入できないようにする。サニタイズは allowlist 方式：`a-z 0-9 - .` のみ通す。
 
 ```bash
-SLUG=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || basename "$(pwd)")
-CHECKPOINT_DIR="$HOME/.uzustack/projects/$SLUG/checkpoints"
+eval "$(~/.claude/skills/uzustack/bin/uzustack-slug 2>/dev/null)" && mkdir -p ~/.uzustack/projects/$SLUG
+CHECKPOINT_DIR="${UZUSTACK_HOME:-$HOME/.uzustack}/projects/$SLUG/checkpoints"
 mkdir -p "$CHECKPOINT_DIR"
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 # bash 側でタイトルをサニタイズ。raw タイトルを $1 として渡す。
@@ -187,8 +187,8 @@ CONTEXT 保存完了
 ### Step 1：保存済み context を集める
 
 ```bash
-SLUG=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || basename "$(pwd)")
-CHECKPOINT_DIR="$HOME/.uzustack/projects/$SLUG/checkpoints"
+eval "$(~/.claude/skills/uzustack/bin/uzustack-slug 2>/dev/null)" && mkdir -p ~/.uzustack/projects/$SLUG
+CHECKPOINT_DIR="${UZUSTACK_HOME:-$HOME/.uzustack}/projects/$SLUG/checkpoints"
 if [ -d "$CHECKPOINT_DIR" ]; then
   echo "CHECKPOINT_DIR=$CHECKPOINT_DIR"
   # ls -1t ではなく find + sort を使う：ファイル名 YYYYMMDD-HHMMSS prefix が


### PR DESCRIPTION
## Summary
- context-save / context-restore で SLUG / BRANCH を `uzustack-slug` bin の eval から取得するよう統一
- checkpoint path に `${UZUSTACK_HOME:-$HOME/.uzustack}` env 上書きを導入
- 4 箇所の path 計算（context-save 3 箇所、context-restore 1 箇所）を同じ idiom に揃える

## Test plan
- [ ] `eval \"\$(uzustack-slug)\"` で SLUG / BRANCH が environment に流れる
- [ ] \`~/.uzustack/projects/\$SLUG/checkpoints/\` が \`mkdir -p\` で作成される
- [ ] \`UZUSTACK_HOME=/tmp/foo\` で env 上書きが効く
- [ ] \`/context-save\` 実行後の checkpoint path が新規約に一致
- [ ] \`/context-restore\` で過去 checkpoint がリストアップされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)