### PR TITLE
feat: bin 翻訳 — その他補助 binary 21 個 — Phase 3 step-38

### DIFF
--- a/bin/uzustack-analytics
+++ b/bin/uzustack-analytics
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# uzustack-analytics — local JSONL からの personal usage dashboard
+#
+# Usage:
+#   uzustack-analytics          # default: last 7 days
+#   uzustack-analytics 7d       # last 7 days
+#   uzustack-analytics 30d      # last 30 days
+#   uzustack-analytics all      # all time
+#
+# Env override (test 用):
+#   UZUSTACK_STATE_DIR  — ~/.uzustack state directory を override
+set -uo pipefail
+
+STATE_DIR="${UZUSTACK_STATE_DIR:-$HOME/.uzustack}"
+JSONL_FILE="$STATE_DIR/analytics/skill-usage.jsonl"
+
+# ─── 時間 window を parse ────────────────────────────────────
+WINDOW="${1:-7d}"
+case "$WINDOW" in
+  7d)  DAYS=7;  LABEL="last 7 days" ;;
+  30d) DAYS=30; LABEL="last 30 days" ;;
+  all) DAYS=0;  LABEL="all time" ;;
+  *)   DAYS=7;  LABEL="last 7 days" ;;
+esac
+
+# ─── data 確認 ───────────────────────────────────────────────
+if [ ! -f "$JSONL_FILE" ]; then
+  echo "uzustack usage — no data yet"
+  echo ""
+  echo "Usage data will appear here after you use uzustack skills"
+  echo "with telemetry enabled (uzustack-config set telemetry anonymous)."
+  exit 0
+fi
+
+TOTAL_LINES="$(wc -l < "$JSONL_FILE" | tr -d ' ')"
+if [ "$TOTAL_LINES" = "0" ]; then
+  echo "uzustack usage — no data yet"
+  exit 0
+fi
+
+# ─── 時間 window で filter ───────────────────────────────────
+if [ "$DAYS" -gt 0 ] 2>/dev/null; then
+  # cutoff date を計算
+  if date -v-1d +%Y-%m-%d >/dev/null 2>&1; then
+    # macOS date
+    CUTOFF="$(date -v-${DAYS}d -u +%Y-%m-%dT%H:%M:%SZ)"
+  else
+    # GNU date
+    CUTOFF="$(date -u -d "$DAYS days ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "2000-01-01T00:00:00Z")"
+  fi
+  # Filter: skill_run event (新 format) OR basic skill event (旧 format、event_type なし)
+  # 旧 format: {"skill":"X","ts":"Y","repo":"Z"} (event_type field なし)
+  # 新 format: {"event_type":"skill_run","skill":"X","ts":"Y",...}
+  FILTERED="$(awk -F'"' -v cutoff="$CUTOFF" '
+    /"ts":"/ {
+      # hook_fire event は skip
+      if (/"event":"hook_fire"/) next
+      # skill_run 以外の新 format event は skip
+      if (/"event_type":"/ && !/"event_type":"skill_run"/) next
+      for (i=1; i<=NF; i++) {
+        if ($i == "ts" && $(i+1) ~ /^:/) {
+          ts = $(i+2)
+          if (ts >= cutoff) { print; break }
+        }
+      }
+    }
+  ' "$JSONL_FILE")"
+else
+  # All time: skill_run event + 旧 format basic event を含む、hook_fire は除外
+  FILTERED="$(awk '/"ts":"/ && !/"event":"hook_fire"/' "$JSONL_FILE" | grep -v '"event_type":"upgrade_' 2>/dev/null || true)"
+fi
+
+if [ -z "$FILTERED" ]; then
+  echo "uzustack usage ($LABEL) — no skill runs found"
+  exit 0
+fi
+
+# ─── skill 別に集計 ──────────────────────────────────────────
+# skill 名を抽出して count
+SKILL_COUNTS="$(echo "$FILTERED" | awk -F'"' '
+  /"skill":"/ {
+    for (i=1; i<=NF; i++) {
+      if ($i == "skill" && $(i+1) ~ /^:/) {
+        skill = $(i+2)
+        counts[skill]++
+        break
+      }
+    }
+  }
+  END {
+    for (s in counts) print counts[s], s
+  }
+' | sort -rn)"
+
+# outcome を count
+TOTAL="$(echo "$FILTERED" | wc -l | tr -d ' ')"
+SUCCESS="$(echo "$FILTERED" | grep -c '"outcome":"success"' || true)"
+SUCCESS="${SUCCESS:-0}"; SUCCESS="$(echo "$SUCCESS" | tr -d ' \n\r\t')"
+ERRORS="$(echo "$FILTERED" | grep -c '"outcome":"error"' || true)"
+ERRORS="${ERRORS:-0}"; ERRORS="$(echo "$ERRORS" | tr -d ' \n\r\t')"
+# 旧 format event は outcome field なし → success として count
+NO_OUTCOME="$(echo "$FILTERED" | grep -vc '"outcome":' || true)"
+NO_OUTCOME="${NO_OUTCOME:-0}"; NO_OUTCOME="$(echo "$NO_OUTCOME" | tr -d ' \n\r\t')"
+SUCCESS=$(( SUCCESS + NO_OUTCOME ))
+
+# success rate を算出
+if [ "$TOTAL" -gt 0 ] 2>/dev/null; then
+  SUCCESS_RATE=$(( SUCCESS * 100 / TOTAL ))
+else
+  SUCCESS_RATE=100
+fi
+
+# ─── 総 duration を算出 ──────────────────────────────────────
+TOTAL_DURATION="$(echo "$FILTERED" | awk -F'[:,]' '
+  /"duration_s"/ {
+    for (i=1; i<=NF; i++) {
+      if ($i ~ /"duration_s"/) {
+        val = $(i+1)
+        gsub(/[^0-9.]/, "", val)
+        if (val+0 > 0) total += val
+      }
+    }
+  }
+  END { printf "%.0f", total }
+')"
+
+# duration を整形
+TOTAL_DURATION="${TOTAL_DURATION:-0}"
+if [ "$TOTAL_DURATION" -ge 3600 ] 2>/dev/null; then
+  HOURS=$(( TOTAL_DURATION / 3600 ))
+  MINS=$(( (TOTAL_DURATION % 3600) / 60 ))
+  DUR_DISPLAY="${HOURS}h ${MINS}m"
+elif [ "$TOTAL_DURATION" -ge 60 ] 2>/dev/null; then
+  MINS=$(( TOTAL_DURATION / 60 ))
+  DUR_DISPLAY="${MINS}m"
+else
+  DUR_DISPLAY="${TOTAL_DURATION}s"
+fi
+
+# ─── 出力 render ─────────────────────────────────────────────
+echo "uzustack usage ($LABEL)"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# bar scaling 用に max count を取得
+MAX_COUNT="$(echo "$SKILL_COUNTS" | head -1 | awk '{print $1}')"
+BAR_WIDTH=20
+
+echo "$SKILL_COUNTS" | while read -r COUNT SKILL; do
+  # bar を scale
+  if [ "$MAX_COUNT" -gt 0 ] 2>/dev/null; then
+    BAR_LEN=$(( COUNT * BAR_WIDTH / MAX_COUNT ))
+  else
+    BAR_LEN=1
+  fi
+  [ "$BAR_LEN" -lt 1 ] && BAR_LEN=1
+
+  # bar を build
+  BAR=""
+  i=0
+  while [ "$i" -lt "$BAR_LEN" ]; do
+    BAR="${BAR}█"
+    i=$(( i + 1 ))
+  done
+
+  # この skill の avg duration を算出
+  AVG_DUR="$(echo "$FILTERED" | awk -v skill="$SKILL" '
+    index($0, "\"skill\":\"" skill "\"") > 0 {
+      # "duration_s": で split して value を抽出
+      n = split($0, parts, "\"duration_s\":")
+      if (n >= 2) {
+        # parts[2] は value から開始 (例: "142,")
+        gsub(/[^0-9.].*/, "", parts[2])
+        if (parts[2]+0 > 0) { total += parts[2]; count++ }
+      }
+    }
+    END { if (count > 0) printf "%.0f", total/count; else print "0" }
+  ')"
+
+  # avg duration を整形
+  if [ "$AVG_DUR" -ge 60 ] 2>/dev/null; then
+    AVG_DISPLAY="$(( AVG_DUR / 60 ))m"
+  else
+    AVG_DISPLAY="${AVG_DUR}s"
+  fi
+
+  printf "  /%-20s %s  %d runs  (avg %s)\n" "$SKILL" "$BAR" "$COUNT" "$AVG_DISPLAY"
+done
+
+echo ""
+echo "Success rate: ${SUCCESS_RATE}% | Errors: ${ERRORS} | Total time: ${DUR_DISPLAY}"
+echo "Events: ${TOTAL} skill runs"

--- a/bin/uzustack-builder-profile
+++ b/bin/uzustack-builder-profile
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# uzustack-builder-profile — LEGACY SHIM。
+#
+# `uzustack-developer-profile` に統合済。本 binary は `uzustack-developer-profile
+# --read` へ delegate し、`/office-hours` の動作を transition 期間中維持する。
+# 全 call site が移行完了したら削除可能。
+#
+# `~/.uzustack/builder-profile.jsonl` から統合先 `~/.uzustack/developer-profile.json`
+# への移行は最初の read で自動実行される — 詳細は `uzustack-developer-profile
+# --migrate` 参照。
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+exec "$SCRIPT_DIR/uzustack-developer-profile" --read "$@"

--- a/bin/uzustack-community-dashboard
+++ b/bin/uzustack-community-dashboard
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# uzustack-community-dashboard — Supabase からの community 利用統計
+#
+# community-pulse edge function を呼び出して集計値を取得:
+# skill popularity / crash cluster / version 分布 / retention。
+#
+# Env override (test 用):
+#   UZUSTACK_DIR                    — auto-detected uzustack root を override
+#   UZUSTACK_SUPABASE_URL           — Supabase project URL を override
+#   UZUSTACK_SUPABASE_ANON_KEY      — Supabase anon key を override
+set -uo pipefail
+
+UZUSTACK_DIR="${UZUSTACK_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+
+# env で未 override なら Supabase config を source
+if [ -z "${UZUSTACK_SUPABASE_URL:-}" ] && [ -f "$UZUSTACK_DIR/supabase/config.sh" ]; then
+  . "$UZUSTACK_DIR/supabase/config.sh"
+fi
+SUPABASE_URL="${UZUSTACK_SUPABASE_URL:-}"
+ANON_KEY="${UZUSTACK_SUPABASE_ANON_KEY:-}"
+
+if [ -z "$SUPABASE_URL" ] || [ -z "$ANON_KEY" ]; then
+  echo "uzustack community dashboard"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
+  echo "Supabase not configured yet. The community dashboard will be"
+  echo "available once the uzustack Supabase project is set up."
+  echo ""
+  echo "For local analytics, run: uzustack-analytics"
+  exit 0
+fi
+
+# ─── edge function から集計値を fetch ────────────────────────
+DATA="$(curl -sf --max-time 15 \
+  "${SUPABASE_URL}/functions/v1/community-pulse" \
+  -H "apikey: ${ANON_KEY}" \
+  2>/dev/null || echo "{}")"
+
+echo "uzustack community dashboard"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+# ─── Weekly active install ───────────────────────────────────
+WEEKLY="$(echo "$DATA" | grep -o '"weekly_active":[0-9]*' | grep -o '[0-9]*' || echo "0")"
+CHANGE="$(echo "$DATA" | grep -o '"change_pct":[0-9-]*' | grep -o '[0-9-]*' || echo "0")"
+
+echo "Weekly active installs: ${WEEKLY}"
+if [ "$CHANGE" -gt 0 ] 2>/dev/null; then
+  echo "  Change: +${CHANGE}%"
+elif [ "$CHANGE" -lt 0 ] 2>/dev/null; then
+  echo "  Change: ${CHANGE}%"
+fi
+echo ""
+
+# ─── Skill popularity (top 10) ───────────────────────────────
+echo "Top skills (last 7 days)"
+echo "────────────────────────"
+
+# JSON から top_skills array を parse
+SKILLS="$(echo "$DATA" | grep -o '"top_skills":\[[^]]*\]' || echo "")"
+if [ -n "$SKILLS" ] && [ "$SKILLS" != '"top_skills":[]' ]; then
+  # 各 object を parse — key 順序は問わない (JSONB は順序を保存しない)
+  echo "$SKILLS" | grep -o '{[^}]*}' | while read -r OBJ; do
+    SKILL="$(echo "$OBJ" | grep -o '"skill":"[^"]*"' | awk -F'"' '{print $4}')"
+    COUNT="$(echo "$OBJ" | grep -o '"count":[0-9]*' | grep -o '[0-9]*')"
+    [ -n "$SKILL" ] && [ -n "$COUNT" ] && printf "  /%-20s %s runs\n" "$SKILL" "$COUNT"
+  done
+else
+  echo "  No data yet"
+fi
+echo ""
+
+# ─── Crash cluster ───────────────────────────────────────────
+echo "Top crash clusters"
+echo "──────────────────"
+
+CRASHES="$(echo "$DATA" | grep -o '"crashes":\[[^]]*\]' || echo "")"
+if [ -n "$CRASHES" ] && [ "$CRASHES" != '"crashes":[]' ]; then
+  echo "$CRASHES" | grep -o '{[^}]*}' | head -5 | while read -r OBJ; do
+    ERR="$(echo "$OBJ" | grep -o '"error_class":"[^"]*"' | awk -F'"' '{print $4}')"
+    C="$(echo "$OBJ" | grep -o '"total_occurrences":[0-9]*' | grep -o '[0-9]*')"
+    [ -n "$ERR" ] && printf "  %-30s %s occurrences\n" "$ERR" "${C:-?}"
+  done
+else
+  echo "  No crashes reported"
+fi
+echo ""
+
+# ─── Version 分布 ────────────────────────────────────────────
+echo "Version distribution (last 7 days)"
+echo "───────────────────────────────────"
+
+VERSIONS="$(echo "$DATA" | grep -o '"versions":\[[^]]*\]' || echo "")"
+if [ -n "$VERSIONS" ] && [ "$VERSIONS" != '"versions":[]' ]; then
+  echo "$VERSIONS" | grep -o '{[^}]*}' | head -5 | while read -r OBJ; do
+    VER="$(echo "$OBJ" | grep -o '"version":"[^"]*"' | awk -F'"' '{print $4}')"
+    COUNT="$(echo "$OBJ" | grep -o '"count":[0-9]*' | grep -o '[0-9]*')"
+    [ -n "$VER" ] && [ -n "$COUNT" ] && printf "  v%-15s %s events\n" "$VER" "$COUNT"
+  done
+else
+  echo "  No data yet"
+fi
+
+echo ""
+echo "For local analytics: uzustack-analytics"

--- a/bin/uzustack-developer-profile
+++ b/bin/uzustack-developer-profile
@@ -1,0 +1,450 @@
+#!/usr/bin/env bash
+# uzustack-developer-profile — 統合 developer profile の access と derive。
+#
+# `uzustack-builder-profile` を supersede。旧 binary は `uzustack-developer-profile
+# --read` に delegate する legacy shim として残る。
+#
+# Subcommands:
+#   --read              (default)  builder-profile 形式の KEY: VALUE を出力
+#                                  (/office-hours 互換用)
+#   --derive            question event から inferred dimension を再計算し
+#                       ~/.uzustack/developer-profile.json を更新
+#   --profile           profile 全体を JSON で出力
+#   --gap               declared vs inferred の gap を JSON で出力
+#   --trace <dim>       dimension に寄与した event を表示
+#   --narrative         (v2 stub) coach bio paragraph を出力
+#   --vibe              (v2 stub) one-word archetype を出力
+#   --check-mismatch    declared と observed の有意 gap を検出
+#   --migrate           builder-profile.jsonl → developer-profile.json を migrate
+#                       idempotent、成功時は source file を archive
+#
+# Profile file: ~/.uzustack/developer-profile.json (統合 schema、
+# docs/designs/PLAN_TUNING_V0.md 参照)。Event file: ~/.uzustack/projects/{SLUG}/
+# question-events.jsonl。
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+UZUSTACK_HOME="${UZUSTACK_HOME:-$HOME/.uzustack}"
+PROFILE_FILE="$UZUSTACK_HOME/developer-profile.json"
+LEGACY_FILE="$UZUSTACK_HOME/builder-profile.jsonl"
+eval "$("$SCRIPT_DIR/uzustack-slug" 2>/dev/null || true)"
+SLUG="${SLUG:-unknown}"
+
+CMD="${1:---read}"
+shift || true
+
+# -----------------------------------------------------------------------
+# Migration: builder-profile.jsonl → developer-profile.json
+# -----------------------------------------------------------------------
+do_migrate() {
+  if [ ! -f "$LEGACY_FILE" ]; then
+    echo "MIGRATE: no legacy file to migrate"
+    return 0
+  fi
+
+  if [ -f "$PROFILE_FILE" ]; then
+    # 既に migrate 済 → no-op (idempotent)
+    echo "MIGRATE: already migrated (developer-profile.json exists)"
+    return 0
+  fi
+
+  # tmp file に migration を実行 → atomic rename
+  local TMPOUT
+  TMPOUT=$(mktemp "$UZUSTACK_HOME/developer-profile.json.XXXXXX.tmp")
+  trap 'rm -f "$TMPOUT"' EXIT
+
+  cat "$LEGACY_FILE" | bun -e "
+    const lines = (await Bun.stdin.text()).trim().split('\n').filter(Boolean);
+    const sessions = [];
+    const signalsAcc = {};
+    const resources = new Set();
+    const topics = new Set();
+    for (const line of lines) {
+      try {
+        const e = JSON.parse(line);
+        sessions.push(e);
+        for (const s of (e.signals || [])) {
+          signalsAcc[s] = (signalsAcc[s] || 0) + 1;
+        }
+        for (const r of (e.resources_shown || [])) resources.add(r);
+        for (const t of (e.topics || [])) topics.add(t);
+      } catch {}
+    }
+    const profile = {
+      identity: {},
+      declared: {},
+      inferred: {
+        values: {
+          scope_appetite: 0.5,
+          risk_tolerance: 0.5,
+          detail_preference: 0.5,
+          autonomy: 0.5,
+          architecture_care: 0.5,
+        },
+        sample_size: 0,
+        diversity: { skills_covered: 0, question_ids_covered: 0, days_span: 0 },
+      },
+      gap: {},
+      overrides: {},
+      sessions,
+      signals_accumulated: signalsAcc,
+      resources_shown: Array.from(resources),
+      topics: Array.from(topics),
+      migrated_at: new Date().toISOString(),
+      schema_version: 1,
+    };
+    console.log(JSON.stringify(profile, null, 2));
+  " > "$TMPOUT"
+
+  # Atomic rename
+  mv "$TMPOUT" "$PROFILE_FILE"
+  trap - EXIT
+
+  # gbrain-sync: cross-machine sync 用に enqueue (sync off 時は no-op)
+  SCRIPT_DIR_E="$(cd "$(dirname "$0")" && pwd)"
+  "$SCRIPT_DIR_E/uzustack-brain-enqueue" "developer-profile.json" 2>/dev/null &
+
+  # legacy file を archive
+  local TS
+  TS="$(date +%Y-%m-%d-%H%M%S)"
+  mv "$LEGACY_FILE" "$LEGACY_FILE.migrated-$TS"
+
+  local COUNT
+  COUNT=$(bun -e "console.log(JSON.parse(require('fs').readFileSync('$PROFILE_FILE','utf-8')).sessions.length)" 2>/dev/null || echo "?")
+  echo "MIGRATE: ok — migrated $COUNT sessions from builder-profile.jsonl"
+}
+
+# -----------------------------------------------------------------------
+# Load-or-migrate helper: developer-profile.json を必ず存在させる。
+# builder-profile.jsonl があれば auto migrate。
+# 何もなければ minimal stub を作成。
+# -----------------------------------------------------------------------
+ensure_profile() {
+  if [ -f "$PROFILE_FILE" ]; then
+    return 0
+  fi
+  if [ -f "$LEGACY_FILE" ]; then
+    do_migrate >/dev/null
+    return 0
+  fi
+  # 何も無ければ stub 作成
+  mkdir -p "$UZUSTACK_HOME"
+  cat > "$PROFILE_FILE" <<EOF
+{
+  "identity": {},
+  "declared": {},
+  "inferred": {
+    "values": {
+      "scope_appetite": 0.5,
+      "risk_tolerance": 0.5,
+      "detail_preference": 0.5,
+      "autonomy": 0.5,
+      "architecture_care": 0.5
+    },
+    "sample_size": 0,
+    "diversity": { "skills_covered": 0, "question_ids_covered": 0, "days_span": 0 }
+  },
+  "gap": {},
+  "overrides": {},
+  "sessions": [],
+  "signals_accumulated": {},
+  "schema_version": 1
+}
+EOF
+}
+
+# -----------------------------------------------------------------------
+# Read: /office-hours 互換の legacy KEY: VALUE を出力
+# -----------------------------------------------------------------------
+do_read() {
+  ensure_profile
+  cat "$PROFILE_FILE" | bun -e "
+    const p = JSON.parse(await Bun.stdin.text());
+    const sessions = p.sessions || [];
+    const count = sessions.length;
+    let tier = 'introduction';
+    if (count >= 8) tier = 'inner_circle';
+    else if (count >= 4) tier = 'regular';
+    else if (count >= 1) tier = 'welcome_back';
+
+    const last = sessions[count - 1] || {};
+    const prev = sessions[count - 2] || {};
+    const crossProject = prev.project_slug && last.project_slug
+      ? prev.project_slug !== last.project_slug
+      : false;
+
+    const designs = sessions.map(e => e.design_doc || '').filter(Boolean);
+    const designTitles = sessions
+      .map(e => (e.design_doc ? (e.project_slug || 'unknown') : ''))
+      .filter(Boolean);
+
+    const signalCounts = p.signals_accumulated || {};
+    let totalSignals = 0;
+    for (const v of Object.values(signalCounts)) totalSignals += v;
+    const signalStr = Object.entries(signalCounts).map(([k,v]) => k + ':' + v).join(',');
+
+    const builderSessions = sessions.filter(e => e.mode !== 'startup').length;
+    const nudgeEligible = builderSessions >= 3 && totalSignals >= 5;
+
+    const resources = p.resources_shown || [];
+    const topics = p.topics || [];
+
+    console.log('SESSION_COUNT: ' + count);
+    console.log('TIER: ' + tier);
+    console.log('LAST_PROJECT: ' + (last.project_slug || ''));
+    console.log('LAST_ASSIGNMENT: ' + (last.assignment || ''));
+    console.log('LAST_DESIGN_TITLE: ' + (last.design_doc || ''));
+    console.log('DESIGN_COUNT: ' + designs.length);
+    console.log('DESIGN_TITLES: ' + JSON.stringify(designTitles));
+    console.log('ACCUMULATED_SIGNALS: ' + signalStr);
+    console.log('TOTAL_SIGNAL_COUNT: ' + totalSignals);
+    console.log('CROSS_PROJECT: ' + crossProject);
+    console.log('NUDGE_ELIGIBLE: ' + nudgeEligible);
+    console.log('RESOURCES_SHOWN: ' + resources.join(','));
+    console.log('RESOURCES_SHOWN_COUNT: ' + resources.length);
+    console.log('TOPICS: ' + topics.join(','));
+  "
+}
+
+# -----------------------------------------------------------------------
+# Profile: 全 JSON を出力
+# -----------------------------------------------------------------------
+do_profile() {
+  ensure_profile
+  cat "$PROFILE_FILE"
+}
+
+# -----------------------------------------------------------------------
+# Gap: declared vs inferred の diff
+# -----------------------------------------------------------------------
+do_gap() {
+  ensure_profile
+  cat "$PROFILE_FILE" | bun -e "
+    const p = JSON.parse(await Bun.stdin.text());
+    const declared = p.declared || {};
+    const inferred = (p.inferred && p.inferred.values) || {};
+    const dims = ['scope_appetite','risk_tolerance','detail_preference','autonomy','architecture_care'];
+    const gap = {};
+    for (const d of dims) {
+      if (declared[d] !== undefined && inferred[d] !== undefined) {
+        gap[d] = +(Math.abs(declared[d] - inferred[d])).toFixed(3);
+      }
+    }
+    console.log(JSON.stringify({ declared, inferred, gap }, null, 2));
+  "
+}
+
+# -----------------------------------------------------------------------
+# Derive: question-events.jsonl から inferred dimension を再計算
+# -----------------------------------------------------------------------
+do_derive() {
+  ensure_profile
+  local EVENTS="$UZUSTACK_HOME/projects/$SLUG/question-log.jsonl"
+  local REGISTRY="$ROOT_DIR/scripts/question-registry.ts"
+  local SIGNALS="$ROOT_DIR/scripts/psychographic-signals.ts"
+  if [ ! -f "$REGISTRY" ] || [ ! -f "$SIGNALS" ]; then
+    echo "DERIVE: registry or signals file missing, cannot derive" >&2
+    exit 1
+  fi
+
+  cd "$ROOT_DIR"
+  PROFILE_FILE_PATH="$PROFILE_FILE" EVENTS_PATH="$EVENTS" bun -e "
+    import('./scripts/question-registry.ts').then(async (regmod) => {
+      const sigmod = await import('./scripts/psychographic-signals.ts');
+      const fs = require('fs');
+      const { QUESTIONS } = regmod;
+      const { SIGNAL_MAP, applySignal, newDimensionTotals, normalizeToDimensionValue } = sigmod;
+
+      const profilePath = process.env.PROFILE_FILE_PATH;
+      const eventsPath = process.env.EVENTS_PATH;
+      const profile = JSON.parse(fs.readFileSync(profilePath, 'utf-8'));
+
+      let lines = [];
+      if (fs.existsSync(eventsPath)) {
+        lines = fs.readFileSync(eventsPath, 'utf-8').trim().split('\n').filter(Boolean);
+      }
+
+      const totals = newDimensionTotals();
+      const skills = new Set();
+      const qids = new Set();
+      const days = new Set();
+      let count = 0;
+      for (const line of lines) {
+        let e;
+        try { e = JSON.parse(line); } catch { continue; }
+        if (!e.question_id || !e.user_choice) continue;
+        count++;
+        skills.add(e.skill);
+        qids.add(e.question_id);
+        if (e.ts) days.add(String(e.ts).slice(0,10));
+        const def = QUESTIONS[e.question_id];
+        if (def && def.signal_key) {
+          applySignal(totals, def.signal_key, e.user_choice);
+        }
+      }
+
+      const values = {};
+      for (const [dim, total] of Object.entries(totals)) {
+        values[dim] = +normalizeToDimensionValue(total).toFixed(3);
+      }
+
+      profile.inferred = {
+        values,
+        sample_size: count,
+        diversity: {
+          skills_covered: skills.size,
+          question_ids_covered: qids.size,
+          days_span: days.size,
+        },
+      };
+
+      // gap を再計算
+      const gap = {};
+      for (const d of Object.keys(values)) {
+        if (profile.declared && profile.declared[d] !== undefined) {
+          gap[d] = +(Math.abs(profile.declared[d] - values[d])).toFixed(3);
+        }
+      }
+      profile.gap = gap;
+      profile.derived_at = new Date().toISOString();
+
+      const tmp = profilePath + '.tmp';
+      fs.writeFileSync(tmp, JSON.stringify(profile, null, 2));
+      fs.renameSync(tmp, profilePath);
+      console.log('DERIVE: ok — ' + count + ' events, ' + skills.size + ' skills, ' + qids.size + ' questions');
+    }).catch(err => { console.error('DERIVE:', err.message); process.exit(1); });
+  "
+}
+
+# -----------------------------------------------------------------------
+# Trace: dimension に寄与した event を表示
+# -----------------------------------------------------------------------
+do_trace() {
+  local DIM="${1:-}"
+  if [ -z "$DIM" ]; then
+    echo "TRACE: missing dimension argument" >&2
+    exit 1
+  fi
+  local EVENTS="$UZUSTACK_HOME/projects/$SLUG/question-log.jsonl"
+  if [ ! -f "$EVENTS" ]; then
+    echo "TRACE: no events for this project"
+    return 0
+  fi
+  cd "$ROOT_DIR"
+  EVENTS_PATH="$EVENTS" TRACE_DIM="$DIM" bun -e "
+    import('./scripts/question-registry.ts').then(async (regmod) => {
+      const sigmod = await import('./scripts/psychographic-signals.ts');
+      const fs = require('fs');
+      const { QUESTIONS } = regmod;
+      const { SIGNAL_MAP } = sigmod;
+      const target = process.env.TRACE_DIM;
+      const lines = fs.readFileSync(process.env.EVENTS_PATH, 'utf-8').trim().split('\n').filter(Boolean);
+      const rows = [];
+      for (const line of lines) {
+        let e;
+        try { e = JSON.parse(line); } catch { continue; }
+        const def = QUESTIONS[e.question_id];
+        if (!def || !def.signal_key) continue;
+        const deltas = SIGNAL_MAP[def.signal_key]?.[e.user_choice] || [];
+        for (const d of deltas) {
+          if (d.dim === target) {
+            rows.push({ ts: e.ts, question_id: e.question_id, choice: e.user_choice, delta: d.delta });
+          }
+        }
+      }
+      if (rows.length === 0) {
+        console.log('TRACE: no events contribute to ' + target);
+      } else {
+        console.log('TRACE: ' + rows.length + ' events for ' + target);
+        for (const r of rows) {
+          console.log('  ' + (r.ts || '').slice(0,19) + '  ' + r.question_id + '  → ' + r.choice + '  (' + (r.delta > 0 ? '+' : '') + r.delta + ')');
+        }
+      }
+    });
+  "
+}
+
+# -----------------------------------------------------------------------
+# Check mismatch: declared ≠ inferred (gap > threshold) を flag
+# -----------------------------------------------------------------------
+do_check_mismatch() {
+  ensure_profile
+  cat "$PROFILE_FILE" | bun -e "
+    const p = JSON.parse(await Bun.stdin.text());
+    const declared = p.declared || {};
+    const inferred = (p.inferred && p.inferred.values) || {};
+    const sampleSize = (p.inferred && p.inferred.sample_size) || 0;
+    const diversity = (p.inferred && p.inferred.diversity) || {};
+
+    // mismatch 報告には十分な data が必要
+    if (sampleSize < 10) {
+      console.log('MISMATCH: not enough data (' + sampleSize + ' events; need 10+)');
+      process.exit(0);
+    }
+
+    const THRESHOLD = 0.3;
+    const flagged = [];
+    for (const d of Object.keys(declared)) {
+      if (inferred[d] === undefined) continue;
+      const gap = Math.abs(declared[d] - inferred[d]);
+      if (gap > THRESHOLD) {
+        flagged.push({ dim: d, declared: declared[d], inferred: inferred[d], gap: +gap.toFixed(3) });
+      }
+    }
+
+    if (flagged.length === 0) {
+      console.log('MISMATCH: none');
+    } else {
+      console.log('MISMATCH: ' + flagged.length + ' dimension(s) disagree (gap > ' + THRESHOLD + ')');
+      for (const f of flagged) {
+        console.log('  ' + f.dim + ': declared ' + f.declared + ' vs inferred ' + f.inferred + ' (gap ' + f.gap + ')');
+      }
+    }
+  "
+}
+
+# -----------------------------------------------------------------------
+# Narrative + Vibe (v2 stubs)
+# -----------------------------------------------------------------------
+do_narrative() {
+  echo "NARRATIVE: (v2 — not yet implemented; use /plan-tune profile for now)"
+}
+
+do_vibe() {
+  ensure_profile
+  cd "$ROOT_DIR"
+  cat "$PROFILE_FILE" | PROFILE_DATA="$(cat "$PROFILE_FILE")" bun -e "
+    import('./scripts/archetypes.ts').then(async (mod) => {
+      const p = JSON.parse(process.env.PROFILE_DATA);
+      const dims = (p.inferred && p.inferred.values) || {
+        scope_appetite: 0.5, risk_tolerance: 0.5, detail_preference: 0.5,
+        autonomy: 0.5, architecture_care: 0.5,
+      };
+      const arch = mod.matchArchetype(dims);
+      console.log(arch.name);
+      console.log(arch.description);
+    });
+  "
+}
+
+# -----------------------------------------------------------------------
+# Dispatch
+# -----------------------------------------------------------------------
+case "$CMD" in
+  --read) do_read ;;
+  --profile) do_profile ;;
+  --gap) do_gap ;;
+  --derive) do_derive ;;
+  --trace) do_trace "$@" ;;
+  --narrative) do_narrative ;;
+  --vibe) do_vibe ;;
+  --check-mismatch) do_check_mismatch ;;
+  --migrate) do_migrate ;;
+  --help|-h) sed -n '1,/^set -euo/p' "$0" | sed 's|^# \?||' ;;
+  *)
+    echo "uzustack-developer-profile: unknown subcommand '$CMD'" >&2
+    echo "run --help for usage" >&2
+    exit 1
+    ;;
+esac

--- a/bin/uzustack-diff-scope
+++ b/bin/uzustack-diff-scope
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# uzustack-diff-scope — base branch との diff を category 別に分類
+# Usage: source <(uzustack-diff-scope main)  → SCOPE_FRONTEND=true SCOPE_BACKEND=false ... を set
+# Or:    uzustack-diff-scope main            → SCOPE_*=... 行を print
+set -euo pipefail
+
+BASE="${1:-main}"
+
+# 変更 file list を取得
+FILES=$(git diff "${BASE}...HEAD" --name-only 2>/dev/null || git diff "${BASE}" --name-only 2>/dev/null || echo "")
+
+if [ -z "$FILES" ]; then
+  echo "SCOPE_FRONTEND=false"
+  echo "SCOPE_BACKEND=false"
+  echo "SCOPE_PROMPTS=false"
+  echo "SCOPE_TESTS=false"
+  echo "SCOPE_DOCS=false"
+  echo "SCOPE_CONFIG=false"
+  echo "SCOPE_MIGRATIONS=false"
+  echo "SCOPE_API=false"
+  echo "SCOPE_AUTH=false"
+  exit 0
+fi
+
+FRONTEND=false
+BACKEND=false
+PROMPTS=false
+TESTS=false
+DOCS=false
+CONFIG=false
+MIGRATIONS=false
+API=false
+AUTH=false
+
+while IFS= read -r f; do
+  case "$f" in
+    # Frontend: CSS / view / component / template
+    *.css|*.scss|*.less|*.sass|*.pcss|*.module.css|*.module.scss) FRONTEND=true ;;
+    *.tsx|*.jsx|*.vue|*.svelte|*.astro) FRONTEND=true ;;
+    *.erb|*.haml|*.slim|*.hbs|*.ejs) FRONTEND=true ;;
+    *.html) FRONTEND=true ;;
+    tailwind.config.*|postcss.config.*) FRONTEND=true ;;
+    app/views/*|*/components/*|styles/*|css/*|app/assets/stylesheets/*) FRONTEND=true ;;
+
+    # Prompts: prompt builder / system prompt / generation service
+    *prompt_builder*|*generation_service*|*writer_service*|*designer_service*) PROMPTS=true ;;
+    *evaluator*|*scorer*|*classifier_service*|*analyzer*) PROMPTS=true ;;
+    *voice*.rb|*writing*.rb|*prompt*.rb|*token*.rb) PROMPTS=true ;;
+    app/services/chat_tools/*|app/services/x_thread_tools/*) PROMPTS=true ;;
+    config/system_prompts/*) PROMPTS=true ;;
+
+    # Tests
+    *.test.*|*.spec.*|*_test.*|*_spec.*) TESTS=true ;;
+    test/*|tests/*|spec/*|__tests__/*|cypress/*|e2e/*) TESTS=true ;;
+
+    # Docs
+    *.md) DOCS=true ;;
+
+    # Config
+    package.json|package-lock.json|yarn.lock|bun.lockb) CONFIG=true ;;
+    Gemfile|Gemfile.lock) CONFIG=true ;;
+    *.yml|*.yaml) CONFIG=true ;;
+    .github/*) CONFIG=true ;;
+    requirements.txt|pyproject.toml|go.mod|Cargo.toml|composer.json) CONFIG=true ;;
+
+    # Migrations: database migration file
+    db/migrate/*|*/migrations/*|alembic/*|prisma/migrations/*) MIGRATIONS=true ;;
+
+    # API: route / controller / endpoint / GraphQL / OpenAPI schema
+    *controller*|*route*|*endpoint*|*/api/*) API=true ;;
+    *.graphql|*.gql|openapi.*|swagger.*) API=true ;;
+
+    # Auth: authentication / authorization / session / permission
+    *auth*|*session*|*jwt*|*oauth*|*permission*|*role*) AUTH=true ;;
+
+    # Backend: 上記の view / component に match しない code 全般
+    *.rb|*.py|*.go|*.rs|*.java|*.php|*.ex|*.exs) BACKEND=true ;;
+    *.ts|*.js) BACKEND=true ;;  # component 以外の TS / JS は backend
+  esac
+done <<< "$FILES"
+
+echo "SCOPE_FRONTEND=$FRONTEND"
+echo "SCOPE_BACKEND=$BACKEND"
+echo "SCOPE_PROMPTS=$PROMPTS"
+echo "SCOPE_TESTS=$TESTS"
+echo "SCOPE_DOCS=$DOCS"
+echo "SCOPE_CONFIG=$CONFIG"
+echo "SCOPE_MIGRATIONS=$MIGRATIONS"
+echo "SCOPE_API=$API"
+echo "SCOPE_AUTH=$AUTH"

--- a/bin/uzustack-extension
+++ b/bin/uzustack-extension
@@ -1,0 +1,65 @@
+#!/bin/bash
+# uzustack-extension — Chrome extension の install を補助する helper
+#
+# `$B connect` 経由なら extension は auto-load される。本 script は通常の
+# Chrome (Playwright 制御下ではない) に install する場合に使う。
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# extension directory を探索
+EXT_DIR=""
+if [ -f "$REPO_ROOT/extension/manifest.json" ]; then
+  EXT_DIR="$REPO_ROOT/extension"
+elif [ -f "$HOME/.claude/skills/uzustack/extension/manifest.json" ]; then
+  EXT_DIR="$HOME/.claude/skills/uzustack/extension"
+fi
+
+if [ -z "$EXT_DIR" ]; then
+  echo "Error: extension/ directory が見つからない。"
+  echo "想定 path: $REPO_ROOT/extension/ または ~/.claude/skills/uzustack/extension/"
+  exit 1
+fi
+
+# path を clipboard へ copy
+echo -n "$EXT_DIR" | pbcopy 2>/dev/null
+
+# browse server port を取得
+PORT=""
+STATE_FILE="$REPO_ROOT/.uzustack/browse.json"
+if [ -f "$STATE_FILE" ]; then
+  PORT=$(grep -o '"port":[0-9]*' "$STATE_FILE" | grep -o '[0-9]*')
+fi
+
+echo "uzustack Chrome Extension Setup"
+echo "================================"
+echo ""
+echo "Extension path (clipboard に copy 済):"
+echo "  $EXT_DIR"
+echo ""
+
+if [ -n "$PORT" ]; then
+  echo "Browse server port: $PORT"
+  echo ""
+fi
+
+echo "Quick install (\$B connect 利用時):"
+echo "  \$B connect 実行時に extension が auto-load される。"
+echo "  manual install は不要。"
+echo ""
+echo "Manual install (通常の Chrome の場合):"
+echo ""
+echo "  1. chrome://extensions を開く..."
+
+# chrome://extensions を開く
+osascript -e 'tell application "Google Chrome" to open location "chrome://extensions"' 2>/dev/null || \
+  open "chrome://extensions" 2>/dev/null || \
+  echo "     Chrome を開けない。chrome://extensions に手動で navigate してください。"
+
+echo "  2. 右上の 'Developer mode' を ON"
+echo "  3. 'Load unpacked' を click"
+echo "  4. file picker で: Cmd+Shift+G → paste (clipboard に path あり) → Enter → Select"
+echo "  5. toolbar の uzustack puzzle icon を click → port を入力: ${PORT:-<\$B status を確認>}"
+echo "  6. 'Open Side Panel' を click"

--- a/bin/uzustack-model-benchmark
+++ b/bin/uzustack-model-benchmark
@@ -1,0 +1,168 @@
+#!/usr/bin/env bun
+/**
+ * uzustack-model-benchmark — run the same prompt across multiple providers
+ * and compare latency, tokens, cost, quality, and tool-call count.
+ *
+ * Usage:
+ *   uzustack-model-benchmark <skill-or-prompt-file> [options]
+ *
+ * Options:
+ *   --models claude,gpt,gemini   Comma-separated provider list (default: claude)
+ *   --prompt "<text>"            Inline prompt instead of a file
+ *   --workdir <path>             Working dir passed to each CLI (default: cwd)
+ *   --timeout-ms <n>             Per-provider timeout (default: 300000)
+ *   --output table|json|markdown Output format (default: table)
+ *   --skip-unavailable           Skip providers that fail available() check
+ *                                (default: include them with unavailable marker)
+ *   --judge                      Run Anthropic SDK judge on outputs for quality score
+ *                                (requires ANTHROPIC_API_KEY; adds ~$0.05 per call)
+ *   --dry-run                    Validate flags + resolve auth, don't invoke providers
+ *
+ * Examples:
+ *   uzustack-model-benchmark --prompt "Write a haiku about databases" --models claude,gpt
+ *   uzustack-model-benchmark ./test-prompt.txt --models claude,gpt,gemini --judge
+ *   uzustack-model-benchmark --prompt "hi" --models claude,gpt,gemini --dry-run
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { runBenchmark, formatTable, formatJson, formatMarkdown, type BenchmarkInput } from '../test/helpers/benchmark-runner';
+import { ClaudeAdapter } from '../test/helpers/providers/claude';
+import { GptAdapter } from '../test/helpers/providers/gpt';
+import { GeminiAdapter } from '../test/helpers/providers/gemini';
+
+const ADAPTER_FACTORIES = {
+  claude: () => new ClaudeAdapter(),
+  gpt: () => new GptAdapter(),
+  gemini: () => new GeminiAdapter(),
+};
+
+type OutputFormat = 'table' | 'json' | 'markdown';
+
+function arg(name: string, def?: string): string | undefined {
+  const idx = process.argv.findIndex(a => a === name || a.startsWith(name + '='));
+  if (idx < 0) return def;
+  const eqIdx = process.argv[idx].indexOf('=');
+  if (eqIdx >= 0) return process.argv[idx].slice(eqIdx + 1);
+  return process.argv[idx + 1];
+}
+
+function flag(name: string): boolean {
+  return process.argv.includes(name);
+}
+
+function parseProviders(s: string | undefined): Array<'claude' | 'gpt' | 'gemini'> {
+  if (!s) return ['claude'];
+  const seen = new Set<'claude' | 'gpt' | 'gemini'>();
+  for (const p of s.split(',').map(x => x.trim()).filter(Boolean)) {
+    if (p === 'claude' || p === 'gpt' || p === 'gemini') seen.add(p);
+    else {
+      console.error(`WARN: unknown provider '${p}' — skipping. Valid: claude, gpt, gemini.`);
+    }
+  }
+  return seen.size ? Array.from(seen) : ['claude'];
+}
+
+function resolvePrompt(positional: string | undefined): string {
+  const inline = arg('--prompt');
+  if (inline) return inline;
+  if (!positional) {
+    console.error('ERROR: specify a prompt via positional path or --prompt "<text>"');
+    process.exit(1);
+  }
+  if (fs.existsSync(positional)) {
+    return fs.readFileSync(positional, 'utf-8');
+  }
+  // Not a file — treat as inline prompt
+  return positional;
+}
+
+async function main(): Promise<void> {
+  const positional = process.argv.slice(2).find(a => !a.startsWith('--'));
+  const prompt = resolvePrompt(positional);
+  const providers = parseProviders(arg('--models'));
+  const workdir = arg('--workdir', process.cwd())!;
+  const timeoutMs = parseInt(arg('--timeout-ms', '300000')!, 10);
+  const output = (arg('--output', 'table') as OutputFormat);
+  const skipUnavailable = flag('--skip-unavailable');
+  const doJudge = flag('--judge');
+  const dryRun = flag('--dry-run');
+
+  if (dryRun) {
+    await dryRunReport({ prompt, providers, workdir, timeoutMs, output, doJudge });
+    return;
+  }
+
+  const input: BenchmarkInput = {
+    prompt,
+    workdir,
+    providers,
+    timeoutMs,
+    skipUnavailable,
+  };
+
+  const report = await runBenchmark(input);
+
+  if (doJudge) {
+    try {
+      const { judgeEntries } = await import('../test/helpers/benchmark-judge');
+      await judgeEntries(report);
+    } catch (err) {
+      console.error(`WARN: judge unavailable: ${(err as Error).message}`);
+    }
+  }
+
+  let out: string;
+  switch (output) {
+    case 'json':     out = formatJson(report); break;
+    case 'markdown': out = formatMarkdown(report); break;
+    case 'table':
+    default:         out = formatTable(report); break;
+  }
+  process.stdout.write(out + '\n');
+}
+
+async function dryRunReport(opts: {
+  prompt: string;
+  providers: Array<'claude' | 'gpt' | 'gemini'>;
+  workdir: string;
+  timeoutMs: number;
+  output: OutputFormat;
+  doJudge: boolean;
+}): Promise<void> {
+  const lines: string[] = [];
+  lines.push('== uzustack-model-benchmark --dry-run ==');
+  lines.push(`  prompt:     ${opts.prompt.length > 80 ? opts.prompt.slice(0, 80) + '…' : opts.prompt}`);
+  lines.push(`  providers:  ${opts.providers.join(', ')}`);
+  lines.push(`  workdir:    ${opts.workdir}`);
+  lines.push(`  timeout_ms: ${opts.timeoutMs}`);
+  lines.push(`  output:     ${opts.output}`);
+  lines.push(`  judge:      ${opts.doJudge ? 'on (Anthropic SDK)' : 'off'}`);
+  lines.push('');
+  lines.push('Adapter availability:');
+  let authFailures = 0;
+  for (const name of opts.providers) {
+    const factory = ADAPTER_FACTORIES[name];
+    if (!factory) {
+      lines.push(`  ${name}: UNKNOWN PROVIDER`);
+      authFailures += 1;
+      continue;
+    }
+    const adapter = factory();
+    const check = await adapter.available();
+    if (check.ok) {
+      lines.push(`  ${adapter.name}: OK`);
+    } else {
+      lines.push(`  ${adapter.name}: NOT READY — ${check.reason}`);
+      authFailures += 1;
+    }
+  }
+  lines.push('');
+  lines.push(`(--dry-run — no prompts sent. ${authFailures} provider(s) unavailable.)`);
+  process.stdout.write(lines.join('\n') + '\n');
+}
+
+main().catch(err => {
+  console.error('FATAL:', err);
+  process.exit(1);
+});

--- a/bin/uzustack-question-log
+++ b/bin/uzustack-question-log
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# uzustack-question-log — AskUserQuestion event を project log に append する
+#
+# Usage:
+#   uzustack-question-log '{"skill":"ship","question_id":"ship-test-failure-triage",\
+#     "question_summary":"Tests failed","options_count":3,"user_choice":"fix-now",\
+#     "recommended":"fix-now","session_id":"ppid"}'
+#
+# v1: log のみ。/plan-tune の inspection と (v2 で) inferred-dimension derivation
+# pipeline が consume する。
+#
+# Schema (全 field 検証):
+#   skill              — skill 名 (kebab-case)
+#   question_id        — 登録済 id (推奨) または ad-hoc `{skill}-{slug}`
+#   question_summary   — 質問内容の 1 行 summary (<= 200 chars)
+#   category           — approval | clarification | routing | cherry-pick | feedback-loop
+#                        (省略時は registry から lookup)
+#   door_type          — one-way | two-way
+#                        (省略時は registry から lookup)
+#   options_count      — 提示された options 数 (positive integer)
+#   user_choice        — user 選択 key (free string、registry-options が望ましい)
+#   recommended        — agent 推奨 option key (optional)
+#   followed_recommendation — bool (optional、両方ある時に算出)
+#   session_id         — 安定 session identifier
+#   ts                 — ISO 8601 timestamp (未指定時は auto-inject)
+#
+# Append-only JSONL。dedup は read 時 (uzustack-question-sensitivity --read-log) に行う。
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+eval "$("$SCRIPT_DIR/uzustack-slug" 2>/dev/null)"
+UZUSTACK_HOME="${UZUSTACK_HOME:-$HOME/.uzustack}"
+mkdir -p "$UZUSTACK_HOME/projects/$SLUG"
+
+INPUT="$1"
+
+# 検証 + registry からの enrich
+TMPERR=$(mktemp)
+trap 'rm -f "$TMPERR"' EXIT
+set +e
+VALIDATED=$(printf '%s' "$INPUT" | bun -e "
+const path = require('path');
+const raw = await Bun.stdin.text();
+let j;
+try { j = JSON.parse(raw); } catch { process.stderr.write('uzustack-question-log: invalid JSON\n'); process.exit(1); }
+
+// Required: skill (kebab-case)
+if (!j.skill || !/^[a-z0-9-]+\$/.test(j.skill)) {
+  process.stderr.write('uzustack-question-log: invalid skill, must be kebab-case\n');
+  process.exit(1);
+}
+
+// Required: question_id (kebab-case, <=64 chars)
+if (!j.question_id || !/^[a-z0-9-]+\$/.test(j.question_id) || j.question_id.length > 64) {
+  process.stderr.write('uzustack-question-log: invalid question_id, must be kebab-case <=64 chars\n');
+  process.exit(1);
+}
+
+// Required: question_summary (non-empty, <=200 chars, no newlines)
+if (typeof j.question_summary !== 'string' || !j.question_summary.length) {
+  process.stderr.write('uzustack-question-log: question_summary required\n');
+  process.exit(1);
+}
+if (j.question_summary.length > 200) {
+  j.question_summary = j.question_summary.slice(0, 200);
+}
+if (j.question_summary.includes('\n')) {
+  j.question_summary = j.question_summary.replace(/\n+/g, ' ');
+}
+
+// summary に対する injection 防御 — learnings-log と同 pattern
+const INJECTION_PATTERNS = [
+  /ignore\s+(all\s+)?previous\s+(instructions|context|rules)/i,
+  /you\s+are\s+now\s+/i,
+  /always\s+output\s+no\s+findings/i,
+  /skip\s+(all\s+)?(security|review|checks)/i,
+  /override[:\s]/i,
+  /\bsystem\s*:/i,
+  /\bassistant\s*:/i,
+  /\buser\s*:/i,
+  /do\s+not\s+(report|flag|mention)/i,
+];
+for (const pat of INJECTION_PATTERNS) {
+  if (pat.test(j.question_summary)) {
+    process.stderr.write('uzustack-question-log: question_summary contains suspicious instruction-like content, rejected\n');
+    process.exit(1);
+  }
+}
+
+// category + door_type の registry lookup による enrichment。
+// Registry file は \$UZUSTACK_ROOT/scripts/question-registry.ts、ただし TypeScript
+// を runtime で import しない — 渡された値を pass-through し default で埋める。
+// caller (preamble resolver) が registry から知っている category + door_type を
+// 渡す前提、ad-hoc id では両方とも省略可。
+
+const ALLOWED_CATEGORIES = ['approval', 'clarification', 'routing', 'cherry-pick', 'feedback-loop'];
+if (j.category !== undefined) {
+  if (!ALLOWED_CATEGORIES.includes(j.category)) {
+    process.stderr.write('uzustack-question-log: invalid category, must be one of: ' + ALLOWED_CATEGORIES.join(', ') + '\n');
+    process.exit(1);
+  }
+}
+
+const ALLOWED_DOORS = ['one-way', 'two-way'];
+if (j.door_type !== undefined) {
+  if (!ALLOWED_DOORS.includes(j.door_type)) {
+    process.stderr.write('uzustack-question-log: invalid door_type, must be one-way or two-way\n');
+    process.exit(1);
+  }
+}
+
+// options_count — 指定時は positive integer
+if (j.options_count !== undefined) {
+  const n = Number(j.options_count);
+  if (!Number.isInteger(n) || n < 1 || n > 26) {
+    process.stderr.write('uzustack-question-log: options_count must be integer in [1, 26]\n');
+    process.exit(1);
+  }
+  j.options_count = n;
+}
+
+// user_choice — required、<= 64 chars、single-line、injection pattern 不可
+if (typeof j.user_choice !== 'string' || !j.user_choice.length) {
+  process.stderr.write('uzustack-question-log: user_choice required\n');
+  process.exit(1);
+}
+if (j.user_choice.length > 64) j.user_choice = j.user_choice.slice(0, 64);
+j.user_choice = j.user_choice.replace(/\n+/g, ' ');
+
+// recommended — optional、user_choice と同 constraint
+if (j.recommended !== undefined) {
+  if (typeof j.recommended !== 'string') {
+    process.stderr.write('uzustack-question-log: recommended must be string\n');
+    process.exit(1);
+  }
+  if (j.recommended.length > 64) j.recommended = j.recommended.slice(0, 64);
+}
+
+// followed_recommendation — 両方ある時に算出
+if (j.recommended !== undefined && j.user_choice !== undefined) {
+  j.followed_recommendation = j.user_choice === j.recommended;
+}
+
+// session_id — kebab-friendly、<=64 chars
+if (j.session_id !== undefined) {
+  if (typeof j.session_id !== 'string') {
+    process.stderr.write('uzustack-question-log: session_id must be string\n');
+    process.exit(1);
+  }
+  if (j.session_id.length > 64) j.session_id = j.session_id.slice(0, 64);
+}
+
+// timestamp 未指定なら inject
+if (!j.ts) j.ts = new Date().toISOString();
+
+console.log(JSON.stringify(j));
+" 2>"$TMPERR")
+VALIDATE_RC=$?
+set -e
+
+if [ $VALIDATE_RC -ne 0 ] || [ -z "$VALIDATED" ]; then
+  if [ -s "$TMPERR" ]; then
+    cat "$TMPERR" >&2
+  fi
+  exit 1
+fi
+
+echo "$VALIDATED" >> "$UZUSTACK_HOME/projects/$SLUG/question-log.jsonl"
+
+# NOTE: question-log.jsonl は意図的に gbrain-sync の enqueue 対象外。
+# Codex v2 review に従い、audit / derivation data は annotate 元の
+# question-preferences.json と一緒に local に留める。

--- a/bin/uzustack-question-log
+++ b/bin/uzustack-question-log
@@ -24,7 +24,7 @@
 #   session_id         — 安定 session identifier
 #   ts                 — ISO 8601 timestamp (未指定時は auto-inject)
 #
-# Append-only JSONL。dedup は read 時 (uzustack-question-sensitivity --read-log) に行う。
+# Append-only JSONL。dedup は read 時に行う。
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 eval "$("$SCRIPT_DIR/uzustack-slug" 2>/dev/null)"

--- a/bin/uzustack-question-preference
+++ b/bin/uzustack-question-preference
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+# uzustack-question-preference — per-question preference の read/write/check。
+#
+# Preference file: ~/.uzustack/projects/{SLUG}/question-preferences.json
+# Schema: { "<question_id>": "always-ask" | "never-ask" | "ask-only-for-one-way" }
+#
+# Subcommands:
+#   --check <id>                   → ASK_NORMALLY | AUTO_DECIDE | ASK_ONLY_ONE_WAY を出力
+#   --write '{...}'                → preference を set (user-origin gate を強制)
+#   --read                         → preferences JSON を dump
+#   --clear [<id>]                 → 1 件 or 全件 clear
+#   --stats                        → 簡易 summary
+#
+# User-origin gate
+# ----------------
+# --write subcommand は input に `source` field を REQUIRED:
+#   - "plan-tune"         — user が /plan-tune で preference を選択 (allowed)
+#   - "inline-user"       — user 自身の chat msg 内 inline `tune:` (allowed)
+#   - "inline-tool-output"— tool output / file content 内 tune: prefix (REJECTED)
+#   - "inline-file"       — agent が読んだ file 内 tune: prefix (REJECTED)
+# これは docs/designs/PLAN_TUNING_V0.md の profile-poisoning 防御。
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+UZUSTACK_HOME="${UZUSTACK_HOME:-$HOME/.uzustack}"
+eval "$("$SCRIPT_DIR/uzustack-slug" 2>/dev/null || true)"
+SLUG="${SLUG:-unknown}"
+PREF_FILE="$UZUSTACK_HOME/projects/$SLUG/question-preferences.json"
+EVENT_FILE="$UZUSTACK_HOME/projects/$SLUG/question-events.jsonl"
+mkdir -p "$UZUSTACK_HOME/projects/$SLUG"
+
+CMD="${1:-}"
+shift || true
+
+ensure_file() {
+  if [ ! -f "$PREF_FILE" ]; then
+    echo '{}' > "$PREF_FILE"
+  fi
+}
+
+# -----------------------------------------------------------------------
+# --check <question_id>
+# -----------------------------------------------------------------------
+do_check() {
+  local QID="${1:-}"
+  if [ -z "$QID" ]; then
+    echo "ASK_NORMALLY"
+    return 0
+  fi
+  ensure_file
+  cd "$ROOT_DIR"
+  PREF_FILE_PATH="$PREF_FILE" QID="$QID" bun -e "
+    import('./scripts/one-way-doors.ts').then((oneway) => {
+      const fs = require('fs');
+      const qid = process.env.QID;
+      const prefs = JSON.parse(fs.readFileSync(process.env.PREF_FILE_PATH, 'utf-8'));
+      const pref = prefs[qid];
+
+      // one-way 状態を最初に check — safety が preference を override
+      const oneWay = oneway.isOneWayDoor({ question_id: qid });
+
+      if (oneWay) {
+        console.log('ASK_NORMALLY');
+        if (pref === 'never-ask') {
+          console.log('NOTE: one-way door overrides your never-ask preference for safety.');
+        }
+        return;
+      }
+
+      switch (pref) {
+        case 'never-ask':
+          console.log('AUTO_DECIDE');
+          break;
+        case 'ask-only-for-one-way':
+          // one-way ではない (上で check 済) → 2-way question を auto-decide
+          console.log('AUTO_DECIDE');
+          break;
+        case 'always-ask':
+        case undefined:
+        case null:
+          console.log('ASK_NORMALLY');
+          break;
+        default:
+          console.log('ASK_NORMALLY');
+          console.log('NOTE: unknown preference value: ' + pref);
+      }
+    }).catch(err => { console.error('check:', err.message); process.exit(1); });
+  "
+}
+
+# -----------------------------------------------------------------------
+# --write '{...}' (user-origin gate あり)
+# -----------------------------------------------------------------------
+do_write() {
+  local INPUT="${1:-}"
+  if [ -z "$INPUT" ]; then
+    echo "uzustack-question-preference: --write requires a JSON payload" >&2
+    exit 1
+  fi
+  ensure_file
+  local TMPERR
+  TMPERR=$(mktemp)
+  # function-local cleanup を RETURN trap で行う (関数が stack に居る間のみ
+  # variable lookup が走り、EXIT-trap の unbound-var race を避ける)
+  trap "rm -f '$TMPERR'" RETURN
+
+  set +e
+  local RESULT
+  RESULT=$(printf '%s' "$INPUT" | PREF_FILE_PATH="$PREF_FILE" EVENT_FILE_PATH="$EVENT_FILE" bun -e "
+    const fs = require('fs');
+    const raw = await Bun.stdin.text();
+    let j;
+    try { j = JSON.parse(raw); } catch { process.stderr.write('uzustack-question-preference: invalid JSON\n'); process.exit(1); }
+
+    // Required: question_id (kebab-case, <=64)
+    if (!j.question_id || !/^[a-z0-9-]+\$/.test(j.question_id) || j.question_id.length > 64) {
+      process.stderr.write('uzustack-question-preference: invalid question_id\n');
+      process.exit(1);
+    }
+
+    // Required: preference
+    const ALLOWED_PREFS = ['always-ask', 'never-ask', 'ask-only-for-one-way'];
+    if (!ALLOWED_PREFS.includes(j.preference)) {
+      process.stderr.write('uzustack-question-preference: invalid preference (must be one of: ' + ALLOWED_PREFS.join(', ') + ')\n');
+      process.exit(1);
+    }
+
+    // user-origin gate — every write で REQUIRED
+    // docs/designs/PLAN_TUNING_V0.md §Security model 参照
+    const ALLOWED_SOURCES = ['plan-tune', 'inline-user'];
+    const REJECTED_SOURCES = ['inline-tool-output', 'inline-file', 'inline-file-content', 'inline-unknown'];
+    if (!j.source) {
+      process.stderr.write('uzustack-question-preference: source field required (one of: ' + ALLOWED_SOURCES.join(', ') + ')\n');
+      process.exit(1);
+    }
+    if (REJECTED_SOURCES.includes(j.source)) {
+      process.stderr.write('uzustack-question-preference: rejected — source \"' + j.source + '\" is not user-originated (profile poisoning defense)\n');
+      process.exit(2);
+    }
+    if (!ALLOWED_SOURCES.includes(j.source)) {
+      process.stderr.write('uzustack-question-preference: invalid source \"' + j.source + '\"; allowed: ' + ALLOWED_SOURCES.join(', ') + '\n');
+      process.exit(1);
+    }
+
+    // Optional free_text — sanitize (injection pattern 不可、改行 不可、<=300 chars)
+    if (j.free_text !== undefined) {
+      if (typeof j.free_text !== 'string') {
+        process.stderr.write('uzustack-question-preference: free_text must be string\n');
+        process.exit(1);
+      }
+      if (j.free_text.length > 300) j.free_text = j.free_text.slice(0, 300);
+      j.free_text = j.free_text.replace(/\n+/g, ' ');
+      const INJECTION_PATTERNS = [
+        /ignore\s+(all\s+)?previous\s+(instructions|context|rules)/i,
+        /you\s+are\s+now\s+/i,
+        /override[:\s]/i,
+        /\bsystem\s*:/i,
+        /\bassistant\s*:/i,
+        /do\s+not\s+(report|flag|mention)/i,
+      ];
+      for (const pat of INJECTION_PATTERNS) {
+        if (pat.test(j.free_text)) {
+          process.stderr.write('uzustack-question-preference: free_text contains injection-like content, rejected\n');
+          process.exit(1);
+        }
+      }
+    }
+
+    // preferences file へ書き込み
+    const prefs = JSON.parse(fs.readFileSync(process.env.PREF_FILE_PATH, 'utf-8'));
+    prefs[j.question_id] = j.preference;
+    fs.writeFileSync(process.env.PREF_FILE_PATH, JSON.stringify(prefs, null, 2));
+
+    // audit + derivation 用に question-events.jsonl にも record を append
+    const evt = {
+      ts: new Date().toISOString(),
+      event_type: 'preference-set',
+      question_id: j.question_id,
+      preference: j.preference,
+      source: j.source,
+      ...(j.free_text ? { free_text: j.free_text } : {}),
+    };
+    fs.appendFileSync(process.env.EVENT_FILE_PATH, JSON.stringify(evt) + '\n');
+
+    console.log('OK: ' + j.question_id + ' → ' + j.preference + ' (source: ' + j.source + ')');
+  " 2>"$TMPERR")
+  local RC=$?
+  set -e
+
+  if [ $RC -ne 0 ]; then
+    cat "$TMPERR" >&2
+    exit $RC
+  fi
+  echo "$RESULT"
+}
+
+# -----------------------------------------------------------------------
+# --read
+# -----------------------------------------------------------------------
+do_read() {
+  ensure_file
+  cat "$PREF_FILE"
+}
+
+# -----------------------------------------------------------------------
+# --clear [<id>]
+# -----------------------------------------------------------------------
+do_clear() {
+  local QID="${1:-}"
+  ensure_file
+  if [ -z "$QID" ]; then
+    echo '{}' > "$PREF_FILE"
+    echo "OK: cleared all preferences"
+  else
+    PREF_FILE_PATH="$PREF_FILE" QID="$QID" bun -e "
+      const fs = require('fs');
+      const prefs = JSON.parse(fs.readFileSync(process.env.PREF_FILE_PATH, 'utf-8'));
+      if (prefs[process.env.QID] !== undefined) {
+        delete prefs[process.env.QID];
+        fs.writeFileSync(process.env.PREF_FILE_PATH, JSON.stringify(prefs, null, 2));
+        console.log('OK: cleared ' + process.env.QID);
+      } else {
+        console.log('NOOP: no preference set for ' + process.env.QID);
+      }
+    "
+  fi
+}
+
+# -----------------------------------------------------------------------
+# --stats
+# -----------------------------------------------------------------------
+do_stats() {
+  ensure_file
+  cat "$PREF_FILE" | bun -e "
+    const prefs = JSON.parse(await Bun.stdin.text());
+    const entries = Object.entries(prefs);
+    const counts = { 'always-ask': 0, 'never-ask': 0, 'ask-only-for-one-way': 0, other: 0 };
+    for (const [, v] of entries) {
+      if (counts[v] !== undefined) counts[v]++;
+      else counts.other++;
+    }
+    console.log('TOTAL: ' + entries.length);
+    console.log('ALWAYS_ASK: ' + counts['always-ask']);
+    console.log('NEVER_ASK: ' + counts['never-ask']);
+    console.log('ASK_ONLY_ONE_WAY: ' + counts['ask-only-for-one-way']);
+    if (counts.other) console.log('OTHER: ' + counts.other);
+  "
+}
+
+case "$CMD" in
+  --check) do_check "$@" ;;
+  --write) do_write "$@" ;;
+  --read|"") do_read ;;
+  --clear) do_clear "$@" ;;
+  --stats) do_stats ;;
+  --help|-h) sed -n '1,/^set -euo/p' "$0" | sed 's|^# \?||' ;;
+  *)
+    echo "uzustack-question-preference: unknown subcommand '$CMD'" >&2
+    exit 1
+    ;;
+esac

--- a/bin/uzustack-repo-mode
+++ b/bin/uzustack-repo-mode
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# uzustack-repo-mode — solo / collaborative の repo mode を判定
+# Usage: source <(uzustack-repo-mode)  → REPO_MODE 変数を set
+# Or:    uzustack-repo-mode            → REPO_MODE=... 行を print
+#
+# 判定 heuristic (90 日 window):
+#   Solo:          top author >= 80% of commits
+#   Collaborative: top author < 80%
+#
+# Override: uzustack-config set repo_mode solo|collaborative
+# Cache:    ~/.uzustack/projects/$SLUG/repo-mode.json (7-day TTL)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# SLUG を直接計算 (uzustack-slug の eval は branch 名が shell metacharacter を含み得るので避ける)
+REMOTE_URL=$(git remote get-url origin 2>/dev/null || true)
+if [ -z "$REMOTE_URL" ]; then
+  echo "REPO_MODE=unknown"
+  exit 0
+fi
+SLUG=$(echo "$REMOTE_URL" | sed 's|.*[:/]\([^/]*/[^/]*\)\.git$|\1|;s|.*[:/]\([^/]*/[^/]*\)$|\1|' | tr '/' '-')
+[ -z "${SLUG:-}" ] && { echo "REPO_MODE=unknown"; exit 0; }
+
+# 入力検証: 既知の値のみ allow (source <(...) 経由の shell injection を防ぐ)
+validate_mode() {
+  case "$1" in solo|collaborative|unknown) echo "$1" ;; *) echo "unknown" ;; esac
+}
+
+# Config override が最優先
+OVERRIDE=$("$SCRIPT_DIR/uzustack-config" get repo_mode 2>/dev/null || true)
+if [ -n "$OVERRIDE" ] && [ "$OVERRIDE" != "null" ]; then
+  echo "REPO_MODE=$(validate_mode "$OVERRIDE")"
+  exit 0
+fi
+
+# Cache 確認 (7-day TTL)
+CACHE_DIR="$HOME/.uzustack/projects/$SLUG"
+CACHE_FILE="$CACHE_DIR/repo-mode.json"
+if [ -f "$CACHE_FILE" ]; then
+  CACHE_AGE=$(( $(date +%s) - $(stat -f %m "$CACHE_FILE" 2>/dev/null || stat -c %Y "$CACHE_FILE" 2>/dev/null || echo 0) ))
+  if [ "$CACHE_AGE" -lt 604800 ]; then  # 7 日 (秒)
+    MODE=$(grep -o '"mode":"[^"]*"' "$CACHE_FILE" | head -1 | cut -d'"' -f4)
+    [ -n "$MODE" ] && echo "REPO_MODE=$(validate_mode "$MODE")" && exit 0
+  fi
+fi
+
+# git history から計算 (90 日 window)
+# default branch を使う (HEAD は feature-branch sampling bias を生む)
+DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/||' || true)
+# Fallback: origin/main → origin/master → HEAD の順
+if [ -z "$DEFAULT_BRANCH" ]; then
+  if git rev-parse --verify origin/main &>/dev/null; then
+    DEFAULT_BRANCH="origin/main"
+  elif git rev-parse --verify origin/master &>/dev/null; then
+    DEFAULT_BRANCH="origin/master"
+  else
+    DEFAULT_BRANCH="HEAD"
+  fi
+fi
+SHORTLOG=$(git shortlog -sn --since="90 days ago" --no-merges "$DEFAULT_BRANCH" 2>/dev/null)
+if [ -z "$SHORTLOG" ]; then
+  echo "REPO_MODE=unknown"
+  exit 0
+fi
+
+# TOTAL は全 author で計算 (truncate しない、solo bias を避ける)
+TOTAL=$(echo "$SHORTLOG" | awk '{s+=$1} END {print s}')
+TOP=$(echo "$SHORTLOG" | head -1 | awk '{print $1}')
+AUTHORS=$(echo "$SHORTLOG" | wc -l | tr -d ' ')
+
+# 最小 sample: 5 commit 以上ないと判定しない
+if [ "$TOTAL" -lt 5 ]; then
+  echo "REPO_MODE=unknown"
+  exit 0
+fi
+
+TOP_PCT=$(( TOP * 100 / TOTAL ))
+
+# Solo: top author >= 80% (たまの outside PR では mode 変わらない)
+if [ "$TOP_PCT" -ge 80 ]; then
+  MODE=solo
+else
+  MODE=collaborative
+fi
+
+# 結果を atomic に cache (~/.uzustack が unwritable なら silently fail)
+mkdir -p "$CACHE_DIR" 2>/dev/null || true
+CACHE_TMP=$(mktemp "$CACHE_DIR/.repo-mode-XXXXXX" 2>/dev/null || true)
+if [ -n "$CACHE_TMP" ]; then
+  echo "{\"mode\":\"$MODE\",\"top_pct\":$TOP_PCT,\"authors\":$AUTHORS,\"total\":$TOTAL,\"computed\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" > "$CACHE_TMP" 2>/dev/null && mv "$CACHE_TMP" "$CACHE_FILE" 2>/dev/null || rm -f "$CACHE_TMP" 2>/dev/null
+fi
+
+echo "REPO_MODE=$MODE"

--- a/bin/uzustack-review-log
+++ b/bin/uzustack-review-log
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# uzustack-review-log — review 結果を atomic に log する
+# Usage: uzustack-review-log '{"skill":"...","timestamp":"...","status":"..."}'
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+eval "$("$SCRIPT_DIR/uzustack-slug" 2>/dev/null)"
+UZUSTACK_HOME="${UZUSTACK_HOME:-$HOME/.uzustack}"
+mkdir -p "$UZUSTACK_HOME/projects/$SLUG"
+
+# 入力検証: parseable な JSON のみ受け付け (malformed / injection を reject)
+INPUT="$1"
+if ! printf '%s' "$INPUT" | bun -e "JSON.parse(await Bun.stdin.text())" 2>/dev/null; then
+  # JSON として invalid、append しない
+  echo "uzustack-review-log: invalid JSON、append を skip" >&2
+  exit 1
+fi
+
+echo "$INPUT" >> "$UZUSTACK_HOME/projects/$SLUG/$BRANCH-reviews.jsonl"
+
+# gbrain-sync: cross-machine sync 用に enqueue (sync off 時は no-op)
+"$SCRIPT_DIR/uzustack-brain-enqueue" "projects/$SLUG/$BRANCH-reviews.jsonl" 2>/dev/null &

--- a/bin/uzustack-review-read
+++ b/bin/uzustack-review-read
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# uzustack-review-read — review log と config を dashboard 向けに読み出す
+# Usage: uzustack-review-read
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+eval "$("$SCRIPT_DIR/uzustack-slug" 2>/dev/null)"
+UZUSTACK_HOME="${UZUSTACK_HOME:-$HOME/.uzustack}"
+cat "$UZUSTACK_HOME/projects/$SLUG/$BRANCH-reviews.jsonl" 2>/dev/null || echo "NO_REVIEWS"
+echo "---CONFIG---"
+"$SCRIPT_DIR/uzustack-config" get skip_eng_review 2>/dev/null || echo "false"
+echo "---HEAD---"
+git rev-parse --short HEAD 2>/dev/null || echo "unknown"

--- a/bin/uzustack-security-dashboard
+++ b/bin/uzustack-security-dashboard
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# uzustack-security-dashboard — community 全体の prompt-injection 攻撃統計
+#
+# community-pulse edge function response の `security` section を読む
+# (supabase/functions/community-pulse/index.ts)。telemetry=community の uzustack
+# user 全体で集計された attack data を表示する。
+#
+# Call signature:
+#   uzustack-security-dashboard           # human-readable dashboard
+#   uzustack-security-dashboard --json    # machine-readable (CI / scripts)
+#
+# Env override (test 用):
+#   UZUSTACK_DIR                    — auto-detected uzustack root を override
+#   UZUSTACK_SUPABASE_URL           — Supabase project URL を override
+#   UZUSTACK_SUPABASE_ANON_KEY      — Supabase anon key を override
+set -uo pipefail
+
+UZUSTACK_DIR="${UZUSTACK_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+
+# Supabase config を source
+if [ -z "${UZUSTACK_SUPABASE_URL:-}" ] && [ -f "$UZUSTACK_DIR/supabase/config.sh" ]; then
+  . "$UZUSTACK_DIR/supabase/config.sh"
+fi
+SUPABASE_URL="${UZUSTACK_SUPABASE_URL:-}"
+ANON_KEY="${UZUSTACK_SUPABASE_ANON_KEY:-}"
+
+JSON_MODE=0
+[ "${1:-}" = "--json" ] && JSON_MODE=1
+
+if [ -z "$SUPABASE_URL" ] || [ -z "$ANON_KEY" ]; then
+  if [ "$JSON_MODE" = "1" ]; then
+    echo '{"error":"supabase_not_configured"}'
+    exit 0
+  fi
+  echo "uzustack security dashboard"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
+  echo "Supabase not configured. Local log at ~/.uzustack/security/attempts.jsonl"
+  echo "still captures every attempt — tail it with:"
+  echo "  cat ~/.uzustack/security/attempts.jsonl | tail -20"
+  exit 0
+fi
+
+DATA="$(curl -sf --max-time 15 \
+  "${SUPABASE_URL}/functions/v1/community-pulse" \
+  -H "apikey: ${ANON_KEY}" \
+  2>/dev/null || echo "{}")"
+
+# security section を抽出。jq が ある場合は brace-balanced parse (top_attack_domains 等の
+# nested array/object を正確に処理) を優先。jq 無い時は regex に fallback —
+# regex は lossy だが dashboard が "0 attacks" に degrade する方が誤集計より安全。
+if command -v jq >/dev/null 2>&1; then
+  SEC_SECTION="$(echo "$DATA" | jq -rc '.security // empty | "\"security\":\(.)"' 2>/dev/null || echo "")"
+else
+  SEC_SECTION="$(echo "$DATA" | grep -o '"security":{[^}]*}' 2>/dev/null || echo "")"
+fi
+
+if [ "$JSON_MODE" = "1" ]; then
+  # Machine-readable — security section 全体 (or empty object) を echo
+  if [ -n "$SEC_SECTION" ]; then
+    echo "{${SEC_SECTION}}"
+  else
+    echo '{"security":{"attacks_last_7_days":0,"top_attack_domains":[],"top_attack_layers":[],"verdict_distribution":[]}}'
+  fi
+  exit 0
+fi
+
+# Human-readable dashboard
+echo "uzustack security dashboard"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+TOTAL="$(echo "$DATA" | grep -o '"attacks_last_7_days":[0-9]*' | grep -o '[0-9]*' | head -1 || echo "0")"
+echo "Attacks detected last 7 days: ${TOTAL}"
+if [ "$TOTAL" = "0" ]; then
+  echo "  (No attack attempts reported by the community yet. Good news.)"
+fi
+echo ""
+
+# 攻撃された top domain — top_attack_domains array 内の object を parse
+DOMAINS="$(echo "$DATA" | sed -n 's/.*"top_attack_domains":\(\[[^]]*\]\).*/\1/p' | head -1)"
+if [ -n "$DOMAINS" ] && [ "$DOMAINS" != "[]" ]; then
+  echo "Top attacked domains"
+  echo "────────────────────"
+  echo "$DOMAINS" | grep -o '{[^}]*}' | head -10 | while read -r OBJ; do
+    DOMAIN="$(echo "$OBJ" | grep -o '"domain":"[^"]*"' | awk -F'"' '{print $4}')"
+    COUNT="$(echo "$OBJ" | grep -o '"count":[0-9]*' | grep -o '[0-9]*')"
+    [ -n "$DOMAIN" ] && [ -n "$COUNT" ] && printf "  %-40s %s attempts\n" "$DOMAIN" "$COUNT"
+  done
+  echo ""
+fi
+
+# 攻撃を catch した layer
+LAYERS="$(echo "$DATA" | sed -n 's/.*"top_attack_layers":\(\[[^]]*\]\).*/\1/p' | head -1)"
+if [ -n "$LAYERS" ] && [ "$LAYERS" != "[]" ]; then
+  echo "Top detection layers"
+  echo "────────────────────"
+  echo "$LAYERS" | grep -o '{[^}]*}' | while read -r OBJ; do
+    LAYER="$(echo "$OBJ" | grep -o '"layer":"[^"]*"' | awk -F'"' '{print $4}')"
+    COUNT="$(echo "$OBJ" | grep -o '"count":[0-9]*' | grep -o '[0-9]*')"
+    [ -n "$LAYER" ] && [ -n "$COUNT" ] && printf "  %-28s %s\n" "$LAYER" "$COUNT"
+  done
+  echo ""
+fi
+
+# Verdict 分布
+VERDICTS="$(echo "$DATA" | sed -n 's/.*"verdict_distribution":\(\[[^]]*\]\).*/\1/p' | head -1)"
+if [ -n "$VERDICTS" ] && [ "$VERDICTS" != "[]" ]; then
+  echo "Verdict distribution"
+  echo "────────────────────"
+  echo "$VERDICTS" | grep -o '{[^}]*}' | while read -r OBJ; do
+    VERDICT="$(echo "$OBJ" | grep -o '"verdict":"[^"]*"' | awk -F'"' '{print $4}')"
+    COUNT="$(echo "$OBJ" | grep -o '"count":[0-9]*' | grep -o '[0-9]*')"
+    [ -n "$VERDICT" ] && [ -n "$COUNT" ] && printf "  %-14s %s\n" "$VERDICT" "$COUNT"
+  done
+  echo ""
+fi
+
+echo "Your local log: ~/.uzustack/security/attempts.jsonl"
+echo "Your telemetry mode: $(${UZUSTACK_DIR}/bin/uzustack-config get telemetry 2>/dev/null || echo unknown)"

--- a/bin/uzustack-session-update
+++ b/bin/uzustack-session-update
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# uzustack-session-update — session start 時に uzustack を auto-update (team mode)
+#
+# Claude Code SessionStart hook から呼ばれる。fast / silent / non-fatal が必須。
+# update 全体は background (fork) で走り、hook 自体は即 exit する。session
+# 起動が遅延しないよう設計されている。
+#
+# Always exit 0 — error は Claude Code session を絶対 block してはならない。
+
+set +e
+
+UZUSTACK_DIR="${UZUSTACK_DIR:-$HOME/.claude/skills/uzustack}"
+STATE_DIR="${UZUSTACK_STATE_DIR:-$HOME/.uzustack}"
+THROTTLE_FILE="$STATE_DIR/.last-session-update"
+LOCK_DIR="$STATE_DIR/.setup-lock"
+LOG_FILE="$STATE_DIR/analytics/session-update.log"
+THROTTLE_SECONDS=3600  # 1 時間
+
+log_entry() {
+  mkdir -p "$(dirname "$LOG_FILE")"
+  echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) $1" >> "$LOG_FILE" 2>/dev/null || true
+}
+
+# ── Guard: uzustack は git repo であること ──
+if [ ! -d "$UZUSTACK_DIR/.git" ]; then
+  exit 0
+fi
+
+# ── Guard: team mode が有効であること ──
+AUTO=$("$UZUSTACK_DIR/bin/uzustack-config" get auto_upgrade 2>/dev/null || true)
+if [ "$AUTO" != "true" ]; then
+  exit 0
+fi
+
+# ── Throttle: 直近に check 済なら skip ──
+if [ -f "$THROTTLE_FILE" ]; then
+  LAST=$(cat "$THROTTLE_FILE" 2>/dev/null || echo 0)
+  NOW=$(date +%s)
+  ELAPSED=$(( NOW - LAST ))
+  if [ "$ELAPSED" -lt "$THROTTLE_SECONDS" ]; then
+    exit 0
+  fi
+fi
+
+# ── background に fork: session start の latency を 0 にする ──
+(
+  # git が credential prompt を出さないよう抑止 (background process が hang する)
+  export GIT_TERMINAL_PROMPT=0
+
+  mkdir -p "$STATE_DIR"
+
+  # ── lockfile を取得 (別 session が setup 中なら skip) ──
+  if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+    # Lock 存在 — stale (PID 死) かどうか確認
+    if [ -f "$LOCK_DIR/pid" ]; then
+      LOCK_PID=$(cat "$LOCK_DIR/pid" 2>/dev/null || echo 0)
+      if [ "$LOCK_PID" -gt 0 ] 2>/dev/null && ! kill -0 "$LOCK_PID" 2>/dev/null; then
+        # Stale lock — 削除して再取得
+        rm -rf "$LOCK_DIR" 2>/dev/null
+        mkdir "$LOCK_DIR" 2>/dev/null || { log_entry "SKIP lock_contested"; exit 0; }
+      else
+        log_entry "SKIP locked_by=$LOCK_PID"
+        exit 0
+      fi
+    else
+      log_entry "SKIP locked_no_pid"
+      exit 0
+    fi
+  fi
+
+  # stale lock 検出用に PID を書き込む
+  echo $$ > "$LOCK_DIR/pid" 2>/dev/null
+
+  # exit 時に lock を cleanup
+  trap 'rm -rf "$LOCK_DIR" 2>/dev/null' EXIT
+
+  # ── 最新を pull ──
+  OLD_HEAD=$(git -C "$UZUSTACK_DIR" rev-parse HEAD 2>/dev/null)
+  git -C "$UZUSTACK_DIR" pull --ff-only -q 2>/dev/null
+  PULL_EXIT=$?
+  NEW_HEAD=$(git -C "$UZUSTACK_DIR" rev-parse HEAD 2>/dev/null)
+
+  # outcome に関わらず check 時刻を記録
+  date +%s > "$THROTTLE_FILE" 2>/dev/null
+
+  if [ "$PULL_EXIT" -ne 0 ]; then
+    log_entry "PULL_FAILED exit=$PULL_EXIT"
+    exit 0
+  fi
+
+  # ── HEAD が move した場合、setup -q を実行 ──
+  if [ "$OLD_HEAD" != "$NEW_HEAD" ]; then
+    log_entry "UPDATING old=$OLD_HEAD new=$NEW_HEAD"
+
+    # setup には bun が必要
+    if command -v bun >/dev/null 2>&1; then
+      ( cd "$UZUSTACK_DIR" && ./setup -q ) >/dev/null 2>&1 || {
+        log_entry "SETUP_FAILED"
+      }
+    else
+      log_entry "SETUP_SKIPPED bun_missing"
+    fi
+
+    # 次の skill preamble で "just upgraded" を表示するための marker を書く
+    OLD_VER=$(git -C "$UZUSTACK_DIR" show "$OLD_HEAD:VERSION" 2>/dev/null || echo "unknown")
+    echo "$OLD_VER" > "$STATE_DIR/just-upgraded-from" 2>/dev/null
+    rm -f "$STATE_DIR/last-update-check" 2>/dev/null
+    rm -f "$STATE_DIR/update-snoozed" 2>/dev/null
+
+    log_entry "UPDATED from=$OLD_VER to=$(cat "$UZUSTACK_DIR/VERSION" 2>/dev/null || echo unknown)"
+  else
+    log_entry "UP_TO_DATE head=$OLD_HEAD"
+  fi
+) &
+
+exit 0

--- a/bin/uzustack-settings-hook
+++ b/bin/uzustack-settings-hook
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# uzustack-settings-hook — Claude Code settings.json に SessionStart hook を追加 / 削除
+#
+# Usage:
+#   uzustack-settings-hook add <hook-command>     # SessionStart hook を追加
+#   uzustack-settings-hook remove <hook-command>  # SessionStart hook を削除
+#
+# Requires: bun (uzustack の hard dependency)
+# Atomic 書き込み: .tmp + rename で crash / disk-full 時の corruption を防ぐ。
+
+set -euo pipefail
+
+ACTION="${1:-}"
+HOOK_CMD="${2:-}"
+SETTINGS_FILE="${UZUSTACK_SETTINGS_FILE:-$HOME/.claude/settings.json}"
+
+if [ -z "$ACTION" ] || [ -z "$HOOK_CMD" ]; then
+  echo "Usage: uzustack-settings-hook {add|remove} <hook-command>" >&2
+  exit 1
+fi
+
+if ! command -v bun >/dev/null 2>&1; then
+  echo "Error: bun が必要、未 install。" >&2
+  exit 1
+fi
+
+case "$ACTION" in
+  add)
+    UZUSTACK_SETTINGS_PATH="$SETTINGS_FILE" UZUSTACK_HOOK_CMD="$HOOK_CMD" bun -e "
+      const fs = require('fs');
+      const settingsPath = process.env.UZUSTACK_SETTINGS_PATH;
+      const hookCmd = process.env.UZUSTACK_HOOK_CMD;
+
+      let settings = {};
+      try { settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8')); } catch {}
+
+      if (!settings.hooks) settings.hooks = {};
+      if (!settings.hooks.SessionStart) settings.hooks.SessionStart = [];
+
+      // dedup: hook command が既に登録済か確認
+      const exists = settings.hooks.SessionStart.some(entry =>
+        entry.hooks && entry.hooks.some(h => h.command && h.command.includes('uzustack-session-update'))
+      );
+
+      if (!exists) {
+        settings.hooks.SessionStart.push({
+          hooks: [{ type: 'command', command: hookCmd }]
+        });
+      }
+
+      const tmp = settingsPath + '.tmp';
+      fs.writeFileSync(tmp, JSON.stringify(settings, null, 2) + '\n');
+      fs.renameSync(tmp, settingsPath);
+    " 2>/dev/null
+    ;;
+  remove)
+    [ -f "$SETTINGS_FILE" ] || exit 1
+    UZUSTACK_SETTINGS_PATH="$SETTINGS_FILE" bun -e "
+      const fs = require('fs');
+      const settingsPath = process.env.UZUSTACK_SETTINGS_PATH;
+
+      let settings = {};
+      try { settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8')); } catch { process.exit(0); }
+
+      if (settings.hooks && settings.hooks.SessionStart) {
+        settings.hooks.SessionStart = settings.hooks.SessionStart.filter(entry =>
+          !(entry.hooks && entry.hooks.some(h => h.command && h.command.includes('uzustack-session-update')))
+        );
+        if (settings.hooks.SessionStart.length === 0) delete settings.hooks.SessionStart;
+        if (Object.keys(settings.hooks).length === 0) delete settings.hooks;
+      }
+
+      const tmp = settingsPath + '.tmp';
+      fs.writeFileSync(tmp, JSON.stringify(settings, null, 2) + '\n');
+      fs.renameSync(tmp, settingsPath);
+    " 2>/dev/null
+    ;;
+  *)
+    echo "Unknown action: $ACTION (expected add or remove)" >&2
+    exit 1
+    ;;
+esac

--- a/bin/uzustack-specialist-stats
+++ b/bin/uzustack-specialist-stats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# uzustack-specialist-stats — review history から specialist 別の hit rate を計算
+# Usage: uzustack-specialist-stats
+#
+# branch を跨いで全 *-reviews.jsonl を読み、specialist field を parse して
+# hit rate を出力する。GATE_CANDIDATE (10 回以上 dispatch されて 0 findings)
+# と NEVER_GATE (security / data-migration — insurance policy として常時起動)
+# を tag 付けする。
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+eval "$("$SCRIPT_DIR/uzustack-slug" 2>/dev/null)"
+UZUSTACK_HOME="${UZUSTACK_HOME:-$HOME/.uzustack}"
+PROJECT_DIR="$UZUSTACK_HOME/projects/$SLUG"
+
+if [ ! -d "$PROJECT_DIR" ]; then
+  echo "SPECIALIST_STATS: 0 reviews analyzed"
+  exit 0
+fi
+
+# 全 review JSONL を集約 (---CONFIG--- / ---HEAD--- footer は除去)
+COMBINED=""
+for f in "$PROJECT_DIR"/*-reviews.jsonl; do
+  [ -f "$f" ] || continue
+  COMBINED="$COMBINED$(sed '/^---/,$d' "$f" 2>/dev/null)
+"
+done
+
+if [ -z "$COMBINED" ]; then
+  echo "SPECIALIST_STATS: 0 reviews analyzed"
+  exit 0
+fi
+
+printf '%s' "$COMBINED" | bun -e "
+const lines = (await Bun.stdin.text()).trim().split('\n').filter(Boolean);
+const NEVER_GATE = new Set(['security', 'data-migration']);
+const stats = {};
+let reviewed = 0;
+
+for (const line of lines) {
+  try {
+    const e = JSON.parse(line);
+    if (!e.specialists) continue;
+    reviewed++;
+    for (const [name, info] of Object.entries(e.specialists)) {
+      if (!stats[name]) stats[name] = { dispatched: 0, findings: 0 };
+      if (info.dispatched) {
+        stats[name].dispatched++;
+        stats[name].findings += (info.findings || 0);
+      }
+    }
+  } catch {}
+}
+
+console.log('SPECIALIST_STATS: ' + reviewed + ' reviews analyzed');
+const sorted = Object.entries(stats).sort((a, b) => a[0].localeCompare(b[0]));
+for (const [name, s] of sorted) {
+  const pct = s.dispatched > 0 ? Math.round(100 * s.findings / s.dispatched) : 0;
+  let tag = '';
+  if (NEVER_GATE.has(name)) {
+    tag = ' [NEVER_GATE]';
+  } else if (s.dispatched >= 10 && s.findings === 0) {
+    tag = ' [GATE_CANDIDATE]';
+  }
+  console.log(name + ': ' + s.dispatched + '/' + reviewed + ' dispatched, ' + s.findings + ' findings (' + pct + '%)' + tag);
+}
+" 2>/dev/null || { echo "SPECIALIST_STATS: 0 reviews analyzed"; exit 0; }

--- a/bin/uzustack-taste-update
+++ b/bin/uzustack-taste-update
@@ -1,0 +1,293 @@
+#!/usr/bin/env bun
+// uzustack-taste-update — update the persistent taste profile at
+// ~/.uzustack/projects/$SLUG/taste-profile.json
+//
+// Usage:
+//   uzustack-taste-update approved <variant-path> [--reason "<why>"]
+//   uzustack-taste-update rejected <variant-path> [--reason "<why>"]
+//   uzustack-taste-update show                       — print current profile summary
+//   uzustack-taste-update migrate                    — upgrade legacy approved.json to v1
+//
+// Schema v1 at ~/.uzustack/projects/$SLUG/taste-profile.json:
+//
+//   {
+//     "version": 1,
+//     "updated_at": "<ISO 8601>",
+//     "dimensions": {
+//       "fonts":      { "approved": [...], "rejected": [...] },
+//       "colors":     { "approved": [...], "rejected": [...] },
+//       "layouts":    { "approved": [...], "rejected": [...] },
+//       "aesthetics": { "approved": [...], "rejected": [...] }
+//     },
+//     "sessions": [  // last 50 only — truncated via decay
+//       { "ts": "<ISO>", "action": "approved"|"rejected", "variant": "<path>", "reason": "<optional>" }
+//     ]
+//   }
+//
+// Each Preference entry:
+//   { value: string, confidence: number (0-1), approved_count, rejected_count, last_seen }
+//
+// Confidence is computed with Laplace smoothing + 5% weekly decay at read time.
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { execSync } from 'child_process';
+
+const STATE_DIR = process.env.UZUSTACK_STATE_DIR || path.join(process.env.HOME || '/', '.uzustack');
+const SCHEMA_VERSION = 1;
+const SESSION_CAP = 50;
+const DECAY_PER_WEEK = 0.05;
+
+type Dimension = 'fonts' | 'colors' | 'layouts' | 'aesthetics';
+const DIMENSIONS: Dimension[] = ['fonts', 'colors', 'layouts', 'aesthetics'];
+
+interface Preference {
+  value: string;
+  confidence: number;
+  approved_count: number;
+  rejected_count: number;
+  last_seen: string;
+}
+
+interface SessionRecord {
+  ts: string;
+  action: 'approved' | 'rejected';
+  variant: string;
+  reason?: string;
+}
+
+interface TasteProfile {
+  version: number;
+  updated_at: string;
+  dimensions: Record<Dimension, { approved: Preference[]; rejected: Preference[] }>;
+  sessions: SessionRecord[];
+}
+
+function getSlug(): string {
+  try {
+    const output = execSync('git rev-parse --show-toplevel', { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
+    return path.basename(output);
+  } catch {
+    return 'unknown';
+  }
+}
+
+function profilePath(slug: string): string {
+  return path.join(STATE_DIR, 'projects', slug, 'taste-profile.json');
+}
+
+function emptyProfile(): TasteProfile {
+  return {
+    version: SCHEMA_VERSION,
+    updated_at: new Date().toISOString(),
+    dimensions: {
+      fonts: { approved: [], rejected: [] },
+      colors: { approved: [], rejected: [] },
+      layouts: { approved: [], rejected: [] },
+      aesthetics: { approved: [], rejected: [] },
+    },
+    sessions: [],
+  };
+}
+
+function load(slug: string): TasteProfile {
+  const p = profilePath(slug);
+  if (!fs.existsSync(p)) return emptyProfile();
+  try {
+    const raw = JSON.parse(fs.readFileSync(p, 'utf-8'));
+    if (!raw.version || raw.version < SCHEMA_VERSION) {
+      return migrate(raw);
+    }
+    return raw as TasteProfile;
+  } catch (err) {
+    console.error(`WARN: could not parse ${p}:`, (err as Error).message);
+    return emptyProfile();
+  }
+}
+
+function save(slug: string, profile: TasteProfile): void {
+  const p = profilePath(slug);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  profile.updated_at = new Date().toISOString();
+  fs.writeFileSync(p, JSON.stringify(profile, null, 2) + '\n');
+}
+
+/**
+ * Migrate a legacy profile (no version or version < SCHEMA_VERSION) into the
+ * current schema, preserving data where possible. Legacy approved.json aggregates
+ * get normalized into empty-but-valid v1 profiles so the next write populates them.
+ */
+function migrate(legacy: unknown): TasteProfile {
+  const fresh = emptyProfile();
+  if (legacy && typeof legacy === 'object') {
+    const anyLegacy = legacy as Record<string, unknown>;
+    // Preserve sessions if present
+    if (Array.isArray(anyLegacy.sessions)) {
+      fresh.sessions = anyLegacy.sessions.slice(-SESSION_CAP) as SessionRecord[];
+    }
+    // Preserve dimensions if present and well-formed
+    if (anyLegacy.dimensions && typeof anyLegacy.dimensions === 'object') {
+      for (const dim of DIMENSIONS) {
+        const src = (anyLegacy.dimensions as Record<string, unknown>)[dim];
+        if (src && typeof src === 'object') {
+          const ss = src as Record<string, unknown>;
+          if (Array.isArray(ss.approved)) fresh.dimensions[dim].approved = ss.approved as Preference[];
+          if (Array.isArray(ss.rejected)) fresh.dimensions[dim].rejected = ss.rejected as Preference[];
+        }
+      }
+    }
+  }
+  return fresh;
+}
+
+/**
+ * Apply 5% per-week decay to confidence values at read/show time.
+ * Returns a copy; does NOT mutate or persist the input.
+ */
+function applyDecay(profile: TasteProfile): TasteProfile {
+  const now = Date.now();
+  const decayed = JSON.parse(JSON.stringify(profile)) as TasteProfile;
+  for (const dim of DIMENSIONS) {
+    for (const bucket of ['approved', 'rejected'] as const) {
+      for (const pref of decayed.dimensions[dim][bucket]) {
+        const lastSeen = new Date(pref.last_seen).getTime();
+        const weeks = Math.max(0, (now - lastSeen) / (7 * 24 * 60 * 60 * 1000));
+        pref.confidence = Math.max(0, pref.confidence * Math.pow(1 - DECAY_PER_WEEK, weeks));
+      }
+    }
+  }
+  return decayed;
+}
+
+/**
+ * Extract dimension values from a variant description. V1 keeps this simple:
+ * the variant is a path/name like "variant-A" — we can't extract real design
+ * tokens without the mockup's metadata. Callers should pass a reason string
+ * that mentions fonts/colors/layouts/aesthetics. If the reason is missing,
+ * the session is recorded but dimensions don't get updated.
+ *
+ * Future v2: parse the variant PNG's EXIF, or read an accompanying manifest
+ * that design-shotgun writes next to each variant.
+ */
+function extractSignals(reason?: string): Partial<Record<Dimension, string[]>> {
+  if (!reason) return {};
+  const out: Partial<Record<Dimension, string[]>> = {};
+  // naive pattern: "fonts: X, Y; colors: Z" — split by dimension label
+  const labelRe = /(fonts|colors|layouts|aesthetics):\s*([^;]+)/gi;
+  let m: RegExpExecArray | null;
+  while ((m = labelRe.exec(reason)) !== null) {
+    const dim = m[1].toLowerCase() as Dimension;
+    const values = m[2].split(',').map(s => s.trim()).filter(Boolean);
+    out[dim] = values;
+  }
+  return out;
+}
+
+function bumpPref(list: Preference[], value: string, opposite: Preference[], action: 'approved' | 'rejected'): Preference[] {
+  const now = new Date().toISOString();
+  let entry = list.find(p => p.value.toLowerCase() === value.toLowerCase());
+  if (!entry) {
+    entry = { value, confidence: 0, approved_count: 0, rejected_count: 0, last_seen: now };
+    list.push(entry);
+  }
+  if (action === 'approved') {
+    entry.approved_count += 1;
+  } else {
+    entry.rejected_count += 1;
+  }
+  entry.last_seen = now;
+  // Laplace-smoothed confidence
+  const total = entry.approved_count + entry.rejected_count;
+  entry.confidence = entry.approved_count / (total + 1);
+  // Flag conflict if the opposite bucket has a strong entry for this value
+  const opp = opposite.find(p => p.value.toLowerCase() === value.toLowerCase());
+  if (opp && opp.approved_count + opp.rejected_count >= 3 && opp.confidence >= 0.6) {
+    console.error(`NOTE: taste drift — "${value}" previously ${action === 'approved' ? 'rejected' : 'approved'} with confidence ${opp.confidence.toFixed(2)}. Keep both signals; aggregate confidence will rebalance.`);
+  }
+  return list;
+}
+
+function cmdUpdate(action: 'approved' | 'rejected', variant: string, reason?: string): void {
+  const slug = getSlug();
+  const profile = load(slug);
+  const signals = extractSignals(reason);
+
+  for (const dim of DIMENSIONS) {
+    const values = signals[dim];
+    if (!values) continue;
+    const bucket = profile.dimensions[dim][action];
+    const opposite = profile.dimensions[dim][action === 'approved' ? 'rejected' : 'approved'];
+    for (const v of values) bumpPref(bucket, v, opposite, action);
+  }
+
+  // Always record the session even if no dimensions were extracted
+  profile.sessions.push({ ts: new Date().toISOString(), action, variant, reason });
+  // Truncate sessions to last SESSION_CAP entries (FIFO)
+  if (profile.sessions.length > SESSION_CAP) {
+    profile.sessions = profile.sessions.slice(-SESSION_CAP);
+  }
+
+  save(slug, profile);
+  console.log(`${action}: ${variant} → ${profilePath(slug)}`);
+}
+
+function cmdShow(): void {
+  const slug = getSlug();
+  const profile = applyDecay(load(slug));
+  console.log(`taste-profile.json (slug: ${slug}, sessions: ${profile.sessions.length})`);
+  for (const dim of DIMENSIONS) {
+    const top = [...profile.dimensions[dim].approved]
+      .sort((a, b) => b.confidence * b.approved_count - a.confidence * a.approved_count)
+      .slice(0, 3);
+    const topRej = [...profile.dimensions[dim].rejected]
+      .sort((a, b) => b.confidence * b.rejected_count - a.confidence * a.rejected_count)
+      .slice(0, 3);
+    if (top.length || topRej.length) {
+      console.log(`\n[${dim}]`);
+      if (top.length) {
+        console.log('  approved (decayed):');
+        for (const p of top) console.log(`    ${p.value} — conf ${p.confidence.toFixed(2)} (+${p.approved_count}/-${p.rejected_count})`);
+      }
+      if (topRej.length) {
+        console.log('  rejected:');
+        for (const p of topRej) console.log(`    ${p.value} — conf ${p.confidence.toFixed(2)} (+${p.approved_count}/-${p.rejected_count})`);
+      }
+    }
+  }
+}
+
+function cmdMigrate(): void {
+  const slug = getSlug();
+  const profile = load(slug);
+  save(slug, profile);
+  console.log(`migrated taste profile to v${SCHEMA_VERSION} at ${profilePath(slug)}`);
+}
+
+// ─── CLI entry ────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+const cmd = args[0];
+
+switch (cmd) {
+  case 'approved':
+  case 'rejected': {
+    const variant = args[1];
+    if (!variant) {
+      console.error(`Usage: uzustack-taste-update ${cmd} <variant-path> [--reason "<why>"]`);
+      process.exit(1);
+    }
+    const reasonIdx = args.indexOf('--reason');
+    const reason = reasonIdx >= 0 ? args[reasonIdx + 1] : undefined;
+    cmdUpdate(cmd as 'approved' | 'rejected', variant, reason);
+    break;
+  }
+  case 'show':
+    cmdShow();
+    break;
+  case 'migrate':
+    cmdMigrate();
+    break;
+  default:
+    console.error('Usage: uzustack-taste-update {approved|rejected|show|migrate} [args]');
+    process.exit(1);
+}

--- a/bin/uzustack-team-init
+++ b/bin/uzustack-team-init
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# uzustack-team-init — team mode 用の repo-level bootstrap file を生成
+#
+# Usage:
+#   uzustack-team-init optional   # gentle CLAUDE.md 提案、一度だけ
+#   uzustack-team-init required   # CLAUDE.md 強制 + PreToolUse hook
+#
+# team の repo root から実行する (uzustack directory からではない)。
+
+set -euo pipefail
+
+MODE="${1:-}"
+
+if [ "$MODE" != "optional" ] && [ "$MODE" != "required" ]; then
+  echo "Usage: uzustack-team-init {optional|required}" >&2
+  echo "" >&2
+  echo "  optional  — uzustack install を developer ごとに 1 度提案 (gentle)" >&2
+  echo "  required  — uzustack install を強制、無いと作業 block" >&2
+  exit 1
+fi
+
+# git repo であること
+if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
+  echo "Error: git repository ではない。project root から実行すること。" >&2
+  exit 1
+fi
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+CLAUDE_MD="$REPO_ROOT/CLAUDE.md"
+GENERATED=()
+
+# ── vendored copy があれば migrate ──────────────────────────
+
+if [ -d "$REPO_ROOT/.claude/skills/uzustack" ] && [ ! -L "$REPO_ROOT/.claude/skills/uzustack" ]; then
+  if [ -f "$REPO_ROOT/.claude/skills/uzustack/VERSION" ] || [ -d "$REPO_ROOT/.claude/skills/uzustack/.git" ]; then
+    echo "  Found vendored uzustack copy at $REPO_ROOT/.claude/skills/uzustack"
+    echo "  Team mode uses the global install — removing vendored copy..."
+    ( cd "$REPO_ROOT" && git rm -r --cached .claude/skills/uzustack/ 2>/dev/null ) || true
+    if [ -f "$REPO_ROOT/.gitignore" ]; then
+      if ! grep -qF '.claude/skills/uzustack/' "$REPO_ROOT/.gitignore" 2>/dev/null; then
+        echo '.claude/skills/uzustack/' >> "$REPO_ROOT/.gitignore"
+      fi
+    else
+      echo '.claude/skills/uzustack/' > "$REPO_ROOT/.gitignore"
+    fi
+    rm -rf "$REPO_ROOT/.claude/skills/uzustack"
+    GENERATED+=(".gitignore")
+    echo "  Removed vendored copy and added .claude/skills/uzustack/ to .gitignore"
+  fi
+fi
+
+# ── CLAUDE.md snippet ──────────────────────────────────────────
+
+if [ "$MODE" = "optional" ]; then
+  SNIPPET='## uzustack (recommended)
+
+This project uses [uzustack](https://github.com/uzumaki-inc/uzustack) for AI-assisted workflows.
+Install it for the best experience:
+
+```bash
+git clone --depth 1 https://github.com/uzumaki-inc/uzustack.git ~/.claude/skills/uzustack
+cd ~/.claude/skills/uzustack && ./setup --team
+```
+
+Skills like /qa, /ship, /review, /investigate, and /browse become available after install.
+Use /browse for all web browsing. Use ~/.claude/skills/uzustack/... for uzustack file paths.'
+else
+  SNIPPET='## uzustack (REQUIRED — global install)
+
+**Before doing ANY work, verify uzustack is installed:**
+
+```bash
+test -d ~/.claude/skills/uzustack/bin && echo "UZUSTACK_OK" || echo "UZUSTACK_MISSING"
+```
+
+If UZUSTACK_MISSING: STOP. Do not proceed. Tell the user:
+
+> uzustack is required for all AI-assisted work in this repo.
+> Install it:
+> ```bash
+> git clone --depth 1 https://github.com/uzumaki-inc/uzustack.git ~/.claude/skills/uzustack
+> cd ~/.claude/skills/uzustack && ./setup --team
+> ```
+> Then restart your AI coding tool.
+
+Do not skip skills, ignore uzustack errors, or work around missing uzustack.
+
+Using uzustack skills: After install, skills like /qa, /ship, /review, /investigate,
+and /browse are available. Use /browse for all web browsing.
+Use ~/.claude/skills/uzustack/... for uzustack file paths (the global path).'
+fi
+
+# CLAUDE.md に既に uzustack section があるか確認
+if [ -f "$CLAUDE_MD" ] && grep -q "## uzustack" "$CLAUDE_MD" 2>/dev/null; then
+  echo "CLAUDE.md already has a uzustack section. Skipping CLAUDE.md update."
+  echo "  To replace it, remove the existing ## uzustack section and re-run."
+else
+  if [ -f "$CLAUDE_MD" ]; then
+    echo "" >> "$CLAUDE_MD"
+  fi
+  echo "$SNIPPET" >> "$CLAUDE_MD"
+  GENERATED+=("CLAUDE.md")
+  echo "  + CLAUDE.md — added uzustack $MODE section"
+fi
+
+# ── Required mode: enforcement hook ────────────────────────────
+
+if [ "$MODE" = "required" ]; then
+  HOOKS_DIR="$REPO_ROOT/.claude/hooks"
+  SETTINGS="$REPO_ROOT/.claude/settings.json"
+
+  # enforcement hook script を作成
+  mkdir -p "$HOOKS_DIR"
+  cat > "$HOOKS_DIR/check-uzustack.sh" << 'HOOK_EOF'
+#!/bin/bash
+# uzustack が globally に install されていない時 skill 利用を block。
+
+if [ ! -d "$HOME/.claude/skills/uzustack/bin" ]; then
+  cat >&2 <<'MSG'
+BLOCKED: uzustack is not installed globally.
+
+uzustack is required for AI-assisted work in this repo.
+
+Install it:
+  git clone --depth 1 https://github.com/uzumaki-inc/uzustack.git ~/.claude/skills/uzustack
+  cd ~/.claude/skills/uzustack && ./setup --team
+
+Then restart your AI coding tool.
+MSG
+  echo '{"permissionDecision":"deny","message":"uzustack is required but not installed. See stderr for install instructions."}'
+  exit 0
+fi
+
+echo '{}'
+HOOK_EOF
+  chmod +x "$HOOKS_DIR/check-uzustack.sh"
+  GENERATED+=(".claude/hooks/check-uzustack.sh")
+  echo "  + .claude/hooks/check-uzustack.sh — enforcement hook"
+
+  # project-level settings.json に hook を追加
+  if command -v bun >/dev/null 2>&1; then
+    UZUSTACK_SETTINGS_PATH="$SETTINGS" bun -e "
+      const fs = require('fs');
+      const settingsPath = process.env.UZUSTACK_SETTINGS_PATH;
+
+      let settings = {};
+      try { settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8')); } catch {}
+
+      if (!settings.hooks) settings.hooks = {};
+      if (!settings.hooks.PreToolUse) settings.hooks.PreToolUse = [];
+
+      // dedup
+      const exists = settings.hooks.PreToolUse.some(entry =>
+        entry.matcher === 'Skill' &&
+        entry.hooks && entry.hooks.some(h => h.command && h.command.includes('check-uzustack'))
+      );
+
+      if (!exists) {
+        settings.hooks.PreToolUse.push({
+          matcher: 'Skill',
+          hooks: [{
+            type: 'command',
+            command: '\"\$CLAUDE_PROJECT_DIR/.claude/hooks/check-uzustack.sh\"'
+          }]
+        });
+      }
+
+      const tmp = settingsPath + '.tmp';
+      fs.writeFileSync(tmp, JSON.stringify(settings, null, 2) + '\n');
+      fs.renameSync(tmp, settingsPath);
+    " 2>/dev/null
+    GENERATED+=(".claude/settings.json")
+    echo "  + .claude/settings.json — PreToolUse hook registered"
+  else
+    echo "  ! bun not found — manually add the PreToolUse hook to .claude/settings.json"
+  fi
+fi
+
+# ── Summary ────────────────────────────────────────────────────
+
+echo ""
+echo "Team mode ($MODE) initialized."
+echo ""
+if [ ${#GENERATED[@]} -gt 0 ]; then
+  echo "Commit the generated files:"
+  echo "  git add ${GENERATED[*]}"
+  echo "  git commit -m \"chore: require uzustack for AI-assisted work\""
+fi
+echo ""
+echo "Each developer then runs:"
+echo "  git clone --depth 1 https://github.com/uzumaki-inc/uzustack.git ~/.claude/skills/uzustack"
+echo "  cd ~/.claude/skills/uzustack && ./setup --team"

--- a/bin/uzustack-telemetry-sync
+++ b/bin/uzustack-telemetry-sync
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# uzustack-telemetry-sync — local JSONL event を Supabase へ sync
+#
+# Fire-and-forget、background、5 分に 1 回 rate limit。送信前に local-only field
+# を strip し privacy tier を尊重する。telemetry-ingest edge function に POST
+# する (PostgREST 直叩きではない)。
+#
+# Env override (test 用):
+#   UZUSTACK_STATE_DIR           — ~/.uzustack state directory を override
+#   UZUSTACK_DIR                 — auto-detected uzustack root を override
+#   UZUSTACK_SUPABASE_URL        — Supabase project URL を override
+set -uo pipefail
+
+UZUSTACK_DIR="${UZUSTACK_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+STATE_DIR="${UZUSTACK_STATE_DIR:-$HOME/.uzustack}"
+ANALYTICS_DIR="$STATE_DIR/analytics"
+JSONL_FILE="$ANALYTICS_DIR/skill-usage.jsonl"
+CURSOR_FILE="$ANALYTICS_DIR/.last-sync-line"
+RATE_FILE="$ANALYTICS_DIR/.last-sync-time"
+CONFIG_CMD="$UZUSTACK_DIR/bin/uzustack-config"
+
+# env で未 override なら Supabase config を source
+if [ -z "${UZUSTACK_SUPABASE_URL:-}" ] && [ -f "$UZUSTACK_DIR/supabase/config.sh" ]; then
+  . "$UZUSTACK_DIR/supabase/config.sh"
+fi
+SUPABASE_URL="${UZUSTACK_SUPABASE_URL:-}"
+ANON_KEY="${UZUSTACK_SUPABASE_ANON_KEY:-}"
+
+# ─── Pre-checks ──────────────────────────────────────────────
+# Supabase URL 未設定 → silently に exit
+[ -z "$SUPABASE_URL" ] && exit 0
+
+# JSONL file 無し → sync する物がない
+[ -f "$JSONL_FILE" ] || exit 0
+
+# Rate limit: 5 分に 1 回
+if [ -f "$RATE_FILE" ]; then
+  STALE=$(find "$RATE_FILE" -mmin +5 2>/dev/null || true)
+  [ -z "$STALE" ] && exit 0
+fi
+
+# ─── tier を読む ─────────────────────────────────────────────
+TIER="$("$CONFIG_CMD" get telemetry 2>/dev/null || true)"
+TIER="${TIER:-off}"
+[ "$TIER" = "off" ] && exit 0
+
+# ─── cursor を読む ───────────────────────────────────────────
+CURSOR=0
+if [ -f "$CURSOR_FILE" ]; then
+  CURSOR="$(cat "$CURSOR_FILE" 2>/dev/null | tr -d ' \n\r\t')"
+  # 入力検証: 非負整数のみ allow
+  case "$CURSOR" in *[!0-9]*) CURSOR=0 ;; esac
+fi
+
+# Safety: cursor が file 行数を超えたら reset
+TOTAL_LINES="$(wc -l < "$JSONL_FILE" | tr -d ' \n\r\t')"
+if [ "$CURSOR" -gt "$TOTAL_LINES" ] 2>/dev/null; then
+  CURSOR=0
+fi
+
+# 新規送信対象なし
+[ "$CURSOR" -ge "$TOTAL_LINES" ] 2>/dev/null && exit 0
+
+# ─── 未送信行を読む ──────────────────────────────────────────
+SKIP=$(( CURSOR + 1 ))
+UNSENT="$(tail -n "+$SKIP" "$JSONL_FILE" 2>/dev/null || true)"
+[ -z "$UNSENT" ] && exit 0
+
+# ─── local-only field を strip して batch を組み立て ─────────
+# Edge function は raw JSONL field 名 (v / ts / sessions) を期待 — column
+# rename は不要 (function 内部で map される)。
+BATCH="["
+FIRST=true
+COUNT=0
+
+while IFS= read -r LINE; do
+  # 空行 / malformed 行は skip
+  [ -z "$LINE" ] && continue
+  echo "$LINE" | grep -q '^{' || continue
+
+  # local-only field を strip (v / ts / sessions は edge function 用にそのまま)
+  CLEAN="$(echo "$LINE" | sed \
+    -e 's/,"_repo_slug":"[^"]*"//g' \
+    -e 's/,"_branch":"[^"]*"//g' \
+    -e 's/,"repo":"[^"]*"//g')"
+
+  # anonymous tier なら installation_id を strip
+  if [ "$TIER" = "anonymous" ]; then
+    CLEAN="$(echo "$CLEAN" | sed 's/,"installation_id":"[^"]*"//g; s/,"installation_id":null//g')"
+  fi
+
+  if [ "$FIRST" = "true" ]; then
+    FIRST=false
+  else
+    BATCH="$BATCH,"
+  fi
+  BATCH="$BATCH$CLEAN"
+  COUNT=$(( COUNT + 1 ))
+
+  # batch size limit
+  [ "$COUNT" -ge 100 ] && break
+done <<< "$UNSENT"
+
+BATCH="$BATCH]"
+
+# filter 後に送信対象なし
+[ "$COUNT" -eq 0 ] && exit 0
+
+# ─── edge function に POST ───────────────────────────────────
+RESP_FILE="$(mktemp /tmp/uzustack-sync-XXXXXX 2>/dev/null || echo "/tmp/uzustack-sync-$$")"
+HTTP_CODE="$(curl -s -w '%{http_code}' --max-time 10 \
+  -X POST "${SUPABASE_URL}/functions/v1/telemetry-ingest" \
+  -H "Content-Type: application/json" \
+  -H "apikey: ${ANON_KEY}" \
+  -o "$RESP_FILE" \
+  -d "$BATCH" 2>/dev/null || echo "000")"
+
+# ─── 成功時 (2xx) cursor を更新 ──────────────────────────────
+case "$HTTP_CODE" in
+  2*)
+    # response から inserted count を parse — 実際に insert された時のみ advance。
+    # SENT count で advance する (inserted を source 行に map できないため)。
+    # inserted==0 なら systemic に何かおかしい — advance しない。
+    INSERTED="$(grep -o '"inserted":[0-9]*' "$RESP_FILE" 2>/dev/null | grep -o '[0-9]*' || echo "0")"
+    # upsert error (installation 追跡失敗) を確認 — log するが cursor advance は止めない
+    UPSERT_ERRORS="$(grep -o '"upsertErrors"' "$RESP_FILE" 2>/dev/null || true)"
+    if [ -n "$UPSERT_ERRORS" ]; then
+      echo "[uzustack-telemetry-sync] Warning: installation upsert errors in response" >&2
+    fi
+    if [ "${INSERTED:-0}" -gt 0 ] 2>/dev/null; then
+      NEW_CURSOR=$(( CURSOR + COUNT ))
+      echo "$NEW_CURSOR" > "$CURSOR_FILE" 2>/dev/null || true
+    fi
+    ;;
+esac
+
+rm -f "$RESP_FILE" 2>/dev/null || true
+
+# rate limit marker を更新
+touch "$RATE_FILE" 2>/dev/null || true
+
+exit 0

--- a/bin/uzustack-timeline-log
+++ b/bin/uzustack-timeline-log
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# uzustack-timeline-log — project timeline に timeline event を append する
+# Usage: uzustack-timeline-log '{"skill":"review","event":"started","branch":"main"}'
+#
+# session timeline は default で local。`gbrain_sync_mode` を `full` (not
+# `artifacts-only`) privacy tier で有効化すると (`uzustack-brain-init` の
+# first-run stop-gate or preamble 経由)、timeline event は user の private
+# GBrain sync repo へ publish される。詳細は `docs/gbrain-sync.md` 参照。
+# Required fields: skill, event (started|completed)。
+# Optional: branch, outcome, duration_s, session, ts。
+# 検証失敗 → silently に skip (non-blocking)。
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+eval "$("$SCRIPT_DIR/uzustack-slug" 2>/dev/null)"
+UZUSTACK_HOME="${UZUSTACK_HOME:-$HOME/.uzustack}"
+mkdir -p "$UZUSTACK_HOME/projects/$SLUG"
+
+INPUT="$1"
+
+# 入力検証: parseable な JSON で required field を含むことを確認
+if ! printf '%s' "$INPUT" | bun -e "
+  const j = JSON.parse(await Bun.stdin.text());
+  if (!j.skill || !j.event) process.exit(1);
+" 2>/dev/null; then
+  exit 0  # silently に skip、non-blocking
+fi
+
+# timestamp 未指定なら現在時刻を inject
+if ! printf '%s' "$INPUT" | bun -e "const j=JSON.parse(await Bun.stdin.text()); if(!j.ts) process.exit(1)" 2>/dev/null; then
+  INPUT=$(printf '%s' "$INPUT" | bun -e "
+    const j = JSON.parse(await Bun.stdin.text());
+    j.ts = new Date().toISOString();
+    console.log(JSON.stringify(j));
+  " 2>/dev/null) || true
+fi
+
+echo "$INPUT" >> "$UZUSTACK_HOME/projects/$SLUG/timeline.jsonl"
+
+# gbrain-sync: cross-machine sync 用に enqueue (sync off 時は no-op)
+"$SCRIPT_DIR/uzustack-brain-enqueue" "projects/$SLUG/timeline.jsonl" 2>/dev/null &

--- a/bin/uzustack-timeline-read
+++ b/bin/uzustack-timeline-read
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# uzustack-timeline-read — project timeline を読み出して整形
+# Usage: uzustack-timeline-read [--since "7 days ago"] [--limit N] [--branch NAME]
+#
+# session timeline は local-only、外部送信なし。
+# ~/.uzustack/projects/$SLUG/timeline.jsonl を読み filter / 整形する。
+# timeline file が無ければ silently に exit 0。
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+eval "$("$SCRIPT_DIR/uzustack-slug" 2>/dev/null)"
+UZUSTACK_HOME="${UZUSTACK_HOME:-$HOME/.uzustack}"
+
+SINCE=""
+LIMIT=20
+BRANCH=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --since) SINCE="$2"; shift 2 ;;
+    --limit) LIMIT="$2"; shift 2 ;;
+    --branch) BRANCH="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+TIMELINE_FILE="$UZUSTACK_HOME/projects/$SLUG/timeline.jsonl"
+
+if [ ! -f "$TIMELINE_FILE" ]; then
+  exit 0
+fi
+
+cat "$TIMELINE_FILE" 2>/dev/null | bun -e "
+const lines = (await Bun.stdin.text()).trim().split('\n').filter(Boolean);
+const since = '${SINCE}';
+const branch = '${BRANCH}';
+const limit = ${LIMIT};
+
+let sinceMs = 0;
+if (since) {
+  // '7 days ago' のような相対時刻を parse
+  const match = since.match(/(\d+)\s*(day|hour|minute|week|month)s?\s*ago/i);
+  if (match) {
+    const n = parseInt(match[1]);
+    const unit = match[2].toLowerCase();
+    const ms = { minute: 60000, hour: 3600000, day: 86400000, week: 604800000, month: 2592000000 };
+    sinceMs = Date.now() - n * (ms[unit] || 86400000);
+  }
+}
+
+const entries = [];
+for (const line of lines) {
+  try {
+    const e = JSON.parse(line);
+    if (sinceMs && new Date(e.ts).getTime() < sinceMs) continue;
+    if (branch && e.branch !== branch) continue;
+    entries.push(e);
+  } catch {}
+}
+
+if (entries.length === 0) process.exit(0);
+
+// 末尾 N entries を取得
+const recent = entries.slice(-limit);
+
+// skill 別カウント (completed event のみ)
+const counts = {};
+const branches = new Set();
+for (const e of entries) {
+  if (e.event === 'completed') {
+    counts[e.skill] = (counts[e.skill] || 0) + 1;
+  }
+  if (e.branch) branches.add(e.branch);
+}
+
+// summary 出力
+const countStr = Object.entries(counts)
+  .sort((a, b) => b[1] - a[1])
+  .map(([s, n]) => n + ' /' + s)
+  .join(', ');
+
+if (countStr) {
+  console.log('TIMELINE: ' + countStr + ' across ' + branches.size + ' branch' + (branches.size !== 1 ? 'es' : ''));
+}
+
+// recent event 出力
+console.log('');
+console.log('## Recent Events');
+for (const e of recent) {
+  const ts = (e.ts || '').replace('T', ' ').replace(/\.\d+Z$/, 'Z');
+  const dur = e.duration_s ? ' (' + e.duration_s + 's)' : '';
+  const outcome = e.outcome ? ' [' + e.outcome + ']' : '';
+  console.log('- ' + ts + ' /' + e.skill + ' ' + e.event + outcome + dur + (e.branch ? ' on ' + e.branch : ''));
+}
+" 2>/dev/null || exit 0


### PR DESCRIPTION
## Summary

Phase 3 cluster B（bin 翻訳、step-35〜39）の **4 step 目**。preamble から呼ばれる頻度は低めで、特定の skill / 機能から呼ばれる補助 binary 群を翻訳。**21 binary を gstack → uzustack に翻訳**（計 2,786 行、step-37 と同等規模で個数 1.6 倍）。Q1-B 完璧版方針に従い、使う skill が cluster C/D で未翻訳でも binary は揃える。

step-35 で確立した **voice 規約 v1（7 項目）+ 運用方針 v1** を 21 binary に適用。**bisect 単位は 1 binary = 1 commit**、計 21 binary commit + dangling reference fix 1 commit = 22 commit。

## 翻訳対象（21 個 / 2,786 行）

### 記録・分析系（8 個）
- `uzustack-telemetry-sync` (142)、`uzustack-question-log` (171)、`uzustack-question-preference` (262)、`uzustack-specialist-stats` (65)、`uzustack-taste-update` (293 TS)、`uzustack-developer-profile` (450)、`uzustack-builder-profile` (13、SHIM)、`uzustack-model-benchmark` (168 TS)

### dashboard 系（2 個）
- `uzustack-community-dashboard` (105)、`uzustack-security-dashboard` (121)

### review / timeline 連携（4 個）
- `uzustack-review-log` (21)、`uzustack-review-read` (12)、`uzustack-timeline-log` (40)、`uzustack-timeline-read` (94)

### session / settings 管理（2 個）
- `uzustack-session-update` (116)、`uzustack-settings-hook` (82)

### team 機能（1 個）
- `uzustack-team-init` (192)

### 拡張機構（4 個）
- `uzustack-extension` (65)、`uzustack-analytics` (191、upstream は `gstack-analytics` 単一 prefix)、`uzustack-repo-mode` (93)、`uzustack-diff-scope` (90)

## 翻訳判断点（issue #45 で事前合意、2 軸）

step-37 と異なり外部 CLI 連携（`gbrain` 等）はなし、判断軸が 1 つ減って 2 軸。

### 軸 1: 名前空間の境界線

`gstack` 由来 identifier は完全置換。**例外**：upstream の自己参照 / 自己プロセス名表示は uzustack 化、Chrome UI 引用 (`'Developer mode'` / `'Load unpacked'`) は Chrome 自身の英語 UI なので英語維持、CLAUDE.md snippet 内の skill list (`/qa, /ship, /review, /investigate, /browse`) は cluster C/D で skill 翻訳完了次第 自動整合する完璧複製状態。

### 軸 2: 動作確認スコープ

- 各 binary 単独動作 (連携 skill との結合 test は Phase 4 以降)
- `bash -n` syntax check + `--help` or 基本サブコマンド + JSON 出力 valid
- 内部呼び出し (`uzustack-slug` 等) が解決
- setup で 21 binary が PATH 配置

依存先未持ち込みの **完璧複製状態**：`scripts/{question-registry,psychographic-signals,one-way-doors,archetypes}.ts` / `test/helpers/{benchmark-runner,benchmark-judge,providers}` / `extension/` / Supabase project は uzustack 未持ち込み。これらに依存する `model-benchmark` / `question-preference --check` / `developer-profile --derive,--trace,--vibe` / `community-dashboard` / `security-dashboard` / `extension` は dependency 解決時 (cluster C/D / Phase 4+) に動作。bin 配置のみで step-37 の Supabase 系と同じ完璧複製方針。

## 動作確認

- [x] 21 binary 全 syntax check (`bash -n`) PASS、TS 2 binary は `bun build --target=bun --no-bundle` PASS (transpile 成功)
- [x] 全 binary smoke test PASS (no-args / --help / sub-command / 不在 deps / valid input / invalid input)
- [x] dependency 解決 chain 動作確認 (`builder-profile` → `developer-profile` → empty stub auto-create + KEY:VALUE 出力 round-trip)
- [x] 既翻訳 binary との連携動作確認 (review-log / timeline-log → `uzustack-brain-enqueue` 連携、session-update → `uzustack-config get auto_upgrade`)
- [x] setup 配置: bin/ 全体 symlink で 21 binary が自動 pickup (修正不要、step-35/36/37 と同じ結果、**4 度目の実証**)
- [x] dangling reference fix: `uzustack-question-log:27` の `uzustack-question-sensitivity` 参照削除 (commit `8600a63`)

## /simplify 3 並列 review (reuse / quality / efficiency)

memory `upstream_clone_simplify_discipline` に従い 2 区分で仕分け。

**A. uzustack 単独修正（1 件、本 PR で fix 済）**
- `uzustack-question-log:27` の dangling `uzustack-question-sensitivity --read-log` 参照削除 → 「dedup は read 時に行う」のみ残す。memory `avoid_speculative_use_disclaimers` に従い未確認 reader 名は明記せず削除を選択。

**B. upstream tech debt 観測リスト（15 件、issue #38 に追加、累計 22 → 37 件）**
- Reuse 5 件: dangling reference / INJECTION_PATTERNS 重複 (3 binary) / Supabase config-source 重複 (4 binary) / settings.json atomic-write 重複 (2 binary) / `developer-profile` コメント vs コード不整合
- Quality 3 件: dashboard 4 個の `set -uo pipefail` (no `-e`) / dashboard 系 `grep -o + awk` JSON 解析の脆さ / `extension` の `set -e` のみ
- Efficiency 7 件: `timeline-log` 3 回 parse / `analytics` K×N re-scan / `analytics` 4 grep -c / `community/security-dashboard` grep chain 多 pass / `developer-profile` 2 回 cat / UUOC `cat | bun -e` (3 binary) / `repo-mode` SHORTLOG 3 pipe

3 agent が独立に同じ findings (`question-log:27`) を発見した cross-validation 効果あり。守期間中は B 区分は記録のみ、定期 subtree pull で upstream fix を自動吸収。

## 個人 Obsidian vault 同期予定 (PR merge 後)

- step-38 子ノート `frontmatter status: DONE` + `date-completed: 2026-04-29` + `pr: <merged PR#>`
- step-38 子ノート checkbox 全 [x] (実態反映)
- step-38 子ノート末尾「## 結果」section 追記 (step-35/36/37 形式)
- Phase Step 一覧 step-38 行 DONE 化 + リンクテキスト「PR #X merged、cluster B 4 step 目」 + 日付更新
- uzustack草案 `# 重要` section の wiki-link 確認 (memory `obsidian_main_note_link_loss` 規律)

## scope 注記

step-38 で voice 規約 v1 + 運用方針 v1 が 4 step 目 (step-35 確立 → 36/37/38 適用) で完全 internalize。21 binary 翻訳中 judgment 軸は事前合意の 2 軸 + 1 件相談 (specialist-stats output 表示 → 英語維持承認、22 commit 全体に適用) で完結。memory `mechanize_over_scope_skip` の効用が更に立証 (依存先未持ち込み binary 6 個も完璧複製で配置、cluster C/D 翻訳完了次第 自動動作)。

step-39 へ送る item: cluster B 完了に伴う **CONTRIBUTING.md 統合** (voice 規約 v1 + 運用方針 v1 + step-37 拡張 + step-38 学び「dangling reference は機械置換で伝播」「output 英語維持の境界線」)。step-39 子ノートに既に section 追加済 (step-37 PR で先行履行)。

Closes #45
