### PR TITLE
feat: bin 翻訳 — 学習機構群 (learnings-search / learnings-log) — Phase 3 step-36

### DIFF
--- a/bin/uzustack-learnings-log
+++ b/bin/uzustack-learnings-log
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# uzustack-learnings-log — project learnings file に 1 件 append する
+# Usage: uzustack-learnings-log '{"skill":"review","type":"pitfall","key":"n-plus-one","insight":"...","confidence":8,"source":"observed"}'
+#
+# Append-only ストレージ。同 key+type の重複は読み出し時に
+# uzustack-learnings-search が "latest winner" として解決する。
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+eval "$("$SCRIPT_DIR/uzustack-slug" 2>/dev/null)"
+UZUSTACK_HOME="${UZUSTACK_HOME:-$HOME/.uzustack}"
+mkdir -p "$UZUSTACK_HOME/projects/$SLUG"
+
+INPUT="$1"
+
+# 入力を validate して sanitize する
+VALIDATED=$(printf '%s' "$INPUT" | bun -e "
+const raw = await Bun.stdin.text();
+let j;
+try { j = JSON.parse(raw); } catch { process.stderr.write('uzustack-learnings-log: JSON が不正、skip\n'); process.exit(1); }
+
+// Field validation: type は許可リスト内のみ
+const ALLOWED_TYPES = ['pattern', 'pitfall', 'preference', 'architecture', 'tool', 'operational'];
+if (!j.type || !ALLOWED_TYPES.includes(j.type)) {
+  process.stderr.write('uzustack-learnings-log: type \"' + (j.type || '') + '\" が無効、許可値は: ' + ALLOWED_TYPES.join(', ') + '\n');
+  process.exit(1);
+}
+
+// Field validation: key は alphanumeric / hyphen / underscore のみ (injection 面を消す)
+if (!j.key || !/^[a-zA-Z0-9_-]+$/.test(j.key)) {
+  process.stderr.write('uzustack-learnings-log: key が無効、alphanumeric / hyphen / underscore のみ可\n');
+  process.exit(1);
+}
+
+// Field validation: confidence は 1-10 の整数
+const conf = Number(j.confidence);
+if (!Number.isInteger(conf) || conf < 1 || conf > 10) {
+  process.stderr.write('uzustack-learnings-log: confidence は 1-10 の整数\n');
+  process.exit(1);
+}
+j.confidence = conf;
+
+// Field validation: source は許可リスト内のみ
+const ALLOWED_SOURCES = ['observed', 'user-stated', 'inferred', 'cross-model'];
+if (j.source && !ALLOWED_SOURCES.includes(j.source)) {
+  process.stderr.write('uzustack-learnings-log: source が無効、許可値は: ' + ALLOWED_SOURCES.join(', ') + '\n');
+  process.exit(1);
+}
+
+// Content sanitization: insight field から instruction 風 pattern を除去
+// learnings が agent context に load された時に prompt injection に使われ得るため。
+if (j.insight) {
+  const INJECTION_PATTERNS = [
+    /ignore\s+(all\s+)?previous\s+(instructions|context|rules)/i,
+    /you\s+are\s+now\s+/i,
+    /always\s+output\s+no\s+findings/i,
+    /skip\s+(all\s+)?(security|review|checks)/i,
+    /override[:\s]/i,
+    /\bsystem\s*:/i,
+    /\bassistant\s*:/i,
+    /\buser\s*:/i,
+    /do\s+not\s+(report|flag|mention)/i,
+    /approve\s+(all|every|this)/i,
+  ];
+  for (const pat of INJECTION_PATTERNS) {
+    if (pat.test(j.insight)) {
+      process.stderr.write('uzustack-learnings-log: insight に instruction 風 content が含まれる、reject\n');
+      process.exit(1);
+    }
+  }
+}
+
+// timestamp を inject (未指定時のみ)
+if (!j.ts) j.ts = new Date().toISOString();
+
+// source 由来で trust level を mark
+// user-stated = user が agent に明示的に伝えた。それ以外は AI 生成。
+j.trusted = j.source === 'user-stated';
+
+console.log(JSON.stringify(j));
+" 2>/dev/null)
+
+if [ $? -ne 0 ] || [ -z "$VALIDATED" ]; then
+  exit 1
+fi
+
+echo "$VALIDATED" >> "$UZUSTACK_HOME/projects/$SLUG/learnings.jsonl"
+
+# gbrain-sync: cross-machine sync queue に enqueue (sync off の時は no-op)。
+"$SCRIPT_DIR/uzustack-brain-enqueue" "projects/$SLUG/learnings.jsonl" 2>/dev/null &

--- a/bin/uzustack-learnings-search
+++ b/bin/uzustack-learnings-search
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# uzustack-learnings-search — project learnings を読んで filter する
+# Usage: uzustack-learnings-search [--type TYPE] [--query KEYWORD] [--limit N] [--cross-project]
+#
+# ~/.uzustack/projects/$SLUG/learnings.jsonl を読み、confidence decay を適用、
+# 重複解消 (key+type ごとに latest winner) し、format した text を出力する。
+# learnings file が存在しない場合は silent に exit 0。
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+eval "$("$SCRIPT_DIR/uzustack-slug" 2>/dev/null)"
+UZUSTACK_HOME="${UZUSTACK_HOME:-$HOME/.uzustack}"
+
+TYPE=""
+QUERY=""
+LIMIT=10
+CROSS_PROJECT=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --type) TYPE="$2"; shift 2 ;;
+    --query) QUERY="$2"; shift 2 ;;
+    --limit) LIMIT="$2"; shift 2 ;;
+    --cross-project) CROSS_PROJECT=true; shift ;;
+    *) shift ;;
+  esac
+done
+
+LEARNINGS_FILE="$UZUSTACK_HOME/projects/$SLUG/learnings.jsonl"
+
+# 検索対象の JSONL file を集める
+FILES=()
+[ -f "$LEARNINGS_FILE" ] && FILES+=("$LEARNINGS_FILE")
+
+if [ "$CROSS_PROJECT" = true ]; then
+  # 他 project の learnings を追加 (最大 5 件、mtime 順)
+  for f in $(find "$UZUSTACK_HOME/projects" -name "learnings.jsonl" -not -path "*/$SLUG/*" 2>/dev/null | head -5); do
+    FILES+=("$f")
+  done
+fi
+
+if [ ${#FILES[@]} -eq 0 ]; then
+  exit 0
+fi
+
+# JSON parse / decay / dedup / filter を全 file まとめて bun に流す
+UZUSTACK_SEARCH_TYPE="$TYPE" UZUSTACK_SEARCH_QUERY="$QUERY" UZUSTACK_SEARCH_LIMIT="$LIMIT" UZUSTACK_SEARCH_SLUG="$SLUG" UZUSTACK_SEARCH_CROSS="$CROSS_PROJECT" \
+cat "${FILES[@]}" 2>/dev/null | UZUSTACK_SEARCH_TYPE="$TYPE" UZUSTACK_SEARCH_QUERY="$QUERY" UZUSTACK_SEARCH_LIMIT="$LIMIT" UZUSTACK_SEARCH_SLUG="$SLUG" UZUSTACK_SEARCH_CROSS="$CROSS_PROJECT" bun -e "
+const lines = (await Bun.stdin.text()).trim().split('\n').filter(Boolean);
+const now = Date.now();
+const type = process.env.UZUSTACK_SEARCH_TYPE || '';
+const query = (process.env.UZUSTACK_SEARCH_QUERY || '').toLowerCase();
+const limit = parseInt(process.env.UZUSTACK_SEARCH_LIMIT || '10', 10);
+const slug = process.env.UZUSTACK_SEARCH_SLUG || '';
+
+const entries = [];
+for (const line of lines) {
+  try {
+    const e = JSON.parse(line);
+    if (!e.key || !e.type) continue;
+
+    // confidence decay を適用: observed/inferred は 30 日 ごと 1pt 減
+    let conf = e.confidence || 5;
+    if (e.source === 'observed' || e.source === 'inferred') {
+      const days = Math.floor((now - new Date(e.ts).getTime()) / 86400000);
+      conf = Math.max(0, conf - Math.floor(days / 30));
+    }
+    e._effectiveConfidence = conf;
+
+    // 現 project / cross-project の判定。
+    // cross-project entry は表示時に tag を付ける。
+    const isCrossProject = !line.includes(slug) && process.env.UZUSTACK_SEARCH_CROSS === 'true';
+    e._crossProject = isCrossProject;
+
+    // Trust gate: cross-project learnings は trusted (user-stated) のみ load する。
+    // 別 project の AI 生成 learnings が prompt injection 経由で
+    // 本 project の review に影響することを防ぐ。
+    if (isCrossProject && e.trusted === false) continue;
+
+    entries.push(e);
+  } catch {}
+}
+
+// Dedup: key+type ごとに latest winner
+const seen = new Map();
+for (const e of entries) {
+  const dk = e.key + '|' + e.type;
+  const existing = seen.get(dk);
+  if (!existing || new Date(e.ts) > new Date(existing.ts)) {
+    seen.set(dk, e);
+  }
+}
+let results = Array.from(seen.values());
+
+// type で filter
+if (type) results = results.filter(e => e.type === type);
+
+// query で filter
+if (query) results = results.filter(e =>
+  (e.key || '').toLowerCase().includes(query) ||
+  (e.insight || '').toLowerCase().includes(query) ||
+  (e.files || []).some(f => f.toLowerCase().includes(query))
+);
+
+// effective confidence 降順、同値時は recency 降順
+results.sort((a, b) => {
+  if (b._effectiveConfidence !== a._effectiveConfidence) return b._effectiveConfidence - a._effectiveConfidence;
+  return new Date(b.ts).getTime() - new Date(a.ts).getTime();
+});
+
+// limit 適用
+results = results.slice(0, limit);
+
+if (results.length === 0) process.exit(0);
+
+// 出力 format
+const byType = {};
+for (const e of results) {
+  const t = e.type || 'unknown';
+  if (!byType[t]) byType[t] = [];
+  byType[t].push(e);
+}
+
+// Summary 行
+const counts = Object.entries(byType).map(([t, arr]) => arr.length + ' ' + t + (arr.length > 1 ? 's' : ''));
+console.log('LEARNINGS: ' + results.length + ' loaded (' + counts.join(', ') + ')');
+console.log('');
+
+for (const [t, arr] of Object.entries(byType)) {
+  console.log('## ' + t.charAt(0).toUpperCase() + t.slice(1) + 's');
+  for (const e of arr) {
+    const cross = e._crossProject ? ' [cross-project]' : '';
+    const files = e.files?.length ? ' (files: ' + e.files.join(', ') + ')' : '';
+    console.log('- [' + e.key + '] (confidence: ' + e._effectiveConfidence + '/10, ' + e.source + ', ' + (e.ts || '').split('T')[0] + ')' + cross);
+    console.log('  ' + e.insight + files);
+  }
+  console.log('');
+}
+" 2>/dev/null || exit 0


### PR DESCRIPTION
## Summary

Phase 3 cluster B（bin 翻訳、step-35〜39）の **2 step 目**。学習機構の 2 binary を gstack → uzustack に翻訳。Phase 5（learnings 機構の skill 統合）で `{{LEARNINGS_SEARCH}}` / `{{LEARNINGS_LOG}}` placeholder が展開される設計のため、binary 自体は Phase 3 で翻訳済みにしておけば Phase 5 は仕様策定 + placeholder 展開のみに絞れる。

- `uzustack-learnings-search` (138 行 bash + bun-embedded JS): confidence decay / cross-project trust gate / dedup / filter / format
- `uzustack-learnings-log` (89 行 bash + bun-embedded JS): JSON validation / injection pattern reject / append / brain-enqueue spawn

step-35 で確立した **voice 規約 v1（7 項目）+ 運用方針 v1** を 2 binary に適用。bisect 単位は 1 binary = 1 commit。

## 翻訳判断点（issue で事前合意済）

### 判断点 1: `gstack-brain-enqueue` 呼び出し行
→ `uzustack-brain-enqueue` 名で呼び `2>/dev/null &` で silently fail。step-37 で brain 系翻訳時に自動接続（memory `mechanize_over_scope_skip`）。

### 判断点 2: search 出力の `## Patterns` 等 section 見出し
→ 英語維持。type 値（`pattern` / `pitfall` / ...）が ASCII fixed identifier 由来、`t.charAt(0).toUpperCase() + t.slice(1) + 's'` の出力ロジック前提（voice 規約 v1 項目 1 + 4）。

## 動作確認

テスト用 `UZUSTACK_HOME` を mktemp で隔離して全 case 確認済（PR diff 内では再現不可、必要なら手元で）。

- log 正常 → search で表示 ✓
- 6 reject case 全て exit=1 ✓
  - invalid type / invalid key (special chars) / confidence 範囲外 / invalid source / injection pattern / invalid JSON
- confidence decay（60 日 前 observed → 7 - 2 = 5pt）✓
- `--query` filter（hit / miss）✓
- `--cross-project` trust gate（trusted のみ visible）✓
- setup 配置: setup は `bin/` を丸ごと symlink するため自動 pickup（setup 修正不要）

## 副次的発見（issue #38 = Phase 4+ epic への upstream PR 候補追加）

step-35 で 6 件挙げた upstream PR 候補に、本 step で **3 件追加**:

7. **cross-project 検出ロジックの bug**: `!line.includes(slug)` という判定は、現 project の entry が偶然 slug 文字列を含まない場合も「cross-project」と誤判定する。`--cross-project on` 時に現 project の untrusted entry が消える。
8. **bun stderr の dead-code 化**: 丁寧に書かれた validation error message は `2>/dev/null` で潰されており、reader に届かない（exit code のみ伝わる）。
9. **`new Date(e.ts)` 二重生成**: `learnings-search` の dedup loop と sort で計 3 回 `new Date(e.ts)` を再計算する。1000 entries で 3000 オブジェクト生成 + GC 圧。parsing 時に `e._ts_ms = new Date(e.ts).getTime()` を cache すれば 1 回に削減可能。impact は小（JSONL 規模次第）。

3 件とも upstream gstack で同じ挙動。faithful 翻訳で再現済み。issue #38 への追加は step-39 完了 / Phase 3 終盤で一括判断する（memory `upstream_clone_simplify_discipline`）。

## /simplify 実行結果（2026-04-29）

3 agent (reuse / quality / efficiency) 並列 review:
- **uzustack 単独修正**: 0 件（step-36 は voice 規約 v1 で完全機械化、judgment 空間が小さい）
- **upstream PR 候補**: 上記 #9 を新規発見、#7 は efficiency agent が独立に再発見（動作確認の発見と一致）
- **False positive**: bash の env var 二重設定 (`UZUSTACK_SEARCH_*="..." cat | UZUSTACK_SEARCH_*="..." bun`) は pipe 右側で env が継承されない bash の正規用法

## Test plan

- [x] log → search の round-trip（手元 mktemp 環境で確認済）
- [x] validation 6 reject case 全て exit=1
- [x] confidence decay / query / cross-project trust gate
- [x] setup 配置は symlink ベースで自動 pickup を確認

Closes #41

