### PR TITLE
Phase 3 step-35: bin 翻訳 — runtime コア群 7 個と voice 規約 v1

### DIFF
--- a/bin/uzustack-config
+++ b/bin/uzustack-config
@@ -14,75 +14,76 @@ set -euo pipefail
 STATE_DIR="${UZUSTACK_HOME:-$HOME/.uzustack}"
 CONFIG_FILE="$STATE_DIR/config.yaml"
 
-# Annotated header for new config files. Written once on first `set`.
-# Default semantics: DEFAULTS table below is the canonical source. Header text
-# is documentation that must stay in sync with DEFAULTS.
-CONFIG_HEADER='# uzustack configuration — edit freely, changes take effect on next skill run.
+# 新規 config file 用の annotated header。最初の `set` 実行時に 1 回だけ書き込む。
+# Default semantics: 下の DEFAULTS table が canonical source。Header text は
+# documentation なので、DEFAULTS と必ず sync を保つこと。
+CONFIG_HEADER='# uzustack configuration — 自由に編集可、変更は次の skill 実行から有効。
 # Docs: https://github.com/uzumaki-inc/uzustack
 #
 # ─── Behavior ────────────────────────────────────────────────────────
-# proactive: true           # Auto-invoke skills when your request matches one.
-#                           # Set to false to only run skills you type explicitly.
+# proactive: true           # リクエスト内容に合致する skill を自動起動。
+#                           # false にすると明示入力した skill のみ実行。
 #
-# routing_declined: false   # Set to true to skip the CLAUDE.md routing injection
-#                           # prompt. Set back to false to be asked again.
+# routing_declined: false   # CLAUDE.md routing injection prompt を skip するなら true。
+#                           # false に戻せば再度尋ねられる。
 #
 # ─── Telemetry ───────────────────────────────────────────────────────
 # telemetry: off            # off | anonymous | community
-#                           #   off       — no data sent, no local analytics (default)
-#                           #   anonymous — counter only, no device ID
-#                           #   community — usage data + stable device ID
+#                           #   off       — データ送信なし、local 分析もなし (default)
+#                           #   anonymous — counter のみ、device ID なし
+#                           #   community — usage data + 安定 device ID
 #
 # ─── Updates ─────────────────────────────────────────────────────────
-# auto_upgrade: false       # true = silently upgrade on session start
-# update_check: true        # false = suppress version check notifications
+# auto_upgrade: false       # true = session 開始時に silently upgrade
+# update_check: true        # false = version check 通知を抑制
 #
 # ─── Skill naming ────────────────────────────────────────────────────
-# skill_prefix: false       # true = namespace skills as /uzustack-qa, /uzustack-ship
-#                           # false = short names /qa, /ship
+# skill_prefix: false       # true = skill を /uzustack-qa, /uzustack-ship に namespace
+#                           # false = 短縮名 /qa, /ship
 #
 # ─── Checkpoint ──────────────────────────────────────────────────────
 # checkpoint_mode: explicit # explicit | continuous
-#                           #   explicit   — commit only when you run /ship or /checkpoint
-#                           #   continuous — auto-commit after each significant change
-#                           #                with WIP: prefix + [uzustack-context] body
+#                           #   explicit   — /ship or /checkpoint 実行時のみ commit
+#                           #   continuous — 重要な変更ごとに auto-commit
+#                           #                WIP: prefix + [uzustack-context] body 付き
 #
-# checkpoint_push: false    # true = push WIP commits to remote as you go
-#                           # false = keep WIP commits local only (default)
-#                           # Pushing can trigger CI/deploy hooks — opt in carefully.
+# checkpoint_push: false    # true = WIP commit を逐次 remote に push
+#                           # false = WIP commit を local のみ保持 (default)
+#                           # push は CI/deploy hook を発火する可能性 — opt in は慎重に。
 #
 # ─── Writing style (V1) ──────────────────────────────────────────────
 # explain_level: default    # default = jargon-glossed, outcome-framed prose
-#                           #           (V1 default — more accessible for everyone)
-#                           # terse   = V0 prose style, no glosses, no outcome-framing layer
-#                           #           (for power users who know the terms)
-#                           # Unknown values default to "default" with a warning.
-#                           # See docs/designs/PLAN_TUNING_V1.md for rationale.
+#                           #           (V1 default — 全員にアクセスしやすい)
+#                           # terse   = V0 prose style、gloss なし、outcome-framing layer なし
+#                           #           (用語に明るい power user 向け)
+#                           # 不明値は warning 付きで "default" に fallback。
+#                           # rationale は docs/designs/PLAN_TUNING_V1.md 参照。
 #
 # ─── GBrain sync (v1.7+) ─────────────────────────────────────────────
 # gbrain_sync_mode: off     # off | artifacts-only | full
-#                           #   off            — no sync (default)
-#                           #   artifacts-only — sync plans/designs/retros/learnings only
-#                           #                    (skip behavioral data: question-log,
-#                           #                    developer-profile, timeline)
-#                           #   full           — sync everything allowlisted
-#                           # Set by the first-run privacy stop-gate. See docs/gbrain-sync.md.
+#                           #   off            — sync しない (default)
+#                           #   artifacts-only — plans/designs/retros/learnings のみ sync
+#                           #                    (behavioral data: question-log /
+#                           #                    developer-profile / timeline は skip)
+#                           #   full           — allowlisted を全 sync
+#                           # 初回 run の privacy stop-gate で設定される。
+#                           # docs/gbrain-sync.md 参照。
 #
 # gbrain_sync_mode_prompted: false
-#                           # Set to true once the privacy gate has asked the user.
-#                           # Flip back to false to be re-prompted.
+#                           # privacy gate がユーザーに尋ね済みなら true。
+#                           # false に戻せば再 prompt される。
 #
 # ─── Advanced ────────────────────────────────────────────────────────
-# codex_reviews: enabled    # disabled = skip Codex adversarial reviews in /ship
-# uzustack_contributor: false # true = file field reports when uzustack misbehaves
-# skip_eng_review: false    # true = skip eng review gate in /ship (not recommended)
+# codex_reviews: enabled    # disabled = /ship 内の Codex adversarial review を skip
+# uzustack_contributor: false # true = uzustack が誤動作した時に field report を送る
+# skip_eng_review: false    # true = /ship 内の eng review gate を skip (非推奨)
 #
 # ─── Workspace-aware ship ────────────────────────────────────────────
-# workspace_root: $HOME/conductor/workspaces  # Where /ship looks for sibling
-#                           # Conductor worktrees when picking a VERSION slot.
-#                           # Set to "null" to disable sibling scanning entirely.
-#                           # Non-Conductor users can point this at any directory
-#                           # that holds parallel worktrees of the same repo.
+# workspace_root: $HOME/conductor/workspaces  # /ship が sibling Conductor
+#                           # worktree を探す場所 (VERSION slot 選択時)。
+#                           # "null" にすれば sibling scan を完全 disable。
+#                           # 非 Conductor ユーザーは、同じ repo の並列 worktree を
+#                           # 持つ任意の directory を指定可能。
 #
 '
 

--- a/bin/uzustack-jsonl-merge
+++ b/bin/uzustack-jsonl-merge
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# uzustack-jsonl-merge — append-only JSONL ファイル用の git merge driver
+#
+# Usage (git が呼び出す。ユーザーが直接呼ぶことは無い):
+#   uzustack-jsonl-merge <base> <ours> <theirs>
+#
+# bin/uzustack-brain-init / bin/uzustack-brain-restore が
+# local git config に登録する:
+#   git config merge.jsonl-append.driver \
+#       "$UZUSTACK_BIN/uzustack-jsonl-merge %O %A %B"
+#
+# Behavior:
+#   base + ours + theirs を結合し、完全一致行を重複排除、
+#   ISO 形式の `ts` フィールドがあればそれで sort、無ければ行の SHA-256 で
+#   決定的な順序にする。結果を <ours> (git merge-driver の規約により %A)
+#   に書き戻す。
+#
+#   2 台のマシンが push と push の間に同じ JSONL ファイルへ追記すると、
+#   ファイル末尾で同一行 conflict が起きる。本 driver はこれを綺麗に解消する:
+#   両方の追記を残し、wall-clock タイムスタンプがあれば順序付け、
+#   無ければ content hash で順序付ける。
+#
+# Exit codes:
+#   0 — merge 成功、結果を <ours> に書き戻し済み
+#   1 — error。git は conflict として扱い、merge を停止する
+
+set -uo pipefail
+
+if [ "$#" -lt 3 ]; then
+  echo "uzustack-jsonl-merge: 引数 3 個 (base ours theirs) が必要、実際は $# 個" >&2
+  exit 1
+fi
+
+BASE="$1"
+OURS="$2"
+THEIRS="$3"
+
+TMP=$(mktemp /tmp/uzustack-jsonl-merge.XXXXXX) || exit 1
+trap 'rm -f "$TMP" 2>/dev/null || true' EXIT
+
+python3 - "$BASE" "$OURS" "$THEIRS" > "$TMP" <<'PYEOF'
+import sys, json, hashlib
+
+paths = sys.argv[1:4]  # base, ours, theirs
+seen = {}  # 行内容 -> sort_key
+
+for path in paths:
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            for line in f:
+                line = line.rstrip('\n')
+                if not line:
+                    continue
+                if line in seen:
+                    continue
+                # ISO ts フィールド優先で sort、無ければ SHA-256 fallback
+                sort_key = None
+                try:
+                    obj = json.loads(line)
+                    ts = obj.get('ts') or obj.get('timestamp')
+                    if isinstance(ts, str):
+                        sort_key = (0, ts)
+                except (json.JSONDecodeError, ValueError, TypeError):
+                    pass
+                if sort_key is None:
+                    h = hashlib.sha256(line.encode('utf-8')).hexdigest()
+                    sort_key = (1, h)
+                seen[line] = sort_key
+    except FileNotFoundError:
+        # base / ours / theirs のいずれかが存在しないのは正常ケース
+        continue
+    except OSError:
+        # permission / IO error は致命。caller には非ゼロ exit で伝える
+        sys.exit(1)
+
+# timestamp 順 (group 0) を先、hash 順 (group 1) を後
+for line, _ in sorted(seen.items(), key=lambda item: item[1]):
+    print(line)
+PYEOF
+
+_PYEXIT=$?
+if [ "$_PYEXIT" != "0" ]; then
+  exit 1
+fi
+
+mv "$TMP" "$OURS" || exit 1
+trap - EXIT
+exit 0

--- a/bin/uzustack-next-version
+++ b/bin/uzustack-next-version
@@ -1,0 +1,477 @@
+#!/usr/bin/env bun
+// uzustack-next-version — host-aware VERSION allocator for /ship.
+//
+// Queries the PR queue (GitHub or GitLab), fetches each open PR's VERSION,
+// scans configurable Conductor sibling worktrees, picks the next free version
+// slot at the requested bump level, and emits the whole picture as JSON.
+//
+// Contract: util NEVER writes files or mutates state. Pure reader + reporter.
+// /ship consumes the JSON and decides what to do.
+//
+// Usage:
+//   uzustack-next-version --base <branch> --bump <major|minor|patch|micro> \
+//     --current-version <X.Y.Z.W> [--workspace-root <path>|null] [--json]
+//
+// Exit codes:
+//   0 — emitted JSON successfully (may include "offline":true or "host":"unknown")
+//   2 — invalid arguments
+//   3 — util bug (unexpected exception)
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+
+type Bump = "major" | "minor" | "patch" | "micro";
+type Version = [number, number, number, number];
+
+type ClaimedPR = {
+  pr: number;
+  branch: string;
+  version: string;
+  url?: string;
+};
+
+type Sibling = {
+  path: string;
+  branch: string;
+  version: string;
+  last_commit_ts: number;
+  has_open_pr: boolean;
+  is_active: boolean;
+};
+
+type Output = {
+  version: string;
+  current_version: string;
+  base_version: string;
+  bump: Bump;
+  host: "github" | "gitlab" | "unknown";
+  offline: boolean;
+  claimed: ClaimedPR[];
+  siblings: Sibling[];
+  active_siblings: Sibling[];
+  reason: string;
+  warnings: string[];
+};
+
+const ACTIVE_SIBLING_MAX_AGE_S = 24 * 60 * 60;
+const GH_API_CONCURRENCY = 10;
+
+function parseVersion(s: string): Version | null {
+  const m = s.trim().match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3]), Number(m[4])];
+}
+
+function fmtVersion(v: Version): string {
+  return v.join(".");
+}
+
+function bumpVersion(v: Version, level: Bump): Version {
+  switch (level) {
+    case "major":
+      return [v[0] + 1, 0, 0, 0];
+    case "minor":
+      return [v[0], v[1] + 1, 0, 0];
+    case "patch":
+      return [v[0], v[1], v[2] + 1, 0];
+    case "micro":
+      return [v[0], v[1], v[2], v[3] + 1];
+  }
+}
+
+function cmpVersion(a: Version, b: Version): number {
+  for (let i = 0; i < 4; i++) {
+    if (a[i] !== b[i]) return a[i] - b[i];
+  }
+  return 0;
+}
+
+// Collision resolution: bump past the highest claimed within the same level.
+// Semantics: if my bump is MINOR and the queue claims 1.7.0.0, I advance to
+// 1.8.0.0 (still a MINOR relative to main). Preserves ship-time intent.
+function pickNextSlot(base: Version, claimed: Version[], level: Bump): { version: Version; reason: string } {
+  let candidate = bumpVersion(base, level);
+  const sortedClaimed = [...claimed].sort(cmpVersion);
+  const highest = sortedClaimed[sortedClaimed.length - 1];
+  if (highest && cmpVersion(highest, base) > 0) {
+    // Queue already advanced past base; bump past the highest claim.
+    const bumpedPastHighest = bumpVersion(highest, level);
+    if (cmpVersion(bumpedPastHighest, candidate) > 0) {
+      return { version: bumpedPastHighest, reason: `bumped past claimed ${fmtVersion(highest)}` };
+    }
+  }
+  return { version: candidate, reason: "no collision; clean bump from base" };
+}
+
+function runCommand(cmd: string, args: string[], timeoutMs = 15000): { ok: boolean; stdout: string; stderr: string } {
+  const r = spawnSync(cmd, args, { encoding: "utf8", timeout: timeoutMs });
+  return {
+    ok: r.status === 0 && !r.error,
+    stdout: r.stdout ?? "",
+    stderr: r.stderr ?? (r.error ? String(r.error) : ""),
+  };
+}
+
+function detectHost(): "github" | "gitlab" | "unknown" {
+  const remote = runCommand("git", ["remote", "get-url", "origin"]);
+  if (remote.ok) {
+    const url = remote.stdout.trim();
+    if (url.includes("github.com")) return "github";
+    if (url.includes("gitlab")) return "gitlab";
+  }
+  const gh = runCommand("gh", ["auth", "status"]);
+  if (gh.ok) return "github";
+  const glab = runCommand("glab", ["auth", "status"]);
+  if (glab.ok) return "gitlab";
+  return "unknown";
+}
+
+function readBaseVersion(base: string, warnings: string[]): string {
+  // git fetch is best-effort; we tolerate failure and fall back to whatever
+  // origin/<base> currently points at.
+  runCommand("git", ["fetch", "origin", base, "--quiet"], 10000);
+  const r = runCommand("git", ["show", `origin/${base}:VERSION`]);
+  if (!r.ok) {
+    warnings.push(`could not read VERSION at origin/${base}; assuming 0.0.0.0`);
+    return "0.0.0.0";
+  }
+  return r.stdout.trim();
+}
+
+async function fetchGithubClaimed(base: string, excludePR: number | null, warnings: string[]): Promise<{ claimed: ClaimedPR[]; offline: boolean }> {
+  const list = runCommand("gh", [
+    "pr",
+    "list",
+    "--state",
+    "open",
+    "--base",
+    base,
+    "--limit",
+    "200",
+    "--json",
+    "number,headRefName,headRepositoryOwner,url,isDraft",
+  ]);
+  if (!list.ok) {
+    warnings.push(`gh pr list failed: ${list.stderr.trim().slice(0, 200)}`);
+    return { claimed: [], offline: true };
+  }
+  let prs: {
+    number: number;
+    headRefName: string;
+    headRepositoryOwner?: { login: string };
+    url: string;
+    isDraft: boolean;
+  }[];
+  try {
+    prs = JSON.parse(list.stdout);
+  } catch (e) {
+    warnings.push(`gh pr list returned invalid JSON`);
+    return { claimed: [], offline: true };
+  }
+  // Determine our repo owner to filter out fork PRs. `gh api contents?ref=<branch>`
+  // resolves to OUR repo regardless of where the PR originated, so fork PRs would
+  // otherwise return our main's VERSION as a phantom claim.
+  const viewer = runCommand("gh", ["repo", "view", "--json", "owner", "-q", ".owner.login"]);
+  const myOwner = viewer.ok ? viewer.stdout.trim() : "";
+  const sameRepoPRs = (myOwner
+    ? prs.filter((p) => (p.headRepositoryOwner?.login ?? "") === myOwner)
+    : prs
+  ).filter((p) => excludePR === null || p.number !== excludePR);
+  // Fetch each PR's VERSION at its head in parallel (bounded concurrency).
+  const results: ClaimedPR[] = [];
+  const queue = [...sameRepoPRs];
+  const workers = Array.from({ length: Math.min(GH_API_CONCURRENCY, sameRepoPRs.length) }, async () => {
+    while (queue.length) {
+      const pr = queue.shift();
+      if (!pr) return;
+      // gh passes branch name via argv, not shell — safe.
+      const content = runCommand("gh", [
+        "api",
+        `repos/{owner}/{repo}/contents/VERSION?ref=${encodeURIComponent(pr.headRefName)}`,
+        "-q",
+        ".content",
+      ]);
+      if (!content.ok) {
+        warnings.push(`PR #${pr.number}: could not fetch VERSION (fork or private)`);
+        continue;
+      }
+      let versionStr: string;
+      try {
+        versionStr = Buffer.from(content.stdout.trim(), "base64").toString("utf8").trim();
+      } catch {
+        warnings.push(`PR #${pr.number}: VERSION is not valid base64`);
+        continue;
+      }
+      if (!parseVersion(versionStr)) {
+        warnings.push(`PR #${pr.number}: VERSION is malformed (${versionStr})`);
+        continue;
+      }
+      results.push({ pr: pr.number, branch: pr.headRefName, version: versionStr, url: pr.url });
+    }
+  });
+  await Promise.all(workers);
+  return { claimed: results, offline: false };
+}
+
+async function fetchGitlabClaimed(base: string, excludePR: number | null, warnings: string[]): Promise<{ claimed: ClaimedPR[]; offline: boolean }> {
+  const list = runCommand("glab", [
+    "mr",
+    "list",
+    "--opened",
+    "--target-branch",
+    base,
+    "--output",
+    "json",
+    "--per-page",
+    "200",
+  ]);
+  if (!list.ok) {
+    warnings.push(`glab mr list failed: ${list.stderr.trim().slice(0, 200)}`);
+    return { claimed: [], offline: true };
+  }
+  let mrs: { iid: number; source_branch: string; web_url: string }[];
+  try {
+    mrs = JSON.parse(list.stdout);
+  } catch {
+    warnings.push(`glab mr list returned invalid JSON`);
+    return { claimed: [], offline: true };
+  }
+  if (excludePR !== null) {
+    mrs = mrs.filter((mr) => mr.iid !== excludePR);
+  }
+  const results: ClaimedPR[] = [];
+  for (const mr of mrs) {
+    const content = runCommand("glab", [
+      "api",
+      `projects/:id/repository/files/VERSION?ref=${encodeURIComponent(mr.source_branch)}`,
+    ]);
+    if (!content.ok) {
+      warnings.push(`MR !${mr.iid}: could not fetch VERSION`);
+      continue;
+    }
+    try {
+      const j = JSON.parse(content.stdout);
+      const versionStr = Buffer.from(j.content, "base64").toString("utf8").trim();
+      if (!parseVersion(versionStr)) {
+        warnings.push(`MR !${mr.iid}: VERSION malformed (${versionStr})`);
+        continue;
+      }
+      results.push({ pr: mr.iid, branch: mr.source_branch, version: versionStr, url: mr.web_url });
+    } catch {
+      warnings.push(`MR !${mr.iid}: unexpected glab api response`);
+    }
+  }
+  return { claimed: results, offline: false };
+}
+
+function resolveWorkspaceRoot(override?: string): string | null {
+  if (override === "null") return null;
+  if (override) return override;
+  const r = runCommand(join(__dirname, "uzustack-config"), ["get", "workspace_root"]);
+  const configured = r.ok ? r.stdout.trim() : "";
+  if (configured === "null") return null;
+  if (configured) return configured;
+  // Default: $HOME/conductor/workspaces/
+  return join(homedir(), "conductor", "workspaces");
+}
+
+function currentRepoSlug(): string {
+  const r = runCommand("git", ["remote", "get-url", "origin"]);
+  if (!r.ok) return "";
+  // Extract "owner/repo" from URL like git@github.com:owner/repo.git
+  const m = r.stdout.trim().match(/[:/]([^/]+\/[^/]+?)(?:\.git)?$/);
+  return m ? m[1] : "";
+}
+
+function scanSiblings(root: string | null, claimed: ClaimedPR[], warnings: string[]): Sibling[] {
+  if (!root || !existsSync(root)) return [];
+  const mySlug = currentRepoSlug();
+  if (!mySlug) {
+    warnings.push("could not determine current repo slug; skipping sibling scan");
+    return [];
+  }
+  const repoName = mySlug.split("/").pop() ?? "";
+  // Conductor layout: <root>/<repo>/<workspace>/
+  const repoDir = join(root, repoName);
+  if (!existsSync(repoDir)) return [];
+  const myAbsPath = resolve(process.cwd());
+  const results: Sibling[] = [];
+  for (const name of readdirSync(repoDir)) {
+    const p = join(repoDir, name);
+    if (resolve(p) === myAbsPath) continue;
+    try {
+      const s = statSync(p);
+      if (!s.isDirectory()) continue;
+    } catch {
+      continue;
+    }
+    if (!existsSync(join(p, ".git")) && !existsSync(join(p, ".git/HEAD"))) continue;
+    const versionFile = join(p, "VERSION");
+    if (!existsSync(versionFile)) continue;
+    let version: string;
+    try {
+      version = readFileSync(versionFile, "utf8").trim();
+      if (!parseVersion(version)) continue;
+    } catch {
+      continue;
+    }
+    const branchR = runCommand("git", ["-C", p, "rev-parse", "--abbrev-ref", "HEAD"]);
+    if (!branchR.ok) continue;
+    const branch = branchR.stdout.trim();
+    const commitTsR = runCommand("git", ["-C", p, "log", "-1", "--format=%ct"]);
+    const last_commit_ts = commitTsR.ok ? Number(commitTsR.stdout.trim()) : 0;
+    const has_open_pr = claimed.some((c) => c.branch === branch);
+    results.push({
+      path: p,
+      branch,
+      version,
+      last_commit_ts,
+      has_open_pr,
+      is_active: false,
+    });
+  }
+  return results;
+}
+
+function markActiveSiblings(siblings: Sibling[], baseVersion: Version): Sibling[] {
+  const now = Math.floor(Date.now() / 1000);
+  return siblings.map((s) => {
+    const v = parseVersion(s.version);
+    const isAhead = v ? cmpVersion(v, baseVersion) > 0 : false;
+    const isFresh = s.last_commit_ts > 0 && now - s.last_commit_ts < ACTIVE_SIBLING_MAX_AGE_S;
+    const is_active = isAhead && isFresh && !s.has_open_pr;
+    return { ...s, is_active };
+  });
+}
+
+function parseArgs(argv: string[]): { base: string; bump: Bump; current: string; workspaceRoot?: string; excludePR: number | null; help: boolean } {
+  let base = "";
+  let bump: Bump | "" = "";
+  let current = "";
+  let workspaceRoot: string | undefined;
+  let excludePR: number | null = null;
+  let help = false;
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--base") base = argv[++i] ?? "";
+    else if (a === "--bump") bump = (argv[++i] ?? "") as Bump;
+    else if (a === "--current-version") current = argv[++i] ?? "";
+    else if (a === "--workspace-root") workspaceRoot = argv[++i];
+    else if (a === "--exclude-pr") {
+      const n = Number(argv[++i]);
+      excludePR = Number.isFinite(n) && n > 0 ? n : null;
+    }
+    else if (a === "-h" || a === "--help") help = true;
+  }
+  if (help) return { base: "", bump: "micro", current: "", excludePR: null, help: true };
+  if (!base) base = "main";
+  if (!bump) {
+    console.error("Error: --bump is required (major|minor|patch|micro)");
+    process.exit(2);
+  }
+  if (!["major", "minor", "patch", "micro"].includes(bump)) {
+    console.error(`Error: --bump must be major|minor|patch|micro (got ${bump})`);
+    process.exit(2);
+  }
+  return { base, bump: bump as Bump, current, workspaceRoot, excludePR, help: false };
+}
+
+// Auto-detect: if --exclude-pr wasn't passed, check whether the current branch
+// already has an open PR and exclude it by default. This prevents the self-
+// reference bug where /ship's own PR inflates the queue on rerun.
+function autoDetectExcludePR(): number | null {
+  const r = runCommand("gh", ["pr", "view", "--json", "number", "-q", ".number"]);
+  if (!r.ok) return null;
+  const n = Number(r.stdout.trim());
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(
+      "Usage: uzustack-next-version --base <branch> --bump <level> --current-version <X.Y.Z.W> [--workspace-root <path|null>]",
+    );
+    process.exit(0);
+  }
+  const warnings: string[] = [];
+  const host = detectHost();
+  const baseVersion = args.current || readBaseVersion(args.base, warnings);
+  const baseParsed = parseVersion(baseVersion);
+  if (!baseParsed) {
+    console.error(`Error: could not parse base version '${baseVersion}'`);
+    process.exit(2);
+  }
+
+  const excludePR = args.excludePR ?? autoDetectExcludePR();
+  if (excludePR !== null && args.excludePR === null) {
+    warnings.push(`auto-excluded PR #${excludePR} (current branch's own PR)`);
+  }
+
+  let claimed: ClaimedPR[] = [];
+  let offline = false;
+  if (host === "github") {
+    ({ claimed, offline } = await fetchGithubClaimed(args.base, excludePR, warnings));
+  } else if (host === "gitlab") {
+    ({ claimed, offline } = await fetchGitlabClaimed(args.base, excludePR, warnings));
+  } else {
+    warnings.push("host unknown; queue-awareness unavailable");
+  }
+
+  // Only count PRs that actually bumped VERSION past base as real "claims".
+  // A PR whose VERSION equals base's VERSION hasn't claimed anything.
+  const realClaims = claimed.filter((c) => {
+    const v = parseVersion(c.version);
+    return v !== null && cmpVersion(v, baseParsed) > 0;
+  });
+  const claimedVersions = realClaims
+    .map((c) => parseVersion(c.version))
+    .filter((v): v is Version => v !== null);
+
+  const { version: picked, reason } = pickNextSlot(baseParsed, claimedVersions, args.bump);
+
+  const workspaceRoot = resolveWorkspaceRoot(args.workspaceRoot);
+  const siblings = markActiveSiblings(scanSiblings(workspaceRoot, claimed, warnings), baseParsed);
+  const activeSiblings = siblings.filter((s) => s.is_active);
+
+  // If an active sibling outranks our pick, bump past it (same bump level).
+  let finalVersion = picked;
+  let finalReason = reason;
+  const activeAhead = activeSiblings
+    .map((s) => parseVersion(s.version))
+    .filter((v): v is Version => v !== null)
+    .filter((v) => cmpVersion(v, finalVersion) >= 0);
+  if (activeAhead.length) {
+    const highest = activeAhead.sort(cmpVersion)[activeAhead.length - 1];
+    finalVersion = bumpVersion(highest, args.bump);
+    finalReason = `bumped past active sibling ${fmtVersion(highest)}`;
+  }
+
+  const out: Output = {
+    version: fmtVersion(finalVersion),
+    current_version: args.current || baseVersion,
+    base_version: baseVersion,
+    bump: args.bump,
+    host,
+    offline,
+    claimed: realClaims,
+    siblings,
+    active_siblings: activeSiblings,
+    reason: finalReason,
+    warnings,
+  };
+  process.stdout.write(JSON.stringify(out, null, 2) + "\n");
+}
+
+// Pure-function exports for testing
+export { parseVersion, fmtVersion, bumpVersion, cmpVersion, pickNextSlot, markActiveSiblings };
+
+// Only run main() when invoked as a script, not when imported by tests.
+if (import.meta.main) {
+  main().catch((e) => {
+    console.error("Unexpected error:", e?.stack ?? e);
+    process.exit(3);
+  });
+}

--- a/bin/uzustack-platform-detect
+++ b/bin/uzustack-platform-detect
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# uzustack-platform-detect: インストール済み AI coding agent と uzustack の status を一覧表示
+# Config-driven: hosts/*.ts の host 定義を host-config-export.ts 経由で読む
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+UZUSTACK_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+printf "%-16s %-10s %-40s %s\n" "Agent" "Version" "Skill Path" "uzustack"
+printf "%-16s %-10s %-40s %s\n" "-----" "-------" "----------" "--------"
+
+for host in $(bun run "$UZUSTACK_DIR/scripts/host-config-export.ts" list 2>/dev/null); do
+  cmd=$(bun run "$UZUSTACK_DIR/scripts/host-config-export.ts" get "$host" cliCommand 2>/dev/null)
+  root=$(bun run "$UZUSTACK_DIR/scripts/host-config-export.ts" get "$host" globalRoot 2>/dev/null)
+  spath="$HOME/$root"
+
+  if command -v "$cmd" >/dev/null 2>&1; then
+    ver=$("$cmd" --version 2>/dev/null | head -1 || echo "unknown")
+    if [ -d "$spath" ] || [ -L "$spath" ]; then
+      status="INSTALLED"
+    else
+      status="NOT INSTALLED"
+    fi
+    printf "%-16s %-10s %-40s %s\n" "$host" "$ver" "$spath" "$status"
+  fi
+done

--- a/bin/uzustack-slug
+++ b/bin/uzustack-slug
@@ -1,25 +1,25 @@
 #!/usr/bin/env bash
-# uzustack-slug — output project slug and sanitized branch name
-# Usage: eval "$(uzustack-slug)"  → sets SLUG and BRANCH variables
-# Or:    uzustack-slug            → prints SLUG=... and BRANCH=... lines
+# uzustack-slug — project slug と sanitized branch name を出力
+# Usage: eval "$(uzustack-slug)"  → SLUG と BRANCH 変数を set
+# Or:    uzustack-slug            → SLUG=... と BRANCH=... の行を print
 #
-# Security: output is sanitized to [a-zA-Z0-9._-] only, preventing
-# shell injection when consumed via source or eval.
+# Security: 出力は [a-zA-Z0-9._-] のみに sanitize、source / eval 経由での
+# shell injection を防ぐ。
 set -euo pipefail
 
 CACHE_DIR="$HOME/.uzustack/slug-cache"
 PROJECT_DIR="$(pwd)"
-# Encode absolute path as cache key: /Users/j/foo → _Users_j_foo
+# absolute path を cache key に encode: /Users/j/foo → _Users_j_foo
 CACHE_KEY=$(printf '%s' "$PROJECT_DIR" | tr '/' '_')
 CACHE_FILE="${CACHE_DIR}/${CACHE_KEY}"
 
-# 1. Try cached slug first (guarantees consistency across sessions)
+# 1. cached slug を最優先 (session 間の一貫性を保証)
 if [[ -f "$CACHE_FILE" ]]; then
   SLUG=$(cat "$CACHE_FILE")
 fi
 
-# 2. If no cache, compute from git remote (separated from pipeline to avoid
-#    pipefail swallowing the error and producing an empty slug)
+# 2. cache 無しなら git remote から計算 (pipeline 分離は pipefail がエラーを
+#    swallow して空 slug を出すのを防ぐため)
 if [[ -z "${SLUG:-}" ]]; then
   REMOTE_URL=$(git remote get-url origin 2>/dev/null) || REMOTE_URL=""
   if [[ -n "$REMOTE_URL" ]]; then
@@ -28,10 +28,10 @@ if [[ -z "${SLUG:-}" ]]; then
   fi
 fi
 
-# 3. Fallback to basename only when there's truly no git remote configured
+# 3. git remote が完全に未設定の時のみ basename に fallback
 SLUG="${SLUG:-$(basename "$PWD" | tr -cd 'a-zA-Z0-9._-')}"
 
-# 4. Cache the slug for future sessions (atomic write, fail silently)
+# 4. 次回 session 用に slug を cache (atomic write、失敗時は silently)
 if [[ -n "$SLUG" ]]; then
   mkdir -p "$CACHE_DIR" 2>/dev/null || true
   CACHE_TMP=$(mktemp "$CACHE_DIR/.slug-XXXXXX" 2>/dev/null) || CACHE_TMP=""

--- a/bin/uzustack-telemetry-log
+++ b/bin/uzustack-telemetry-log
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# uzustack-telemetry-log — telemetry event を local JSONL に追記
+#
+# Data flow:
+#   preamble (start) ──▶ .pending marker
+#   preamble (epilogue) ──▶ uzustack-telemetry-log ──▶ skill-usage.jsonl
+#                                                  └──▶ uzustack-telemetry-sync (bg)
+#
+# Usage:
+#   uzustack-telemetry-log --skill qa --duration 142 --outcome success \
+#     --used-browse true --session-id "12345-1710756600"
+#
+# Env overrides (for testing):
+#   UZUSTACK_HOME  — ~/.uzustack state directory を上書き
+#   UZUSTACK_DIR   — auto-detect された uzustack root を上書き
+#
+# NOTE: set -uo pipefail を使用 (no -e) — telemetry は非ゼロ exit してはいけない
+set -uo pipefail
+
+UZUSTACK_DIR="${UZUSTACK_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+STATE_DIR="${UZUSTACK_HOME:-$HOME/.uzustack}"
+ANALYTICS_DIR="$STATE_DIR/analytics"
+JSONL_FILE="$ANALYTICS_DIR/skill-usage.jsonl"
+PENDING_DIR="$ANALYTICS_DIR"  # .pending-* file はここに置く
+CONFIG_CMD="$UZUSTACK_DIR/bin/uzustack-config"
+VERSION_FILE="$UZUSTACK_DIR/VERSION"
+
+# ─── flag を parse ─────────────────────────────────────────────
+SKILL=""
+DURATION=""
+OUTCOME="unknown"
+USED_BROWSE="false"
+SESSION_ID=""
+ERROR_CLASS=""
+ERROR_MESSAGE=""
+FAILED_STEP=""
+EVENT_TYPE="skill_run"
+SOURCE=""
+# Security-event field (--event-type が attack_attempt の時のみ populate)
+SEC_URL_DOMAIN=""
+SEC_PAYLOAD_HASH=""
+SEC_CONFIDENCE=""
+SEC_LAYER=""
+SEC_VERDICT=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --skill)         SKILL="$2"; shift 2 ;;
+    --duration)      DURATION="$2"; shift 2 ;;
+    --outcome)       OUTCOME="$2"; shift 2 ;;
+    --used-browse)   USED_BROWSE="$2"; shift 2 ;;
+    --session-id)    SESSION_ID="$2"; shift 2 ;;
+    --error-class)   ERROR_CLASS="$2"; shift 2 ;;
+    --error-message) ERROR_MESSAGE="$2"; shift 2 ;;
+    --failed-step)   FAILED_STEP="$2"; shift 2 ;;
+    --event-type)    EVENT_TYPE="$2"; shift 2 ;;
+    --source)        SOURCE="$2"; shift 2 ;;
+    # Security event field — browse/src/security.ts logAttempt() が emit する
+    --url-domain)    SEC_URL_DOMAIN="$2"; shift 2 ;;
+    --payload-hash)  SEC_PAYLOAD_HASH="$2"; shift 2 ;;
+    --confidence)    SEC_CONFIDENCE="$2"; shift 2 ;;
+    --layer)         SEC_LAYER="$2"; shift 2 ;;
+    --verdict)       SEC_VERDICT="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+# Source: flag > env > default 'live'
+SOURCE="${SOURCE:-${UZUSTACK_TELEMETRY_SOURCE:-live}}"
+
+# ─── telemetry tier を読む ─────────────────────────────────────
+TIER="$("$CONFIG_CMD" get telemetry 2>/dev/null || true)"
+TIER="${TIER:-off}"
+
+# tier を validate
+case "$TIER" in
+  off|anonymous|community) ;;
+  *) TIER="off" ;;  # 不正値 → off に fallback
+esac
+
+if [ "$TIER" = "off" ]; then
+  # telemetry off の場合でも、本 session の pending marker は clear する
+  [ -n "$SESSION_ID" ] && rm -f "$PENDING_DIR/.pending-$SESSION_ID" 2>/dev/null || true
+  exit 0
+fi
+
+# ─── 古い .pending marker を finalize ────────────────────────
+# 各 session が独自の .pending-$SESSION_ID file を持つ。並行 session 間の
+# race を避けるため、自分の session 以外の marker は finalize する。
+for PFILE in "$PENDING_DIR"/.pending-*; do
+  [ -f "$PFILE" ] || continue
+  # 自 session の marker は skip (まだ in-flight)
+  PFILE_BASE="$(basename "$PFILE")"
+  PFILE_SID="${PFILE_BASE#.pending-}"
+  [ "$PFILE_SID" = "$SESSION_ID" ] && continue
+
+  PENDING_DATA="$(cat "$PFILE" 2>/dev/null || true)"
+  rm -f "$PFILE" 2>/dev/null || true
+  if [ -n "$PENDING_DATA" ]; then
+    # pending marker から field を抽出 (grep -o + awk)
+    P_SKILL="$(echo "$PENDING_DATA" | grep -o '"skill":"[^"]*"' | head -1 | awk -F'"' '{print $4}')"
+    P_TS="$(echo "$PENDING_DATA" | grep -o '"ts":"[^"]*"' | head -1 | awk -F'"' '{print $4}')"
+    P_SID="$(echo "$PENDING_DATA" | grep -o '"session_id":"[^"]*"' | head -1 | awk -F'"' '{print $4}')"
+    P_VER="$(echo "$PENDING_DATA" | grep -o '"uzustack_version":"[^"]*"' | head -1 | awk -F'"' '{print $4}')"
+    P_OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+    P_ARCH="$(uname -m)"
+
+    # 古い event は outcome: unknown として書き込む
+    mkdir -p "$ANALYTICS_DIR"
+    printf '{"v":1,"ts":"%s","event_type":"skill_run","skill":"%s","session_id":"%s","uzustack_version":"%s","os":"%s","arch":"%s","duration_s":null,"outcome":"unknown","error_class":null,"used_browse":false,"sessions":1}\n' \
+      "$P_TS" "$P_SKILL" "$P_SID" "$P_VER" "$P_OS" "$P_ARCH" >> "$JSONL_FILE" 2>/dev/null || true
+  fi
+done
+
+# 自 session の pending marker を clear (これから本 event を log する)
+[ -n "$SESSION_ID" ] && rm -f "$PENDING_DIR/.pending-$SESSION_ID" 2>/dev/null || true
+
+# ─── metadata を集める ────────────────────────────────────────
+TS="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%S 2>/dev/null || echo "")"
+UZUSTACK_VERSION="$(cat "$VERSION_FILE" 2>/dev/null | tr -d '[:space:]' || echo "unknown")"
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+ARCH="$(uname -m)"
+SESSIONS="1"
+if [ -d "$STATE_DIR/sessions" ]; then
+  _SC="$(find "$STATE_DIR/sessions" -mmin -120 -type f 2>/dev/null | wc -l | tr -d ' \n\r\t')"
+  [ -n "$_SC" ] && [ "$_SC" -gt 0 ] 2>/dev/null && SESSIONS="$_SC"
+fi
+
+# community tier 用に installation_id を生成
+# random UUID を local 保存 — hostname/user 由来ではないので、マシン同定情報を
+# 知っている人間でも推測・相関できない。
+INSTALL_ID=""
+if [ "$TIER" = "community" ]; then
+  ID_FILE="$HOME/.uzustack/installation-id"
+  if [ -f "$ID_FILE" ]; then
+    INSTALL_ID="$(cat "$ID_FILE" 2>/dev/null)"
+  fi
+  if [ -z "$INSTALL_ID" ]; then
+    # random UUID v4 を生成
+    if command -v uuidgen >/dev/null 2>&1; then
+      INSTALL_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
+    elif [ -r /proc/sys/kernel/random/uuid ]; then
+      INSTALL_ID="$(cat /proc/sys/kernel/random/uuid)"
+    else
+      # Fallback: /dev/urandom から random hex
+      INSTALL_ID="$(od -An -tx1 -N16 /dev/urandom 2>/dev/null | tr -d ' \n')"
+    fi
+    if [ -n "$INSTALL_ID" ]; then
+      mkdir -p "$(dirname "$ID_FILE")" 2>/dev/null
+      printf '%s' "$INSTALL_ID" > "$ID_FILE" 2>/dev/null
+    fi
+  fi
+fi
+
+# Local-only field (remote 送信されない)
+REPO_SLUG=""
+BRANCH=""
+if command -v git >/dev/null 2>&1; then
+  REPO_SLUG="$(git remote get-url origin 2>/dev/null | sed 's|.*[:/]\([^/]*/[^/]*\)\.git$|\1|;s|.*[:/]\([^/]*/[^/]*\)$|\1|' | tr '/' '-' 2>/dev/null || true)"
+  BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+fi
+
+# ─── JSON を構築して append ───────────────────────────────────
+mkdir -p "$ANALYTICS_DIR"
+
+# 文字列 field を JSON 安全に sanitize (quote / backslash / control char を除去)
+json_safe() { printf '%s' "$1" | tr -d '"\\\n\r\t' | head -c 200; }
+SKILL="$(json_safe "$SKILL")"
+OUTCOME="$(json_safe "$OUTCOME")"
+SESSION_ID="$(json_safe "$SESSION_ID")"
+SOURCE="$(json_safe "$SOURCE")"
+EVENT_TYPE="$(json_safe "$EVENT_TYPE")"
+REPO_SLUG="$(json_safe "$REPO_SLUG")"
+BRANCH="$(json_safe "$BRANCH")"
+
+# null field を escape — ERROR_CLASS / FAILED_STEP は json_safe() で sanitize
+ERR_FIELD="null"
+[ -n "$ERROR_CLASS" ] && ERR_FIELD="\"$(json_safe "$ERROR_CLASS")\""
+
+ERR_MSG_FIELD="null"
+[ -n "$ERROR_MESSAGE" ] && ERR_MSG_FIELD="\"$(printf '%s' "$ERROR_MESSAGE" | head -c 200 | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/	/\\t/g' | tr '\n\r' '  ')\""
+
+STEP_FIELD="null"
+[ -n "$FAILED_STEP" ] && STEP_FIELD="\"$(json_safe "$FAILED_STEP")\""
+
+# 異常な duration を cap
+if [ -n "$DURATION" ] && [ "$DURATION" -gt 86400 ] 2>/dev/null; then
+  DURATION=""  # 24h 超 → null
+fi
+if [ -n "$DURATION" ] && [ "$DURATION" -lt 0 ] 2>/dev/null; then
+  DURATION=""  # 負値 → null
+fi
+
+DUR_FIELD="null"
+[ -n "$DURATION" ] && DUR_FIELD="$DURATION"
+
+INSTALL_FIELD="null"
+[ -n "$INSTALL_ID" ] && INSTALL_FIELD="\"$INSTALL_ID\""
+
+BROWSE_BOOL="false"
+[ "$USED_BROWSE" = "true" ] && BROWSE_BOOL="true"
+
+# Security field を sanitize — salted hash と enum 値だが、防御的に json_safe() を
+# 適用。Domain は RFC 1035 の 253 文字制限まで。
+SEC_URL_DOMAIN="$(json_safe "$SEC_URL_DOMAIN")"
+SEC_PAYLOAD_HASH="$(json_safe "$SEC_PAYLOAD_HASH")"
+SEC_LAYER="$(json_safe "$SEC_LAYER")"
+SEC_VERDICT="$(json_safe "$SEC_VERDICT")"
+
+# Confidence は数値 0-1。未設定 / 不正の場合 null に default。
+SEC_CONF_FIELD="null"
+if [ -n "$SEC_CONFIDENCE" ]; then
+  # awk で validate + [0,1] に clamp。parse 失敗時は null fallback。
+  _sc="$(awk -v v="$SEC_CONFIDENCE" 'BEGIN { if (v+0 >= 0 && v+0 <= 1) printf "%.4f", v+0; else print "" }' 2>/dev/null || echo "")"
+  [ -n "$_sc" ] && SEC_CONF_FIELD="$_sc"
+fi
+
+SEC_DOMAIN_FIELD="null"
+[ -n "$SEC_URL_DOMAIN" ] && SEC_DOMAIN_FIELD="\"$SEC_URL_DOMAIN\""
+SEC_HASH_FIELD="null"
+[ -n "$SEC_PAYLOAD_HASH" ] && SEC_HASH_FIELD="\"$SEC_PAYLOAD_HASH\""
+SEC_LAYER_FIELD="null"
+[ -n "$SEC_LAYER" ] && SEC_LAYER_FIELD="\"$SEC_LAYER\""
+SEC_VERDICT_FIELD="null"
+[ -n "$SEC_VERDICT" ] && SEC_VERDICT_FIELD="\"$SEC_VERDICT\""
+
+printf '{"v":1,"ts":"%s","event_type":"%s","skill":"%s","session_id":"%s","uzustack_version":"%s","os":"%s","arch":"%s","duration_s":%s,"outcome":"%s","error_class":%s,"error_message":%s,"failed_step":%s,"used_browse":%s,"sessions":%s,"installation_id":%s,"source":"%s","security_url_domain":%s,"security_payload_hash":%s,"security_confidence":%s,"security_layer":%s,"security_verdict":%s,"_repo_slug":"%s","_branch":"%s"}\n' \
+  "$TS" "$EVENT_TYPE" "$SKILL" "$SESSION_ID" "$UZUSTACK_VERSION" "$OS" "$ARCH" \
+  "$DUR_FIELD" "$OUTCOME" "$ERR_FIELD" "$ERR_MSG_FIELD" "$STEP_FIELD" \
+  "$BROWSE_BOOL" "${SESSIONS:-1}" \
+  "$INSTALL_FIELD" "$SOURCE" \
+  "$SEC_DOMAIN_FIELD" "$SEC_HASH_FIELD" "$SEC_CONF_FIELD" "$SEC_LAYER_FIELD" "$SEC_VERDICT_FIELD" \
+  "$REPO_SLUG" "$BRANCH" >> "$JSONL_FILE" 2>/dev/null || true
+
+# ─── tier が off でなければ sync を trigger ──────────────────
+SYNC_CMD="$UZUSTACK_DIR/bin/uzustack-telemetry-sync"
+if [ -x "$SYNC_CMD" ]; then
+  "$SYNC_CMD" 2>/dev/null &
+fi
+
+exit 0

--- a/bin/uzustack-telemetry-log
+++ b/bin/uzustack-telemetry-log
@@ -36,7 +36,7 @@ ERROR_MESSAGE=""
 FAILED_STEP=""
 EVENT_TYPE="skill_run"
 SOURCE=""
-# Security-event field (--event-type が attack_attempt の時のみ populate)
+# Security-event fields (--event-type が attack_attempt の時のみ populate)
 SEC_URL_DOMAIN=""
 SEC_PAYLOAD_HASH=""
 SEC_CONFIDENCE=""
@@ -55,7 +55,7 @@ while [ $# -gt 0 ]; do
     --failed-step)   FAILED_STEP="$2"; shift 2 ;;
     --event-type)    EVENT_TYPE="$2"; shift 2 ;;
     --source)        SOURCE="$2"; shift 2 ;;
-    # Security event field — browse/src/security.ts logAttempt() が emit する
+    # Security event fields — browse/src/security.ts logAttempt() が emit する
     --url-domain)    SEC_URL_DOMAIN="$2"; shift 2 ;;
     --payload-hash)  SEC_PAYLOAD_HASH="$2"; shift 2 ;;
     --confidence)    SEC_CONFIDENCE="$2"; shift 2 ;;
@@ -152,7 +152,7 @@ if [ "$TIER" = "community" ]; then
   fi
 fi
 
-# Local-only field (remote 送信されない)
+# Local-only fields (remote 送信されない)
 REPO_SLUG=""
 BRANCH=""
 if command -v git >/dev/null 2>&1; then

--- a/bin/uzustack-update-check
+++ b/bin/uzustack-update-check
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# uzustack-update-check — 全 skill 用の定期 version check
+#
+# Output (1 行 or 何も出さない):
+#   JUST_UPGRADED <old> <new>       — 直近の upgrade marker を発見
+#   UPGRADE_AVAILABLE <old> <new>   — remote VERSION が local と異なる
+#   (なし)                          — 最新 / snoozed / disabled / check skip
+#
+# Env overrides (for testing):
+#   UZUSTACK_DIR         — auto-detect された uzustack root を上書き
+#   UZUSTACK_REMOTE_URL  — remote VERSION URL を上書き
+#   UZUSTACK_HOME        — ~/.uzustack state directory を上書き
+set -euo pipefail
+
+UZUSTACK_DIR="${UZUSTACK_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+STATE_DIR="${UZUSTACK_HOME:-$HOME/.uzustack}"
+CACHE_FILE="$STATE_DIR/last-update-check"
+MARKER_FILE="$STATE_DIR/just-upgraded-from"
+SNOOZE_FILE="$STATE_DIR/update-snoozed"
+VERSION_FILE="$UZUSTACK_DIR/VERSION"
+REMOTE_URL="${UZUSTACK_REMOTE_URL:-https://raw.githubusercontent.com/uzumaki-inc/uzustack/main/VERSION}"
+
+# ─── Force flag (cache + snooze を無効化、stand-alone /uzustack-upgrade 用) ──
+if [ "${1:-}" = "--force" ]; then
+  rm -f "$CACHE_FILE"
+  rm -f "$SNOOZE_FILE"
+fi
+
+# ─── Step 0: update が disabled か check ────────────────────
+_UC=$("$UZUSTACK_DIR/bin/uzustack-config" get update_check 2>/dev/null || true)
+if [ "$_UC" = "false" ]; then
+  exit 0
+fi
+
+# ─── Migration: 古い Codex description を fix (1 回のみ) ─────
+# 既存 install には .agents/skills/uzustack/SKILL.md の description が
+# 過大 (>1024 chars) で Codex が reject するケースがある。runtime root
+# (bun/scripts なし) からは regenerate できないので、過大 file は削除する
+# — 次の ./setup or /uzustack-upgrade で正しく regenerate される。
+# Marker file で install ごとに最大 1 回しか走らないようにする。
+if [ ! -f "$STATE_DIR/.codex-desc-healed" ]; then
+  for _AGENTS_SKILL in "$UZUSTACK_DIR"/.agents/skills/*/SKILL.md; do
+    [ -f "$_AGENTS_SKILL" ] || continue
+    _DESC=$(awk '/^---$/{n++;next}n==1&&/^description:/{d=1;sub(/^description:\s*/,"");if(length>0)print;next}d&&/^  /{sub(/^  /,"");print;next}d{d=0}' "$_AGENTS_SKILL" | wc -c | tr -d ' ')
+    if [ "${_DESC:-0}" -gt 1024 ]; then
+      rm -f "$_AGENTS_SKILL"
+    fi
+  done
+  mkdir -p "$STATE_DIR"
+  touch "$STATE_DIR/.codex-desc-healed"
+fi
+
+# ─── Snooze helper ──────────────────────────────────────────
+# check_snooze <remote_version>
+#   snoozed なら 0 (静かにする)、snooze 無しなら 1 (出力する) を返す。
+#
+#   Snooze file format: <version> <level> <epoch>
+#   Level duration: 1=24h, 2=48h, 3+=7d
+#   New version (version mismatch) は snooze を reset する。
+check_snooze() {
+  local remote_ver="$1"
+  if [ ! -f "$SNOOZE_FILE" ]; then
+    return 1  # snooze file 無し → not snoozed
+  fi
+  local snoozed_ver snoozed_level snoozed_epoch
+  snoozed_ver="$(awk '{print $1}' "$SNOOZE_FILE" 2>/dev/null || true)"
+  snoozed_level="$(awk '{print $2}' "$SNOOZE_FILE" 2>/dev/null || true)"
+  snoozed_epoch="$(awk '{print $3}' "$SNOOZE_FILE" 2>/dev/null || true)"
+
+  # Validate: 3 field すべて非空必須
+  if [ -z "$snoozed_ver" ] || [ -z "$snoozed_level" ] || [ -z "$snoozed_epoch" ]; then
+    return 1  # corrupt file → not snoozed
+  fi
+
+  # Validate: level と epoch は整数必須
+  case "$snoozed_level" in *[!0-9]*) return 1 ;; esac
+  case "$snoozed_epoch" in *[!0-9]*) return 1 ;; esac
+
+  # 新 version が出てる? snooze を ignore。
+  if [ "$snoozed_ver" != "$remote_ver" ]; then
+    return 1
+  fi
+
+  # level に応じて snooze duration を計算
+  local duration
+  case "$snoozed_level" in
+    1) duration=86400 ;;   # 24 時間
+    2) duration=172800 ;;  # 48 時間
+    *) duration=604800 ;;  # 7 日 (level 3+)
+  esac
+
+  local now
+  now="$(date +%s)"
+  local expires=$(( snoozed_epoch + duration ))
+  if [ "$now" -lt "$expires" ]; then
+    return 0  # まだ snoozed
+  fi
+
+  return 1  # snooze expired
+}
+
+# ─── Step 1: local version を読む ─────────────────────────────
+LOCAL=""
+if [ -f "$VERSION_FILE" ]; then
+  LOCAL="$(cat "$VERSION_FILE" 2>/dev/null | tr -d '[:space:]')"
+fi
+if [ -z "$LOCAL" ]; then
+  exit 0  # VERSION file 無し → check skip
+fi
+
+# ─── Step 2: "just upgraded" marker を check ──────────────────
+if [ -f "$MARKER_FILE" ]; then
+  OLD="$(cat "$MARKER_FILE" 2>/dev/null | tr -d '[:space:]')"
+  rm -f "$MARKER_FILE"
+  rm -f "$SNOOZE_FILE"
+  if [ -n "$OLD" ]; then
+    echo "JUST_UPGRADED $OLD $LOCAL"
+  fi
+  # exit せず — upgrade 後にさらに update が来てる可能性があるので
+  # remote check に fall through する
+fi
+
+# ─── Step 3: cache freshness を check ──────────────────────────
+# UP_TO_DATE: 60 min TTL (新 release を素早く検知)
+# UPGRADE_AVAILABLE: 720 min TTL (うるさく言い続ける)
+if [ -f "$CACHE_FILE" ]; then
+  CACHED="$(cat "$CACHE_FILE" 2>/dev/null || true)"
+  case "$CACHED" in
+    UP_TO_DATE*)        CACHE_TTL=60 ;;
+    UPGRADE_AVAILABLE*) CACHE_TTL=720 ;;
+    *)                  CACHE_TTL=0 ;;  # corrupt → force re-fetch
+  esac
+
+  STALE=$(find "$CACHE_FILE" -mmin +$CACHE_TTL 2>/dev/null || true)
+  if [ -z "$STALE" ] && [ "$CACHE_TTL" -gt 0 ]; then
+    case "$CACHED" in
+      UP_TO_DATE*)
+        CACHED_VER="$(echo "$CACHED" | awk '{print $2}')"
+        if [ "$CACHED_VER" = "$LOCAL" ]; then
+          exit 0
+        fi
+        ;;
+      UPGRADE_AVAILABLE*)
+        CACHED_OLD="$(echo "$CACHED" | awk '{print $2}')"
+        if [ "$CACHED_OLD" = "$LOCAL" ]; then
+          CACHED_NEW="$(echo "$CACHED" | awk '{print $3}')"
+          if check_snooze "$CACHED_NEW"; then
+            exit 0  # snoozed — 静かにする
+          fi
+          echo "$CACHED"
+          exit 0
+        fi
+        ;;
+    esac
+  fi
+fi
+
+# ─── Step 4: Slow path — remote version を fetch ──────────────
+mkdir -p "$STATE_DIR"
+
+# Supabase install ping を background で発火 (並列、non-blocking)
+# community health metric 用の update check event を edge function 経由で log。
+# Supabase 未設定 or telemetry off の場合は no-op。
+if [ -z "${UZUSTACK_SUPABASE_URL:-}" ] && [ -f "$UZUSTACK_DIR/supabase/config.sh" ]; then
+  . "$UZUSTACK_DIR/supabase/config.sh"
+fi
+_SUPA_URL="${UZUSTACK_SUPABASE_URL:-}"
+_SUPA_KEY="${UZUSTACK_SUPABASE_ANON_KEY:-}"
+# telemetry opt-out を尊重 — ユーザーが telemetry: off に設定してたら Supabase ping しない
+_TEL_TIER="$("$UZUSTACK_DIR/bin/uzustack-config" get telemetry 2>/dev/null || true)"
+if [ -n "$_SUPA_URL" ] && [ -n "$_SUPA_KEY" ] && [ "${_TEL_TIER:-off}" != "off" ]; then
+  _OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  curl -sf --max-time 5 \
+    -X POST "${_SUPA_URL}/functions/v1/update-check" \
+    -H "Content-Type: application/json" \
+    -H "apikey: ${_SUPA_KEY}" \
+    -d "{\"version\":\"$LOCAL\",\"os\":\"$_OS\"}" \
+    >/dev/null 2>&1 &
+fi
+
+# GitHub raw fetch (primary、常に reliable)
+REMOTE=""
+REMOTE="$(curl -sf --max-time 5 "$REMOTE_URL" 2>/dev/null || true)"
+REMOTE="$(echo "$REMOTE" | tr -d '[:space:]')"
+
+# Validate: version number に見える必要あり (HTML error page を reject)
+if ! echo "$REMOTE" | grep -qE '^[0-9]+\.[0-9.]+$'; then
+  # 不正 or 空 response — 最新と仮定
+  echo "UP_TO_DATE $LOCAL" > "$CACHE_FILE"
+  exit 0
+fi
+
+if [ "$LOCAL" = "$REMOTE" ]; then
+  echo "UP_TO_DATE $LOCAL" > "$CACHE_FILE"
+  exit 0
+fi
+
+# Version 不一致 — upgrade あり
+echo "UPGRADE_AVAILABLE $LOCAL $REMOTE" > "$CACHE_FILE"
+if check_snooze "$REMOTE"; then
+  exit 0  # snoozed — 静かにする
+fi
+
+# upgrade_prompted event を log (slow-path fetch 時のみ、cache replay では log しない)
+TEL_CMD="$UZUSTACK_DIR/bin/uzustack-telemetry-log"
+if [ -x "$TEL_CMD" ]; then
+  "$TEL_CMD" --event-type upgrade_prompted --skill "" --duration 0 \
+    --outcome success --session-id "update-$$-$(date +%s)" 2>/dev/null &
+fi
+
+echo "UPGRADE_AVAILABLE $LOCAL $REMOTE"


### PR DESCRIPTION
## Summary

Phase 3 cluster B（bin 翻訳）の 1 step 目。runtime コア binary 7 個（jsonl-merge / platform-detect / telemetry-log / update-check / next-version）を機械翻訳し、step-32 配置済 2 個（uzustack-config CONFIG_HEADER + uzustack-slug）を日本語化で完成させた。voice 規約 v1（7 項目）を sample (jsonl-merge) で確立し、残り 4 個に展開した。7 commits = 1 commit per binary（bisect 単位を 1 binary に揃えた）。

## Commits

1. `d1b2c0f` — `bin/uzustack-jsonl-merge`（88 行）sample で voice 規約 v1 確立、動作確認 4 件 PASS
2. `de3b039` — `bin/uzustack-platform-detect`（27 行）、`scripts/host-config-export.ts` は Phase 4+
3. `8f181b2` — `bin/uzustack-telemetry-log`（241 行）、JSON schema `uzustack_version`、依存 telemetry-sync は Phase 4+
4. `ab2c653` — `bin/uzustack-update-check`（211 行）、GitHub raw URL を `uzumaki-inc/uzustack` に変更
5. `fc11730` — `bin/uzustack-next-version`（477 行 TypeScript）、primary 言語のため機械置換のみ
6. `9114bbb` — `uzustack-config` の CONFIG_HEADER 70 行を日本語化（end user 表示文字列）
7. `eb14d73` — `uzustack-slug` の voice 翻案

## voice 規約 v1（commit `d1b2c0f` で確立）

1. Section 見出し（`Usage:` / `Behavior:` / `Exit codes:`）は英語維持 — CLI 慣習
2. エラーメッセージは客観形「〜が必要、実際は N 個」
3. インラインコメントは簡潔な日本語、技術用語は backtick で英語維持
4. fixed identifier（`base` / `ours` / `theirs`、API 名）は英語維持
5. bin 名は backtick 囲み
6. embedded code 内コメント（Python 等）も日本語化、技術用語は英語維持
7. 括弧は半角 `(...)` を維持

**運用方針（commit `fc11730` で追加）**：bash + 副言語 embedded は副言語コメントも日本語化、TypeScript / 主言語そのものは英語維持（reader 想定の言語と一致させる）。

## Test plan

- [x] 各 binary の bash syntax check / bun parse check PASS
- [x] `uzustack-jsonl-merge`: 4 シナリオ PASS（引数不足 / 全不在 / ts 順 sort / SHA-256 fallback）
- [x] `uzustack-platform-detect`: bash syntax + ヘッダー表示動作（host 不在で空 list）
- [x] `uzustack-telemetry-log`: telemetry off / anonymous 両方で挙動確認、JSONL schema 確認
- [x] `uzustack-update-check`: VERSION 不在 / disabled / invalid REMOTE_URL 全 PASS
- [x] `uzustack-next-version`: bun --help PASS、no args で `Error: --bump is required` + exit 2
- [x] `uzustack-config`: 日本語 CONFIG_HEADER 書き込み + get 読み出し PASS
- [x] `uzustack-slug`: SLUG / BRANCH 出力 + eval 変数 set PASS

## 副次的成果

- memory `checkpoint_source_discipline` の有効性を実証：前 checkpoint の「BRANCH `/` 抜け bug」記述が **設計通りの security sanitize**（`tr -cd 'a-zA-Z0-9._-'`）であることを `eb14d73` で確認。「期待 vs 設計の照合規律」へ拡張する余地あり。
- 同じ branch 名でも path で挙動が違う設計（telemetry-log の `_branch` は raw、slug の BRANCH は sanitized）を `8f181b2` 動作確認で発見。

Closes #39