### PR TITLE
feat: gen-skill-docs.ts に placeholder engine と host 機構の骨組みを実装 — Phase 3 step-34

### DIFF
--- a/careful/SKILL.md
+++ b/careful/SKILL.md
@@ -24,8 +24,9 @@ hooks:
         - type: command
           command: "bash $CLAUDE_PROJECT_DIR/.claude/skills/careful/bin/check-careful.sh"
           statusMessage: "危険コマンドをチェック中..."
-sensitive: true
 ---
+<!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
+<!-- Regenerate: bun run gen:skill-docs -->
 
 # /careful — destructive コマンドのガードレール
 

--- a/context-restore/SKILL.md
+++ b/context-restore/SKILL.md
@@ -20,6 +20,8 @@ triggers:
   - context restore
   - context-restore
 ---
+<!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
+<!-- Regenerate: bun run gen:skill-docs -->
 
 # /context-restore — 保存済み context を復元
 

--- a/context-save/SKILL.md
+++ b/context-save/SKILL.md
@@ -22,6 +22,8 @@ triggers:
   - context save
   - context-save
 ---
+<!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
+<!-- Regenerate: bun run gen:skill-docs -->
 
 # /context-save — 作業 context を保存
 

--- a/hosts/claude.ts
+++ b/hosts/claude.ts
@@ -20,7 +20,9 @@ const claude: HostConfig = {
 
   frontmatter: {
     mode: 'denylist',
-    stripFields: ['sensitive', 'voice-triggers'],
+    // voice-triggers field は processVoiceTriggers が常に strip するので
+    // ここには含めない（重複 strip にならないように）
+    stripFields: ['sensitive'],
     descriptionLimit: null,
   },
 

--- a/hosts/claude.ts
+++ b/hosts/claude.ts
@@ -1,0 +1,50 @@
+import type { HostConfig } from '../scripts/host-config';
+
+/**
+ * Claude Code host config (Phase 3 で uzustack が現実に動かす唯一の host).
+ *
+ * runtimeRoot.globalSymlinks は **uzustack の現状に存在する asset のみ** に絞る。
+ * gstack 本家は browse/dist や ETHOS.md を含むが uzustack には無いので入れない。
+ * Phase 4+ で browse 等を取り込んだ時、ここに足す。
+ */
+const claude: HostConfig = {
+  name: 'claude',
+  displayName: 'Claude Code',
+  cliCommand: 'claude',
+  cliAliases: [],
+
+  globalRoot: '.claude/skills/uzustack',
+  localSkillRoot: '.claude/skills/uzustack',
+  hostSubdir: '.claude',
+  usesEnvVars: false,
+
+  frontmatter: {
+    mode: 'denylist',
+    stripFields: ['sensitive', 'voice-triggers'],
+    descriptionLimit: null,
+  },
+
+  generation: {
+    generateMetadata: false,
+  },
+
+  pathRewrites: [],
+  toolRewrites: {},
+  // gbrain は uzustack 側で実体を持たない。Phase 4+ で要否を再検討するまで
+  // resolver は registry に残しつつ Claude では空展開させる。
+  suppressedResolvers: ['GBRAIN_CONTEXT_LOAD', 'GBRAIN_SAVE_RESULTS'],
+
+  runtimeRoot: {
+    globalSymlinks: ['bin'],
+  },
+
+  install: {
+    prefixable: true,
+    linkingStrategy: 'real-dir-symlink',
+  },
+
+  coAuthorTrailer: 'Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>',
+  learningsMode: 'full',
+};
+
+export default claude;

--- a/hosts/index.ts
+++ b/hosts/index.ts
@@ -20,8 +20,8 @@ export const HOST_CONFIG_MAP: Record<string, HostConfig> = Object.fromEntries(
 /** Union type of all host names, derived from configs. */
 export type Host = (typeof ALL_HOST_CONFIGS)[number]['name'];
 
-/** All host names as a string array (for CLI arg validation, etc.). */
-export const ALL_HOST_NAMES: string[] = ALL_HOST_CONFIGS.map(c => c.name);
+/** All host names as a typed array (for CLI arg validation, etc.). */
+export const ALL_HOST_NAMES = ALL_HOST_CONFIGS.map(c => c.name) as Host[];
 
 /** Get a host config by name. Throws if not found. */
 export function getHostConfig(name: string): HostConfig {
@@ -35,11 +35,11 @@ export function getHostConfig(name: string): HostConfig {
 /**
  * Resolve a host name from a CLI argument, handling aliases.
  */
-export function resolveHostArg(arg: string): string {
-  if (HOST_CONFIG_MAP[arg]) return arg;
+export function resolveHostArg(arg: string): Host {
+  if (HOST_CONFIG_MAP[arg]) return arg as Host;
 
   for (const config of ALL_HOST_CONFIGS) {
-    if (config.cliAliases?.includes(arg)) return config.name;
+    if (config.cliAliases?.includes(arg)) return config.name as Host;
   }
 
   throw new Error(`Unknown host '${arg}'. Valid hosts: ${ALL_HOST_NAMES.join(', ')}`);

--- a/hosts/index.ts
+++ b/hosts/index.ts
@@ -1,0 +1,57 @@
+/**
+ * Host config registry.
+ *
+ * Phase 3: claude のみ enabled。
+ * Phase 4+ で他 host を足す時は hosts/<name>.ts を作って
+ * ALL_HOST_CONFIGS に push するだけで通る構造を維持する。
+ */
+
+import type { HostConfig } from '../scripts/host-config';
+import claude from './claude';
+
+/** All registered host configs. Add new hosts here. */
+export const ALL_HOST_CONFIGS: HostConfig[] = [claude];
+
+/** Map from host name to config. */
+export const HOST_CONFIG_MAP: Record<string, HostConfig> = Object.fromEntries(
+  ALL_HOST_CONFIGS.map(c => [c.name, c])
+);
+
+/** Union type of all host names, derived from configs. */
+export type Host = (typeof ALL_HOST_CONFIGS)[number]['name'];
+
+/** All host names as a string array (for CLI arg validation, etc.). */
+export const ALL_HOST_NAMES: string[] = ALL_HOST_CONFIGS.map(c => c.name);
+
+/** Get a host config by name. Throws if not found. */
+export function getHostConfig(name: string): HostConfig {
+  const config = HOST_CONFIG_MAP[name];
+  if (!config) {
+    throw new Error(`Unknown host '${name}'. Valid hosts: ${ALL_HOST_NAMES.join(', ')}`);
+  }
+  return config;
+}
+
+/**
+ * Resolve a host name from a CLI argument, handling aliases.
+ */
+export function resolveHostArg(arg: string): string {
+  if (HOST_CONFIG_MAP[arg]) return arg;
+
+  for (const config of ALL_HOST_CONFIGS) {
+    if (config.cliAliases?.includes(arg)) return config.name;
+  }
+
+  throw new Error(`Unknown host '${arg}'. Valid hosts: ${ALL_HOST_NAMES.join(', ')}`);
+}
+
+/**
+ * Get hosts that are NOT the primary host (Claude).
+ * Phase 3 では空配列。Phase 4+ で他 host を入れた時、generated docs を
+ * 必要とするのはこの集合になる。
+ */
+export function getExternalHosts(): HostConfig[] {
+  return ALL_HOST_CONFIGS.filter(c => c.name !== 'claude');
+}
+
+export { claude };

--- a/investigate/SKILL.md
+++ b/investigate/SKILL.md
@@ -26,6 +26,8 @@ triggers:
   - 根本原因分析
   - このエラーを調査して
 ---
+<!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
+<!-- Regenerate: bun run gen:skill-docs -->
 
 # 体系的デバッグ
 

--- a/retro/SKILL.md
+++ b/retro/SKILL.md
@@ -20,6 +20,8 @@ triggers:
   - 週次振り返り
   - エンジニアリングの振り返り
 ---
+<!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
+<!-- Regenerate: bun run gen:skill-docs -->
 
 # /retro — 週次エンジニアリング振り返り
 

--- a/scripts/discover-skills.ts
+++ b/scripts/discover-skills.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared discovery for SKILL.md and .tmpl files.
+ * Scans root + one level of subdirs, skipping non-skill dirs.
+ *
+ * `_upstream` を SKIP するのが uzustack 固有の事情：
+ * gstack 本家を `_upstream/gstack/` に subtree 取り込みしているので、
+ * root + 1 階層 scan が `_upstream/SKILL.md.tmpl` を見ないようにする。
+ * （nested な _upstream/gstack/<skill>/SKILL.md.tmpl は 2 階層深いので元々 hit しない）
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const SKIP = new Set([
+  'node_modules',
+  '.git',
+  'dist',
+  '_upstream',
+  'bin',
+  'scripts',
+  'hosts',
+]);
+
+function subdirs(root: string): string[] {
+  return fs.readdirSync(root, { withFileTypes: true })
+    .filter(d => d.isDirectory() && !d.name.startsWith('.') && !SKIP.has(d.name))
+    .map(d => d.name);
+}
+
+export function discoverTemplates(root: string): Array<{ tmpl: string; output: string }> {
+  const dirs = ['', ...subdirs(root)];
+  const results: Array<{ tmpl: string; output: string }> = [];
+  for (const dir of dirs) {
+    const rel = dir ? `${dir}/SKILL.md.tmpl` : 'SKILL.md.tmpl';
+    if (fs.existsSync(path.join(root, rel))) {
+      results.push({ tmpl: rel, output: rel.replace(/\.tmpl$/, '') });
+    }
+  }
+  return results;
+}
+
+export function discoverSkillFiles(root: string): string[] {
+  const dirs = ['', ...subdirs(root)];
+  const results: string[] = [];
+  for (const dir of dirs) {
+    const rel = dir ? `${dir}/SKILL.md` : 'SKILL.md';
+    if (fs.existsSync(path.join(root, rel))) {
+      results.push(rel);
+    }
+  }
+  return results;
+}

--- a/scripts/gen-skill-docs.ts
+++ b/scripts/gen-skill-docs.ts
@@ -30,17 +30,15 @@ const DRY_RUN = process.argv.includes('--dry-run');
 const HOST_ARG = process.argv.find(a => a.startsWith('--host'));
 type HostArg = Host | 'all';
 const HOST_ARG_VAL: HostArg = (() => {
-  if (!HOST_ARG) return 'claude' as Host;
+  if (!HOST_ARG) return 'claude';
   const val = HOST_ARG.includes('=') ? HOST_ARG.split('=')[1] : process.argv[process.argv.indexOf(HOST_ARG) + 1];
   if (val === 'all') return 'all';
   try {
-    return resolveHostArg(val) as Host;
+    return resolveHostArg(val);
   } catch {
     throw new Error(`Unknown host: ${val}. Use ${ALL_HOST_NAMES.join(', ')}, or all.`);
   }
 })();
-
-let HOST: Host = HOST_ARG_VAL === 'all' ? ('claude' as Host) : HOST_ARG_VAL;
 
 // ─── Frontmatter Helpers ────────────────────────────────────
 
@@ -111,9 +109,12 @@ function extractVoiceTriggers(content: string): string[] {
  */
 function processVoiceTriggers(content: string): string {
   const triggers = extractVoiceTriggers(content);
-  if (triggers.length === 0) return content;
 
+  // voice-triggers field は常に frontmatter から strip（triggers 0 件でも消す）。
+  // これにより transformFrontmatter 側で重複 strip しなくて済む。
   content = content.replace(/^voice-triggers:\n(?:\s+-\s+"[^"]*"\n?)*/m, '');
+
+  if (triggers.length === 0) return content;
 
   const { description } = extractNameAndDescription(content);
   if (!description) return content;
@@ -144,11 +145,7 @@ function transformFrontmatter(content: string, host: Host): string {
 
   if (fm.mode === 'denylist') {
     for (const field of fm.stripFields || []) {
-      if (field === 'voice-triggers') {
-        content = content.replace(/^voice-triggers:\n(?:\s+-\s+"[^"]*"\n?)*/m, '');
-      } else {
-        content = content.replace(new RegExp(`^${field}:\\s*.*\\n`, 'm'), '');
-      }
+      content = content.replace(new RegExp(`^${field}:\\s*.*\\n`, 'm'), '');
     }
     return content;
   }
@@ -168,7 +165,7 @@ function transformFrontmatter(content: string, host: Host): string {
 
 const GENERATED_HEADER = `<!-- AUTO-GENERATED from {{SOURCE}} — do not edit directly -->\n<!-- Regenerate: bun run gen:skill-docs -->\n`;
 
-function processTemplate(tmplPath: string, host: Host = 'claude' as Host): { outputPath: string; content: string } {
+function processTemplate(tmplPath: string, host: Host): { outputPath: string; content: string } {
   const tmplContent = fs.readFileSync(tmplPath, 'utf-8');
   const relTmplPath = path.relative(ROOT, tmplPath);
   const outputPath = tmplPath.replace(/\.tmpl$/, '');
@@ -197,7 +194,6 @@ function processTemplate(tmplPath: string, host: Host = 'claude' as Host): { out
     interactive,
   };
 
-  // Replace placeholders (supports parameterized: {{NAME:arg1:arg2}})
   const currentHostConfig = getHostConfig(host);
   const suppressed = new Set(currentHostConfig.suppressedResolvers || []);
   let content = tmplContent.replace(/\{\{(\w+(?::[^}]+)?)\}\}/g, (_match, fullKey) => {
@@ -210,19 +206,15 @@ function processTemplate(tmplPath: string, host: Host = 'claude' as Host): { out
     return args.length > 0 ? resolver(ctx, args) : resolver(ctx);
   });
 
-  // Fail-loud on any remaining unresolved placeholders
+  // 奇形 placeholder（resolver loop で hit しなかった残存）の defense-in-depth
   const remaining = content.match(/\{\{(\w+(?::[^}]+)?)\}\}/g);
   if (remaining) {
     throw new Error(`Unresolved placeholders in ${relTmplPath}: ${remaining.join(', ')}`);
   }
 
-  // Voice trigger preprocessing (fold into description, strip field)
   content = processVoiceTriggers(content);
-
-  // Frontmatter transformation (Claude denylist mode in Phase 3)
   content = transformFrontmatter(content, host);
 
-  // Prepend generated header (after frontmatter)
   const header = GENERATED_HEADER.replace('{{SOURCE}}', path.basename(tmplPath));
   const fmEnd = content.indexOf('---', content.indexOf('---') + 3);
   if (fmEnd !== -1) {
@@ -241,21 +233,19 @@ function findTemplates(): string[] {
   return discoverTemplates(ROOT).map(t => path.join(ROOT, t.tmpl));
 }
 
-const ALL_HOSTS: Host[] = ALL_HOST_NAMES as Host[];
-const hostsToRun: Host[] = HOST_ARG_VAL === 'all' ? ALL_HOSTS : [HOST];
+const hostsToRun: Host[] = HOST_ARG_VAL === 'all' ? ALL_HOST_NAMES : [HOST_ARG_VAL];
 
-// Token ceiling: warn if any generated SKILL.md exceeds ~40K tokens (160KB).
-// Modern flagship models have 200K-1M context windows so 40K is 4-20% of window.
-// This ceiling catches runaway preamble/resolver growth, not a hard gate.
+// 160KB ≒ 40K tokens; runaway preamble/resolver growth の警戒線（hard gate ではない）。
 const TOKEN_CEILING_BYTES = 160_000;
 let hasChanges = false;
 const tokenBudget: Array<{ skill: string; lines: number; tokens: number }> = [];
 
+const tmplPaths = findTemplates();
+
 for (const currentHost of hostsToRun) {
-  HOST = currentHost;
   const currentHostConfig = getHostConfig(currentHost);
 
-  for (const tmplPath of findTemplates()) {
+  for (const tmplPath of tmplPaths) {
     const dir = path.basename(path.dirname(tmplPath));
 
     if (currentHostConfig.generation.includeSkills?.length) {

--- a/scripts/gen-skill-docs.ts
+++ b/scripts/gen-skill-docs.ts
@@ -1,38 +1,314 @@
 #!/usr/bin/env bun
 /**
- * Generate SKILL.md from each <skill>/SKILL.md.tmpl at the repo top.
- * `.tmpl` is the source of truth; type 1/3 lives in its frontmatter `type:`.
+ * Generate SKILL.md files from .tmpl templates.
+ *
+ * Pipeline:
+ *   read .tmpl → find {{PLACEHOLDERS}} → resolve from registry → format → write .md
+ *
+ * Phase 3 status:
+ *   - Claude のみ enabled (hosts/index.ts の ALL_HOST_CONFIGS で他 host を未登録)
+ *   - resolver は空 stub (resolvers/index.ts 参照、Phase 4+ で本体に置換)
+ *   - frontmatter は denylist mode のみ実装、allowlist は Phase 4+ で fail-loud
+ *
+ * Supports --dry-run: regenerate to memory, exit 1 if different from committed file.
+ * Used by .github/workflows/skill-docs.yml の check-freshness job.
  */
 
-import fs from 'node:fs';
-import path from 'node:path';
+import * as fs from 'fs';
+import * as path from 'path';
+import { discoverTemplates } from './discover-skills';
+import { RESOLVERS } from './resolvers/index';
+import type { Host, TemplateContext } from './resolvers/types';
+import { HOST_PATHS } from './resolvers/types';
+import { ALL_HOST_NAMES, resolveHostArg, getHostConfig } from '../hosts/index';
 
 const ROOT = path.resolve(import.meta.dir, '..');
-// Non-dotfile dirs that aren't skills. Dotfiles are filtered separately below.
-const EXCLUDE = new Set(['_upstream', 'scripts', 'bin', 'node_modules', 'dist', 'build']);
+const DRY_RUN = process.argv.includes('--dry-run');
 
-const candidates = fs.readdirSync(ROOT, { withFileTypes: true })
-  .filter(e => e.isDirectory() && !e.name.startsWith('.') && !EXCLUDE.has(e.name));
+// ─── Host Detection (config-driven) ─────────────────────────
 
-const errors: string[] = [];
-let generated = 0;
+const HOST_ARG = process.argv.find(a => a.startsWith('--host'));
+type HostArg = Host | 'all';
+const HOST_ARG_VAL: HostArg = (() => {
+  if (!HOST_ARG) return 'claude' as Host;
+  const val = HOST_ARG.includes('=') ? HOST_ARG.split('=')[1] : process.argv[process.argv.indexOf(HOST_ARG) + 1];
+  if (val === 'all') return 'all';
+  try {
+    return resolveHostArg(val) as Host;
+  } catch {
+    throw new Error(`Unknown host: ${val}. Use ${ALL_HOST_NAMES.join(', ')}, or all.`);
+  }
+})();
 
-for (const dir of candidates) {
-  const skillPath = path.join(ROOT, dir.name);
-  const tmplPath = path.join(skillPath, 'SKILL.md.tmpl');
-  const outPath = path.join(skillPath, 'SKILL.md');
+let HOST: Host = HOST_ARG_VAL === 'all' ? ('claude' as Host) : HOST_ARG_VAL;
 
-  if (!fs.existsSync(tmplPath)) {
-    if (fs.existsSync(outPath)) {
-      errors.push(`${dir.name}/ has SKILL.md but no SKILL.md.tmpl (.tmpl is the source of truth)`);
+// ─── Frontmatter Helpers ────────────────────────────────────
+
+function extractNameAndDescription(content: string): { name: string; description: string } {
+  const fmStart = content.indexOf('---\n');
+  if (fmStart !== 0) return { name: '', description: '' };
+  const fmEnd = content.indexOf('\n---', fmStart + 4);
+  if (fmEnd === -1) return { name: '', description: '' };
+
+  const frontmatter = content.slice(fmStart + 4, fmEnd);
+  const nameMatch = frontmatter.match(/^name:\s*(.+)$/m);
+  const name = nameMatch ? nameMatch[1].trim() : '';
+
+  let description = '';
+  const lines = frontmatter.split('\n');
+  let inDescription = false;
+  const descLines: string[] = [];
+  for (const line of lines) {
+    if (line.match(/^description:\s*\|?\s*$/)) {
+      inDescription = true;
+      continue;
     }
-    continue;
+    if (line.match(/^description:\s*\S/)) {
+      description = line.replace(/^description:\s*/, '').trim();
+      break;
+    }
+    if (inDescription) {
+      if (line === '' || line.match(/^\s/)) {
+        descLines.push(line.replace(/^  /, ''));
+      } else {
+        break;
+      }
+    }
+  }
+  if (descLines.length > 0) {
+    description = descLines.join('\n').trim();
   }
 
-  fs.copyFileSync(tmplPath, outPath);
-  generated++;
+  return { name, description };
 }
 
-console.log(`[gen-skill-docs] generated=${generated} errors=${errors.length}`);
-for (const err of errors) console.error(`  - ${err}`);
-process.exit(errors.length > 0 ? 1 : 0);
+// ─── Voice Trigger Processing ───────────────────────────────
+
+function extractVoiceTriggers(content: string): string[] {
+  const fmStart = content.indexOf('---\n');
+  if (fmStart !== 0) return [];
+  const fmEnd = content.indexOf('\n---', fmStart + 4);
+  if (fmEnd === -1) return [];
+  const frontmatter = content.slice(fmStart + 4, fmEnd);
+
+  const triggers: string[] = [];
+  let inVoice = false;
+  for (const line of frontmatter.split('\n')) {
+    if (/^voice-triggers:/.test(line)) { inVoice = true; continue; }
+    if (inVoice) {
+      const m = line.match(/^\s+-\s+"(.+)"$/);
+      if (m) triggers.push(m[1]);
+      else if (!/^\s/.test(line)) break;
+    }
+  }
+  return triggers;
+}
+
+/**
+ * Fold voice-triggers YAML field into description, then strip the field
+ * from frontmatter. Must run BEFORE transformFrontmatter so all hosts see
+ * the updated description.
+ */
+function processVoiceTriggers(content: string): string {
+  const triggers = extractVoiceTriggers(content);
+  if (triggers.length === 0) return content;
+
+  content = content.replace(/^voice-triggers:\n(?:\s+-\s+"[^"]*"\n?)*/m, '');
+
+  const { description } = extractNameAndDescription(content);
+  if (!description) return content;
+
+  const voiceLine = `Voice triggers (speech-to-text aliases): ${triggers.map(t => `"${t}"`).join(', ')}.`;
+  const newDescription = description + '\n' + voiceLine;
+
+  const oldIndented = description.split('\n').map(l => `  ${l}`).join('\n');
+  const newIndented = newDescription.split('\n').map(l => `  ${l}`).join('\n');
+  content = content.replace(oldIndented, newIndented);
+
+  return content;
+}
+
+export { extractVoiceTriggers, processVoiceTriggers };
+
+// ─── Frontmatter Transformation ─────────────────────────────
+
+/**
+ * Transform frontmatter for the target host.
+ *
+ * Phase 3: denylist mode のみ実装。allowlist は Phase 4+ で外部 host を
+ * enable する時に追加（gstack 本家の実装を voice 翻案して移植する）。
+ */
+function transformFrontmatter(content: string, host: Host): string {
+  const hostConfig = getHostConfig(host);
+  const fm = hostConfig.frontmatter;
+
+  if (fm.mode === 'denylist') {
+    for (const field of fm.stripFields || []) {
+      if (field === 'voice-triggers') {
+        content = content.replace(/^voice-triggers:\n(?:\s+-\s+"[^"]*"\n?)*/m, '');
+      } else {
+        content = content.replace(new RegExp(`^${field}:\\s*.*\\n`, 'm'), '');
+      }
+    }
+    return content;
+  }
+
+  if (fm.mode === 'allowlist') {
+    throw new Error(
+      `frontmatter.mode='allowlist' is not implemented yet (Phase 4+). ` +
+      `Host: ${hostConfig.name}. ` +
+      `Port the allowlist branch from _upstream/gstack/scripts/gen-skill-docs.ts when enabling external hosts.`
+    );
+  }
+
+  throw new Error(`Unknown frontmatter.mode: ${fm.mode}`);
+}
+
+// ─── Template Processing ────────────────────────────────────
+
+const GENERATED_HEADER = `<!-- AUTO-GENERATED from {{SOURCE}} — do not edit directly -->\n<!-- Regenerate: bun run gen:skill-docs -->\n`;
+
+function processTemplate(tmplPath: string, host: Host = 'claude' as Host): { outputPath: string; content: string } {
+  const tmplContent = fs.readFileSync(tmplPath, 'utf-8');
+  const relTmplPath = path.relative(ROOT, tmplPath);
+  const outputPath = tmplPath.replace(/\.tmpl$/, '');
+
+  const { name: extractedName } = extractNameAndDescription(tmplContent);
+  const skillName = extractedName || path.basename(path.dirname(tmplPath));
+
+  const benefitsMatch = tmplContent.match(/^benefits-from:\s*\[([^\]]*)\]/m);
+  const benefitsFrom = benefitsMatch
+    ? benefitsMatch[1].split(',').map(s => s.trim()).filter(Boolean)
+    : undefined;
+
+  const tierMatch = tmplContent.match(/^preamble-tier:\s*(\d+)$/m);
+  const preambleTier = tierMatch ? parseInt(tierMatch[1], 10) : undefined;
+
+  const interactiveMatch = tmplContent.match(/^interactive:\s*(true|false)\s*$/m);
+  const interactive = interactiveMatch ? interactiveMatch[1] === 'true' : undefined;
+
+  const ctx: TemplateContext = {
+    skillName,
+    tmplPath,
+    benefitsFrom,
+    host,
+    paths: HOST_PATHS[host],
+    preambleTier,
+    interactive,
+  };
+
+  // Replace placeholders (supports parameterized: {{NAME:arg1:arg2}})
+  const currentHostConfig = getHostConfig(host);
+  const suppressed = new Set(currentHostConfig.suppressedResolvers || []);
+  let content = tmplContent.replace(/\{\{(\w+(?::[^}]+)?)\}\}/g, (_match, fullKey) => {
+    const parts = fullKey.split(':');
+    const resolverName = parts[0];
+    const args = parts.slice(1);
+    if (suppressed.has(resolverName)) return '';
+    const resolver = RESOLVERS[resolverName];
+    if (!resolver) throw new Error(`Unknown placeholder {{${resolverName}}} in ${relTmplPath}`);
+    return args.length > 0 ? resolver(ctx, args) : resolver(ctx);
+  });
+
+  // Fail-loud on any remaining unresolved placeholders
+  const remaining = content.match(/\{\{(\w+(?::[^}]+)?)\}\}/g);
+  if (remaining) {
+    throw new Error(`Unresolved placeholders in ${relTmplPath}: ${remaining.join(', ')}`);
+  }
+
+  // Voice trigger preprocessing (fold into description, strip field)
+  content = processVoiceTriggers(content);
+
+  // Frontmatter transformation (Claude denylist mode in Phase 3)
+  content = transformFrontmatter(content, host);
+
+  // Prepend generated header (after frontmatter)
+  const header = GENERATED_HEADER.replace('{{SOURCE}}', path.basename(tmplPath));
+  const fmEnd = content.indexOf('---', content.indexOf('---') + 3);
+  if (fmEnd !== -1) {
+    const insertAt = content.indexOf('\n', fmEnd) + 1;
+    content = content.slice(0, insertAt) + header + content.slice(insertAt);
+  } else {
+    content = header + content;
+  }
+
+  return { outputPath, content };
+}
+
+// ─── Main ───────────────────────────────────────────────────
+
+function findTemplates(): string[] {
+  return discoverTemplates(ROOT).map(t => path.join(ROOT, t.tmpl));
+}
+
+const ALL_HOSTS: Host[] = ALL_HOST_NAMES as Host[];
+const hostsToRun: Host[] = HOST_ARG_VAL === 'all' ? ALL_HOSTS : [HOST];
+
+// Token ceiling: warn if any generated SKILL.md exceeds ~40K tokens (160KB).
+// Modern flagship models have 200K-1M context windows so 40K is 4-20% of window.
+// This ceiling catches runaway preamble/resolver growth, not a hard gate.
+const TOKEN_CEILING_BYTES = 160_000;
+let hasChanges = false;
+const tokenBudget: Array<{ skill: string; lines: number; tokens: number }> = [];
+
+for (const currentHost of hostsToRun) {
+  HOST = currentHost;
+  const currentHostConfig = getHostConfig(currentHost);
+
+  for (const tmplPath of findTemplates()) {
+    const dir = path.basename(path.dirname(tmplPath));
+
+    if (currentHostConfig.generation.includeSkills?.length) {
+      if (!currentHostConfig.generation.includeSkills.includes(dir)) continue;
+    }
+    if (currentHostConfig.generation.skipSkills?.length) {
+      if (currentHostConfig.generation.skipSkills.includes(dir)) continue;
+    }
+
+    const { outputPath, content } = processTemplate(tmplPath, currentHost);
+    const relOutput = path.relative(ROOT, outputPath);
+
+    if (DRY_RUN) {
+      const existing = fs.existsSync(outputPath) ? fs.readFileSync(outputPath, 'utf-8') : '';
+      if (existing !== content) {
+        console.log(`STALE: ${relOutput}`);
+        hasChanges = true;
+      } else {
+        console.log(`FRESH: ${relOutput}`);
+      }
+    } else {
+      fs.writeFileSync(outputPath, content);
+      console.log(`GENERATED: ${relOutput}`);
+    }
+
+    const lines = content.split('\n').length;
+    const tokens = Math.round(content.length / 4);
+    tokenBudget.push({ skill: relOutput, lines, tokens });
+
+    if (content.length > TOKEN_CEILING_BYTES) {
+      console.warn(`⚠️  TOKEN CEILING: ${relOutput} is ${content.length} bytes (~${tokens} tokens), exceeds ${TOKEN_CEILING_BYTES} byte ceiling (~40K tokens)`);
+    }
+  }
+}
+
+if (DRY_RUN && hasChanges) {
+  console.error(`\nGenerated SKILL.md files are stale. Run: bun run gen:skill-docs`);
+  process.exit(1);
+}
+
+if (!DRY_RUN && tokenBudget.length > 0) {
+  tokenBudget.sort((a, b) => b.lines - a.lines);
+  const totalLines = tokenBudget.reduce((s, t) => s + t.lines, 0);
+  const totalTokens = tokenBudget.reduce((s, t) => s + t.tokens, 0);
+
+  console.log('');
+  console.log(`Token Budget`);
+  console.log('═'.repeat(60));
+  for (const t of tokenBudget) {
+    const name = t.skill.replace(/\/SKILL\.md$/, '');
+    console.log(`  ${name.padEnd(30)} ${String(t.lines).padStart(5)} lines  ~${String(t.tokens).padStart(6)} tokens`);
+  }
+  console.log('─'.repeat(60));
+  console.log(`  ${'TOTAL'.padEnd(30)} ${String(totalLines).padStart(5)} lines  ~${String(totalTokens).padStart(6)} tokens`);
+  console.log('');
+}

--- a/scripts/host-config.ts
+++ b/scripts/host-config.ts
@@ -1,0 +1,182 @@
+/**
+ * Declarative host config system.
+ *
+ * Each supported host (Claude Code, future Codex / Factory / OpenCode / ...)
+ * is defined as a typed HostConfig object in hosts/*.ts. This module provides
+ * the interface, loader, and validator.
+ *
+ * Architecture:
+ *   hosts/*.ts  →  hosts/index.ts  →  host-config.ts (this file)
+ *        │                                    │
+ *        └── typed configs ──────────────────→ consumed by gen-skill-docs.ts
+ *                                              (Phase 4+ も同じ interface 経由で
+ *                                               setup / skill-check 等に拡張する)
+ *
+ * Phase 3 状態: claude のみ enabled。他 host は hosts/*.ts ファイルを足して
+ * hosts/index.ts の ALL_HOST_CONFIGS に push するだけで通る構造を保つ。
+ */
+
+export interface HostConfig {
+  /** Unique host identifier (e.g., 'claude'). Must match filename in hosts/. */
+  name: string;
+  /** Human-readable name for UI/logs (e.g., 'Claude Code'). */
+  displayName: string;
+  /** Binary name for `command -v` detection (e.g., 'claude'). */
+  cliCommand: string;
+  /** Alternative binary names. */
+  cliAliases?: string[];
+
+  // --- Path Configuration ---
+  /** Global install path relative to $HOME (e.g., '.claude/skills/uzustack'). */
+  globalRoot: string;
+  /** Project-local skill path relative to repo root. */
+  localSkillRoot: string;
+  /** Gitignored directory under repo root for generated docs (e.g., '.claude'). */
+  hostSubdir: string;
+  /** Whether preamble generates $UZUSTACK_ROOT env vars (true for non-Claude hosts). */
+  usesEnvVars: boolean;
+
+  // --- Frontmatter Transformation ---
+  frontmatter: {
+    /** 'allowlist': ONLY keepFields survive. 'denylist': strip listed fields. */
+    mode: 'allowlist' | 'denylist';
+    /** Fields to preserve (allowlist mode only). */
+    keepFields?: string[];
+    /** Fields to remove (denylist mode only). */
+    stripFields?: string[];
+    /** Max chars for description field. null = no limit. */
+    descriptionLimit?: number | null;
+    /** What to do when description exceeds limit. Default: 'error'. */
+    descriptionLimitBehavior?: 'error' | 'truncate' | 'warn';
+    /** Additional frontmatter fields to inject (host-wide). */
+    extraFields?: Record<string, unknown>;
+    /** Rename fields from template (e.g., { 'voice-triggers': 'triggers' }). */
+    renameFields?: Record<string, string>;
+    /** Conditionally add fields based on template frontmatter values. */
+    conditionalFields?: Array<{ if: Record<string, unknown>; add: Record<string, unknown> }>;
+  };
+
+  // --- Generation ---
+  generation: {
+    /** Whether to create sidecar metadata file (e.g., openai.yaml for future Codex host). */
+    generateMetadata: boolean;
+    /** Metadata file format (e.g., 'openai.yaml'). */
+    metadataFormat?: string | null;
+    /** Skill directories to exclude from generation for this host. */
+    skipSkills?: string[];
+    /** Skill directories to include (allowlist). Union logic: include minus skip. */
+    includeSkills?: string[];
+  };
+
+  // --- Content Rewrites ---
+  /** Literal string replacements on generated SKILL.md content. Order matters, replaceAll. */
+  pathRewrites: Array<{ from: string; to: string }>;
+  /** Tool name string replacements on content. */
+  toolRewrites?: Record<string, string>;
+  /** Resolver functions that return empty string for this host. */
+  suppressedResolvers?: string[];
+
+  // --- Runtime Root ---
+  runtimeRoot: {
+    /** Explicit asset list for global install symlinks (no globs). */
+    globalSymlinks: string[];
+    /** Dir → explicit file list for selective file linking. */
+    globalFiles?: Record<string, string[]>;
+  };
+  /** Optional repo-local sidecar config. */
+  sidecar?: {
+    path: string;
+    symlinks: string[];
+  };
+
+  // --- Install Behavior ---
+  install: {
+    /** Whether uzustack-config skill_prefix applies (Claude only). */
+    prefixable: boolean;
+    /** How skills are linked into the host dir. */
+    linkingStrategy: 'real-dir-symlink' | 'symlink-generated';
+  };
+
+  // --- Host-Specific Behavioral Config ---
+  coAuthorTrailer?: string;
+  learningsMode?: 'full' | 'basic';
+  boundaryInstruction?: string;
+  staticFiles?: Record<string, string>;
+  adapter?: string;
+}
+
+// --- Validation ---
+
+const NAME_REGEX = /^[a-z][a-z0-9-]*$/;
+const PATH_REGEX = /^[a-zA-Z0-9_.\/${}~-]+$/;
+const CLI_REGEX = /^[a-z][a-z0-9_-]*$/;
+
+export function validateHostConfig(config: HostConfig): string[] {
+  const errors: string[] = [];
+
+  if (!NAME_REGEX.test(config.name)) {
+    errors.push(`name '${config.name}' must be lowercase alphanumeric with hyphens`);
+  }
+  if (!config.displayName) {
+    errors.push('displayName is required');
+  }
+  if (!CLI_REGEX.test(config.cliCommand)) {
+    errors.push(`cliCommand '${config.cliCommand}' contains invalid characters`);
+  }
+  if (config.cliAliases) {
+    for (const alias of config.cliAliases) {
+      if (!CLI_REGEX.test(alias)) {
+        errors.push(`cliAlias '${alias}' contains invalid characters`);
+      }
+    }
+  }
+  if (!PATH_REGEX.test(config.globalRoot)) {
+    errors.push(`globalRoot '${config.globalRoot}' contains invalid characters`);
+  }
+  if (!PATH_REGEX.test(config.localSkillRoot)) {
+    errors.push(`localSkillRoot '${config.localSkillRoot}' contains invalid characters`);
+  }
+  if (!PATH_REGEX.test(config.hostSubdir)) {
+    errors.push(`hostSubdir '${config.hostSubdir}' contains invalid characters`);
+  }
+  if (!['allowlist', 'denylist'].includes(config.frontmatter.mode)) {
+    errors.push(`frontmatter.mode must be 'allowlist' or 'denylist'`);
+  }
+  if (!['real-dir-symlink', 'symlink-generated'].includes(config.install.linkingStrategy)) {
+    errors.push(`install.linkingStrategy must be 'real-dir-symlink' or 'symlink-generated'`);
+  }
+
+  return errors;
+}
+
+export function validateAllConfigs(configs: HostConfig[]): string[] {
+  const errors: string[] = [];
+
+  for (const config of configs) {
+    const configErrors = validateHostConfig(config);
+    errors.push(...configErrors.map(e => `[${config.name}] ${e}`));
+  }
+
+  const hostSubdirs = new Map<string, string>();
+  const globalRoots = new Map<string, string>();
+  const names = new Map<string, string>();
+
+  for (const config of configs) {
+    if (names.has(config.name)) {
+      errors.push(`Duplicate name '${config.name}' (also used by ${names.get(config.name)})`);
+    }
+    names.set(config.name, config.name);
+
+    if (hostSubdirs.has(config.hostSubdir)) {
+      errors.push(`Duplicate hostSubdir '${config.hostSubdir}' (${config.name} and ${hostSubdirs.get(config.hostSubdir)})`);
+    }
+    hostSubdirs.set(config.hostSubdir, config.name);
+
+    if (globalRoots.has(config.globalRoot)) {
+      errors.push(`Duplicate globalRoot '${config.globalRoot}' (${config.name} and ${globalRoots.get(config.globalRoot)})`);
+    }
+    globalRoots.set(config.globalRoot, config.name);
+  }
+
+  return errors;
+}

--- a/scripts/resolvers/index.ts
+++ b/scripts/resolvers/index.ts
@@ -1,0 +1,26 @@
+/**
+ * RESOLVERS record — maps {{PLACEHOLDER}} names to generator functions.
+ * Each resolver takes a TemplateContext and returns the replacement string.
+ *
+ * Phase 3 では中身は空 stub。Phase 4+ で本体（preamble.ts / learnings.ts /
+ * gbrain.ts に分割するのが gstack 本家の構造）に置き換わる「hand-off 契約」。
+ *
+ * 既知 placeholder は登録 → 空展開で生成成功。
+ * 未登録 placeholder（{{BOGUS}} 等）は gen-skill-docs.ts 側が
+ * "Unresolved placeholders" で fail-loud にする。
+ */
+
+import type { ResolverFn } from './types';
+
+export const RESOLVERS: Record<string, ResolverFn> = {
+  // Phase 4+ で voice + ETHOS preamble を返す予定
+  PREAMBLE: (_ctx, _args) => '',
+  // Phase 4+ で ~/.uzustack/projects/{SLUG}/learnings.jsonl から検索結果を返す予定（Phase 5）
+  LEARNINGS_SEARCH: (_ctx, _args) => '',
+  // Phase 4+ で学習ログ書き込み指示文を返す予定（Phase 5）
+  LEARNINGS_LOG: (_ctx, _args) => '',
+  // Phase 4+ でマシン間記憶同期の load 指示文を返す予定（Phase 5）
+  GBRAIN_CONTEXT_LOAD: (_ctx, _args) => '',
+  // Phase 4+ でマシン間記憶同期の save 指示文を返す予定（Phase 5）
+  GBRAIN_SAVE_RESULTS: (_ctx, _args) => '',
+};

--- a/scripts/resolvers/types.ts
+++ b/scripts/resolvers/types.ts
@@ -1,0 +1,62 @@
+/**
+ * Resolver type definitions.
+ *
+ * Phase 3 では Host = 'claude' のみ enabled、Resolver の中身は空 stub。
+ * Phase 4+ で他 host や resolver 本体を加える時、ここの型はそのまま使える
+ * よう gstack 本家の構造をなぞっている。
+ */
+
+import { ALL_HOST_CONFIGS } from '../../hosts/index';
+
+/**
+ * Host type — derived from host configs in hosts/*.ts.
+ * Adding a new host: create hosts/<name>.ts + add to hosts/index.ts.
+ * Do NOT hardcode host names here.
+ */
+export type Host = (typeof ALL_HOST_CONFIGS)[number]['name'];
+
+export interface HostPaths {
+  skillRoot: string;
+  localSkillRoot: string;
+  binDir: string;
+}
+
+/**
+ * HOST_PATHS — derived from host configs.
+ * Non-Claude hosts (Phase 4+) will use $UZUSTACK_ROOT env vars (set by preamble).
+ */
+function buildHostPaths(): Record<string, HostPaths> {
+  const paths: Record<string, HostPaths> = {};
+  for (const config of ALL_HOST_CONFIGS) {
+    if (config.usesEnvVars) {
+      paths[config.name] = {
+        skillRoot: '$UZUSTACK_ROOT',
+        localSkillRoot: config.localSkillRoot,
+        binDir: '$UZUSTACK_BIN',
+      };
+    } else {
+      const root = `~/${config.globalRoot}`;
+      paths[config.name] = {
+        skillRoot: root,
+        localSkillRoot: config.localSkillRoot,
+        binDir: `${root}/bin`,
+      };
+    }
+  }
+  return paths;
+}
+
+export const HOST_PATHS: Record<string, HostPaths> = buildHostPaths();
+
+export interface TemplateContext {
+  skillName: string;
+  tmplPath: string;
+  benefitsFrom?: string[];
+  host: Host;
+  paths: HostPaths;
+  preambleTier?: number;
+  interactive?: boolean;
+}
+
+/** Resolver function signature. args is populated for parameterized placeholders like {{INVOKE_SKILL:name}}. */
+export type ResolverFn = (ctx: TemplateContext, args?: string[]) => string;


### PR DESCRIPTION
## Summary

Closes #36.

`scripts/gen-skill-docs.ts` を copy-only から rewrite し、placeholder 展開エンジンと host 機構の骨組みを導入。Phase 3 中は resolver を空 stub のまま稼働させ、Phase 4+ で resolver 本体に置換する hand-off 契約として境界を引いている。

## What's in

### placeholder engine

- `{{NAME}}` / `{{NAME:arg1:arg2}}` parse、resolver registry pattern
- 未登録 placeholder で fail-loud（`Unknown placeholder {{X}}`）
- voice trigger 折り込み：`voice-triggers:` YAML を description に fold + frontmatter から strip（処理は `processVoiceTriggers` の独占責任）

### host 機構（Claude only enabled）

- `hosts/claude.ts`、`hosts/index.ts`：HostConfig 型 typed config 系
- `scripts/host-config.ts`：HostConfig interface + validateHostConfig
- Phase 4+ で他 host を増やす時 `hosts/<name>.ts` 追加 → `ALL_HOST_CONFIGS` push の 2 操作だけで通る構造

### resolver registry（5 stub）

- `scripts/resolvers/types.ts`：`TemplateContext`、`Host`、`HostPaths`
- `scripts/resolvers/index.ts`：`PREAMBLE`、`LEARNINGS_SEARCH`、`LEARNINGS_LOG`、`GBRAIN_CONTEXT_LOAD`、`GBRAIN_SAVE_RESULTS` の 5 stub。すべて Phase 3 中は空文字を返す

### その他

- `--dry-run` で freshness check（divergence 時 exit 1）
- token ceiling 警告（160KB ≒ 40K tokens）
- frontmatter denylist mode（`sensitive:` を strip）
- `scripts/discover-skills.ts` の SKIP に `_upstream` / `bin` / `scripts` / `hosts` を追加
- 5 skill の `SKILL.md` を新 generator で再生成（`GENERATED_HEADER` 付与、`careful/SKILL.md` は denylist で `sensitive: true` を strip）

## What's out (Phase 4+ への hand-off)

- resolver 本体（preamble、learnings、gbrain の中身）
- `frontmatter.mode === 'allowlist'` の実装：Phase 4+ で外部 host を enable する時に追加。当面は throw で fail-loud
- 他 host enable（codex、factory、kiro、opencode 等）
- 外部 host 用の path rewrites / tool rewrites / hook safety prose / metadata 生成

## Commit 構成（bisect-friendly な 2 commit）

- `8d13d88` feat: placeholder engine と host 機構の骨組み本実装（+738/−24）
- `5bb9120` refactor: /simplify findings 取り込み（型タイト化、死コード除去、コメント整理。動作変更なし、SKILL.md は zero diff）

## Test plan

- [x] 既存 5 skill の `SKILL.md` 再生成 → 本 PR の diff（GENERATED_HEADER 追加 + `careful` の `sensitive:` strip）以外 zero diff
- [x] `--dry-run` exit 0 on clean tree（FRESH 5/5）
- [x] `{{PREAMBLE}}` を含む `.tmpl` で空展開成功（`Body: <<>> END` を実体生成）
- [x] `{{BOGUS}}` で `Unknown placeholder {{BOGUS}} in <path>` を throw して exit 1（issue 本文の `Unresolved placeholders` は 2 段階目の path 文言だが、1 段階目で先に hit するためメッセージは `Unknown placeholder`）
- [x] /simplify による refactor commit (`5bb9120`) 後も 4 test 全再走 PASS
- [x] `.github/workflows/skill-docs.yml` `check-freshness` job：CI 結果待ち

## Phase 4+ への hand-off note

- resolver の `(_ctx, _args) => ''` を本体実装に置換する時、`_` を外すだけで型互換が維持される
- 5 stub すべてが `scripts/resolvers/index.ts` に inline。本格実装時に sub-module（`preamble.ts` 等）に分割するかは Phase 4+ の判断
- `allowlist` mode の throw メッセージに `_upstream/gstack/scripts/gen-skill-docs.ts` への参照を入れているので、Phase 4+ でその場所を見ればすぐ port できる

### Phase 4+ 着手時の最初の 1 step

`scripts/resolvers/preamble.ts` を `_upstream/gstack/scripts/resolvers/preamble.ts` から voice 翻案してコピー、`scripts/resolvers/index.ts` の `import` 行を追加して空 stub を本体実装に差し替える。voice 翻案ガイドラインは CONTRIBUTING.md「翻訳の置換ルール表 v1」を参照。

resolver コメントの `Phase 5` は learnings / gbrain 系（`LEARNINGS_SEARCH`、`LEARNINGS_LOG`、`GBRAIN_CONTEXT_LOAD`、`GBRAIN_SAVE_RESULTS`）を Phase 5 に送る方針を示す。Phase 4 で他 host enable + preamble 系、Phase 5 で learnings + gbrain、という段階分けを意図している。
