### PR TITLE
feat: bin 翻訳 — 連携系 7 binary + CONTRIBUTING.md 統合 — Phase 3 step-39 (cluster B 完了)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -300,6 +300,23 @@ voice 規約 v1 項目 4「fixed identifier 英語維持」を、外部 SaaS や
 - **output 表示英語維持の境界線**：sentinel token + 周辺 context は parser 互換重視で **英語維持**。`uzustack-specialist-stats` output / dashboard 系で適用。コメント / status メッセージは日本語化、機械処理される token は英語維持
 - **judgment 軸数の動的性**：外部 CLI 連携の有無で軸数が変動する。step-37（`gbrain` あり）→ 3 軸 / step-38（なし）→ 2 軸 / step-39（なし、CONTRIBUTING 統合あり）→ 2 軸 + 統合タスク。事前合意で軸数を確定すれば cluster 進行が機械化される
 
+#### 規約射程の拡張（cluster B step-39 で確立）— ファイル名も射程に含める
+
+voice 規約 v1（7 項目）+ step-37 拡張は **ファイル名そのもの** も射程に含める。`bin/<name>` の `<name>` も「ファイル内 identifier」と同じ規律で扱う。step-39 完了直前に「規約はファイル内 identifier しか射程に入れていなかった」穴が発覚し、cluster B 完了タイミングで穴埋めとして確立。
+
+**運用ルール**：外部 product / protocol / tool 名で構成された binary は **`uzustack-` prefix なしで維持** する。
+
+**判断基準**：
+
+- upstream で `gstack-` prefix が付いていない binary は、upstream 側でも「外部 identifier 命名」と判断した signal として読む
+- これに従い uzustack 側でも prefix なし維持する（memory `mechanize_over_scope_skip` 規律と整合）
+- 「内容は外部 identifier 維持、ファイル名だけ `uzustack-` prefix」という分裂状態を生まない
+
+**具体例**：
+
+- `bin/chrome-cdp`（Chrome [外部 product 名] + CDP [外部 protocol 名] の合成）— `uzustack-chrome-cdp` ではなく `chrome-cdp` のまま維持
+- 確認 signal：`_upstream/gstack/test/audit-compliance.test.ts` の `bin/chrome-cdp` hardcode（upstream test が path を直接参照、upstream 設計判断の最も強い signal）
+
 #### 集約タイミング規律
 
 cluster 進行中は規範が PR description / memory / step ノート / issue body に分散して動いている。**cluster 完了で規範が固まった直後（次 cluster 着手前）に CONTRIBUTING.md へ集約**する。Phase 完了判定 (step-42) まで待つと cluster 内参照性が上がらず、PR description を漁る運用になる。本節は cluster B step-39 で集約した（step-42 → step-39 完了に前倒し）。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -262,6 +262,48 @@ step-35 以降の bin 機械翻訳と既存 skill の .tmpl 化が「**置換ル
 - **DEFAULTS の意味論判断は step-37 集中**：gstack 文字を含まない key（例：`gbrain_sync_mode`）は機械置換せず、step-37 の brain 系翻訳時に集中判断
 - **v1 で完璧を目指さない**：翻訳作業中に増えるケースは追記して育てる方針。迷ったら `v2 で見直し` フラグ付きで暫定採用し、翻訳作業を止めない
 
+### voice 規約 v1（cluster B = bin 翻訳で確立）
+
+Phase 3 cluster B（bin 翻訳、step-35〜39、PR #40 / #42 / #44 / #46 / #47）で確立した voice 翻案規律。bash + 副言語 embedded スクリプトの翻訳に適用する。本節は cluster B 完了 (step-39) で PR description / memory に分散していた規範を集約したもの。
+
+#### 7 項目（cluster B step-35 = PR #40 commit `d1b2c0f` で確立）
+
+1. **Section 見出し**（`Usage:` / `Behavior:` / `Exit codes:`）は **英語維持** — CLI 慣習に合わせる
+2. **エラーメッセージは客観形（日本語）**：「〜が必要、実際は N 個」のような客観事実、責難形（「〜してください」）は避ける
+3. **インラインコメントは簡潔な日本語**、技術用語は backtick で英語維持
+4. **fixed identifier**（`base` / `ours` / `theirs`、API 名）は **英語維持**
+5. **bin 名**は backtick 囲み（例：`uzustack-config`）
+6. **embedded code** 内コメント（Python heredoc / bun -e の JS 等）も日本語化、技術用語は英語維持
+7. **括弧**は半角 `(...)` を維持
+
+#### 運用方針 v1
+
+- **bash + 副言語 embedded** は副言語コメントも日本語化（cluster B step-36 で確立、Python heredoc / bun -e の JS で適用）
+- **TypeScript / 主言語そのもの**は英語維持（reader 想定の言語と一致させる、cluster B step-35 `uzustack-next-version` 477 行 TS で確立）
+- **embedded Python heredoc 内の error 文字列** も日本語化対象（cluster B step-37 `uzustack-brain-init` / `uzustack-brain-restore` で確認、voice 規約 v1 項目 2 が境界を貫通する）
+
+#### 外部 SaaS / 別プロジェクト identifier 維持（step-37 拡張）
+
+voice 規約 v1 項目 4「fixed identifier 英語維持」を、外部 SaaS や別プロジェクトの identifier にも拡張する。`gstack` 由来は `uzustack` に置換するが、以下は **維持**：
+
+- **外部 CLI 名**：`gbrain`（別プロジェクト）、`Codex CLI` / `Gemini CLI`（外部 product）
+- **外部 path / config**：`~/.gbrain/config.json` / `~/.codex/sessions` / `~/.gemini/projects.json` / `~/.claude/projects`
+- **外部 env**：`GBRAIN_URL` / `GBRAIN_TOKEN` / `CODEX_HOME` / `CODEX_API_KEY` / `OPENAI_API_KEY`
+- **外部プロジェクト共有 config key**：`gbrain_sync_mode` 等（`uzustack-config` に外部プロジェクトと共有する key）
+- **外部 SaaS リソース慣習名**：例 Supabase project name prefix `gbrain`（gbrain CLI で作る project の慣習）
+- **OS / Tool UI 引用**：Chrome の `'Developer mode'` / `'Load unpacked'`（Chrome 自身の英語 UI 引用）
+- **未翻訳 skill 名のまま**（cluster C/D 翻訳完了次第 自動整合）：CLAUDE.md snippet 内の `/qa, /ship, /review, /investigate, /browse` 等
+
+#### step-38 学び 3 点（cluster B 完了時の追加観測、PR #46）
+
+- **機械置換は dangling reference まで忠実に伝播する**：comment 内の他 binary 参照も置換対象。`uzustack-question-log:27` の `uzustack-question-sensitivity`（実体未持ち込み）参照を削除した事例。`/simplify` の quality + reuse agent が独立に同じ findings を発見、cross-validation で confidence 高い
+- **output 表示英語維持の境界線**：sentinel token + 周辺 context は parser 互換重視で **英語維持**。`uzustack-specialist-stats` output / dashboard 系で適用。コメント / status メッセージは日本語化、機械処理される token は英語維持
+- **judgment 軸数の動的性**：外部 CLI 連携の有無で軸数が変動する。step-37（`gbrain` あり）→ 3 軸 / step-38（なし）→ 2 軸 / step-39（なし、CONTRIBUTING 統合あり）→ 2 軸 + 統合タスク。事前合意で軸数を確定すれば cluster 進行が機械化される
+
+#### 集約タイミング規律
+
+cluster 進行中は規範が PR description / memory / step ノート / issue body に分散して動いている。**cluster 完了で規範が固まった直後（次 cluster 着手前）に CONTRIBUTING.md へ集約**する。Phase 完了判定 (step-42) まで待つと cluster 内参照性が上がらず、PR description を漁る運用になる。本節は cluster B step-39 で集約した（step-42 → step-39 完了に前倒し）。
+
 ### 新規翻訳の手順（1 個ずつ、緊急時 / 単発の場合）
 
 緊急で 1 個だけ翻訳したい場合や、cluster に収まらない isolated な skill の場合に使う。継続的に翻訳を進める場合は、後述の **small batch アプローチ** を推奨。

--- a/bin/chrome-cdp
+++ b/bin/chrome-cdp
@@ -1,0 +1,70 @@
+#!/bin/bash
+# CDP (remote debugging) を有効にして Chrome を起動する。
+# 使い方: chrome-cdp [port]
+#
+# Chrome は default data directory に対しては --remote-debugging-port を許可しない。
+# そこで data dir を別途用意し、ユーザーの実 profile を symlink する。Chrome は
+# non-default だと判断するが cookie や extension は同じものが使える。
+
+PORT="${1:-9222}"
+CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+REAL_PROFILE="$HOME/Library/Application Support/Google/Chrome"
+CDP_DATA_DIR="$HOME/.uzustack/cdp-profile/chrome"
+
+if ! [ -f "$CHROME" ]; then
+  echo "$CHROME に Chrome が見つからない" >&2
+  exit 1
+fi
+
+# Chrome が起動中か確認
+if pgrep -f "Google Chrome" >/dev/null 2>&1; then
+  echo "Chrome がまだ起動中。終了させる..."
+  osascript -e 'tell application "Google Chrome" to quit' 2>/dev/null
+
+  # 完全終了を待つ
+  for i in $(seq 1 20); do
+    pgrep -f "Google Chrome" >/dev/null 2>&1 || break
+    sleep 0.5
+  done
+
+  if pgrep -f "Google Chrome" >/dev/null 2>&1; then
+    echo "Chrome が終了しない。強制 kill..." >&2
+    pkill -f "Google Chrome"
+    sleep 1
+  fi
+fi
+
+# 実 profile を symlink した CDP data dir を準備
+# Chrome は --remote-debugging-port には "non-default" data dir を要求する。
+# 実 Default profile を symlink すれば cookie / extension がそのまま使える。
+mkdir -p "$CDP_DATA_DIR"
+if [ -d "$REAL_PROFILE/Default" ] && ! [ -e "$CDP_DATA_DIR/Default" ]; then
+  ln -s "$REAL_PROFILE/Default" "$CDP_DATA_DIR/Default"
+  echo "実 Chrome profile を CDP data dir に link した"
+fi
+# Local State (cookie 復号用の crypto key 等を含む) も link
+if [ -f "$REAL_PROFILE/Local State" ] && ! [ -e "$CDP_DATA_DIR/Local State" ]; then
+  ln -s "$REAL_PROFILE/Local State" "$CDP_DATA_DIR/Local State"
+fi
+
+echo "Chrome を CDP で port $PORT に起動..."
+"$CHROME" \
+  --remote-debugging-port="$PORT" \
+  --remote-debugging-address=127.0.0.1 \
+  --remote-allow-origins="http://127.0.0.1:$PORT" \
+  --user-data-dir="$CDP_DATA_DIR" \
+  --restore-last-session &
+disown
+
+# CDP が利用可能になるのを待つ
+for i in $(seq 1 30); do
+  if curl -s "http://127.0.0.1:$PORT/json/version" >/dev/null 2>&1; then
+    echo "CDP が port $PORT で ready"
+    echo "実行: \$B connect chrome"
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "CDP が 30 秒経っても利用可能にならない。" >&2
+exit 1

--- a/bin/uzustack-codex-probe
+++ b/bin/uzustack-codex-probe
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# uzustack-codex-probe: /codex と /autoplan skill 用の shared helper。
+# template の bash block から source される。直接実行しない。
+#
+# 関数 (全て _uzustack_codex_ prefix で名前空間衛生):
+#   _uzustack_codex_auth_probe      — 多段 signal 認証チェック (env + file)
+#   _uzustack_codex_version_check   — 既知 bad Codex CLI バージョンへの警告
+#   _uzustack_codex_timeout_wrapper — gtimeout -> timeout -> unwrapped fallback
+#   _uzustack_codex_log_event       — telemetry を ~/.uzustack/analytics/ に emit
+#
+# 衛生規則 (test/codex-hardening.test.ts で強制):
+#   - 本ファイル内で set -e / set -u / trap / IFS= / PATH= しない
+#   - 内部変数は _UZUSTACK_CODEX_ prefix
+#   - 関数名は _uzustack_codex_ prefix
+#   - source 時に command 実行しない (関数定義のみ)
+
+# --- 認証 probe -------------------------------------------------------------
+
+_uzustack_codex_auth_probe() {
+  # 多段 signal: env vars または auth file。env-auth ユーザー (CI、platform
+  # engineer) を file-only check で偽陰性弾きしないようにするための組み合わせ。
+  local _codex_home="${CODEX_HOME:-$HOME/.codex}"
+  # 空白以外の非空白文字がある時だけ true となる `-n` を使う。bash の [ -n ] 単独
+  # では空白も通るので、whitespace strip と組み合わせて堅牢化する。
+  local _k1 _k2
+  _k1=$(printf '%s' "${CODEX_API_KEY:-}" | tr -d '[:space:]')
+  _k2=$(printf '%s' "${OPENAI_API_KEY:-}" | tr -d '[:space:]')
+  if [ -n "$_k1" ] || [ -n "$_k2" ] || [ -f "$_codex_home/auth.json" ]; then
+    echo "AUTH_OK"
+    return 0
+  fi
+  echo "AUTH_FAILED"
+  return 1
+}
+
+# --- バージョンチェック ----------------------------------------------------------
+
+_uzustack_codex_version_check() {
+  # 既知 bad Codex CLI バージョンへの警告。anchored regex で 0.120.10 / 0.120.20
+  # が誤マッチしないようにする。0.120.2-beta は bad release にマッチして警告
+  # (実際にバグあり)。新たな Codex CLI バージョンが regress したら本リストを更新。
+  local _ver
+  _ver=$(codex --version 2>/dev/null | head -1)
+  [ -z "$_ver" ] && return 0
+  if echo "$_ver" | grep -Eq '(^|[^0-9.])0\.120\.(0|1|2)([^0-9.]|$)'; then
+    echo "WARN: Codex CLI $_ver has known stdin deadlock bugs. Run: npm install -g @openai/codex@latest"
+    _uzustack_codex_log_event "codex_version_warning"
+  fi
+}
+
+# --- timeout wrapper --------------------------------------------------------
+
+_uzustack_codex_timeout_wrapper() {
+  # wrapper binary を解決: gtimeout (macOS Homebrew coreutils) を優先、
+  # timeout (Linux) で fallback、なければ unwrapped 実行。
+  # 引数: $1 は秒数 (duration)、残りは実行する command。
+  local _duration="$1"
+  shift
+  local _to
+  _to=$(command -v gtimeout 2>/dev/null || command -v timeout 2>/dev/null || echo "")
+  if [ -n "$_to" ]; then
+    "$_to" "$_duration" "$@"
+  else
+    "$@"
+  fi
+}
+
+# --- telemetry event --------------------------------------------------------
+
+_uzustack_codex_log_event() {
+  # ~/.uzustack/analytics/skill-usage.jsonl に telemetry イベントを emit。
+  # $_TEL != "off" のときだけ動く (caller が uzustack-config から設定)。
+  # event 種別: codex_timeout, codex_auth_failed, codex_cli_missing,
+  #              codex_version_warning。
+  # payload schema: {skill, event, duration_s, ts}。prompt 本文 / env var 値 /
+  # auth token は一切含めない。
+  local _event="$1"
+  local _duration="${2:-0}"
+  [ "${_TEL:-off}" = "off" ] && return 0
+  mkdir -p "$HOME/.uzustack/analytics" 2>/dev/null || return 0
+  local _ts
+  _ts=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown)
+  printf '{"skill":"codex","event":"%s","duration_s":"%s","ts":"%s"}\n' \
+    "$_event" "$_duration" "$_ts" \
+    >> "$HOME/.uzustack/analytics/skill-usage.jsonl" 2>/dev/null || true
+}
+
+# --- ハング時の learnings log --------------------------------------------------
+
+_uzustack_codex_log_hang() {
+  # codex 呼び出しが timeout (exit 124) した時に呼ばれる。/investigate skill が
+  # 将来 pattern を surface できるよう operational learning を記録する。
+  # best-effort: error は飲み込む。
+  local _mode="${1:-unknown}"
+  local _prompt_size="${2:-0}"
+  local _log_bin="$HOME/.claude/skills/uzustack/bin/uzustack-learnings-log"
+  [ -x "$_log_bin" ] || return 0
+  local _key="codex-hang-$(date +%s 2>/dev/null || echo unknown)"
+  "$_log_bin" "$(printf '{"skill":"codex","type":"operational","key":"%s","insight":"Codex timed out after 600s during [%s] invocation. Prompt size: %s. Consider splitting prompt or checking network.","confidence":8,"source":"observed","files":["codex/SKILL.md.tmpl","autoplan/SKILL.md.tmpl"]}' "$_key" "$_mode" "$_prompt_size")" \
+    >/dev/null 2>&1 || true
+}

--- a/bin/uzustack-global-discover.ts
+++ b/bin/uzustack-global-discover.ts
@@ -1,0 +1,602 @@
+#!/usr/bin/env bun
+/**
+ * uzustack-global-discover — Discover AI coding sessions across Claude Code, Codex CLI, and Gemini CLI.
+ * Resolves each session's working directory to a git repo, deduplicates by normalized remote URL,
+ * and outputs structured JSON to stdout.
+ *
+ * Usage:
+ *   uzustack-global-discover --since 7d [--format json|summary]
+ *   uzustack-global-discover --help
+ */
+
+import { existsSync, readdirSync, statSync, readFileSync, openSync, readSync, closeSync } from "fs";
+import { join, basename } from "path";
+import { execSync } from "child_process";
+import { homedir } from "os";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+interface Session {
+  tool: "claude_code" | "codex" | "gemini";
+  cwd: string;
+}
+
+interface Repo {
+  name: string;
+  remote: string;
+  paths: string[];
+  sessions: { claude_code: number; codex: number; gemini: number };
+}
+
+interface DiscoveryResult {
+  window: string;
+  start_date: string;
+  repos: Repo[];
+  tools: {
+    claude_code: { total_sessions: number; repos: number };
+    codex: { total_sessions: number; repos: number };
+    gemini: { total_sessions: number; repos: number };
+  };
+  total_sessions: number;
+  total_repos: number;
+}
+
+// ── CLI parsing ────────────────────────────────────────────────────────────
+
+function printUsage(): void {
+  console.error(`Usage: uzustack-global-discover --since <window> [--format json|summary]
+
+  --since <window>   Time window: e.g. 7d, 14d, 30d, 24h
+  --format <fmt>     Output format: json (default) or summary
+  --help             Show this help
+
+Examples:
+  uzustack-global-discover --since 7d
+  uzustack-global-discover --since 14d --format summary`);
+}
+
+function parseArgs(): { since: string; format: "json" | "summary" } {
+  const args = process.argv.slice(2);
+  let since = "";
+  let format: "json" | "summary" = "json";
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--help" || args[i] === "-h") {
+      printUsage();
+      process.exit(0);
+    } else if (args[i] === "--since" && args[i + 1]) {
+      since = args[++i];
+    } else if (args[i] === "--format" && args[i + 1]) {
+      const f = args[++i];
+      if (f !== "json" && f !== "summary") {
+        console.error(`Invalid format: ${f}. Use 'json' or 'summary'.`);
+        printUsage();
+        process.exit(1);
+      }
+      format = f;
+    } else {
+      console.error(`Unknown argument: ${args[i]}`);
+      printUsage();
+      process.exit(1);
+    }
+  }
+
+  if (!since) {
+    console.error("Error: --since is required.");
+    printUsage();
+    process.exit(1);
+  }
+
+  if (!/^\d+(d|h|w)$/.test(since)) {
+    console.error(`Invalid window format: ${since}. Use e.g. 7d, 24h, 2w.`);
+    process.exit(1);
+  }
+
+  return { since, format };
+}
+
+function windowToDate(window: string): Date {
+  const match = window.match(/^(\d+)(d|h|w)$/);
+  if (!match) throw new Error(`Invalid window: ${window}`);
+  const [, numStr, unit] = match;
+  const num = parseInt(numStr, 10);
+  const now = new Date();
+
+  if (unit === "h") {
+    return new Date(now.getTime() - num * 60 * 60 * 1000);
+  } else if (unit === "w") {
+    // weeks — midnight-aligned like days
+    const d = new Date(now);
+    d.setDate(d.getDate() - num * 7);
+    d.setHours(0, 0, 0, 0);
+    return d;
+  } else {
+    // days — midnight-aligned
+    const d = new Date(now);
+    d.setDate(d.getDate() - num);
+    d.setHours(0, 0, 0, 0);
+    return d;
+  }
+}
+
+// ── URL normalization ──────────────────────────────────────────────────────
+
+export function normalizeRemoteUrl(url: string): string {
+  let normalized = url.trim();
+
+  // SSH → HTTPS: git@github.com:user/repo → https://github.com/user/repo
+  const sshMatch = normalized.match(/^(?:ssh:\/\/)?git@([^:]+):(.+)$/);
+  if (sshMatch) {
+    normalized = `https://${sshMatch[1]}/${sshMatch[2]}`;
+  }
+
+  // Strip .git suffix
+  if (normalized.endsWith(".git")) {
+    normalized = normalized.slice(0, -4);
+  }
+
+  // Lowercase the host portion
+  try {
+    const parsed = new URL(normalized);
+    parsed.hostname = parsed.hostname.toLowerCase();
+    normalized = parsed.toString();
+    // Remove trailing slash
+    if (normalized.endsWith("/")) {
+      normalized = normalized.slice(0, -1);
+    }
+  } catch {
+    // Not a valid URL (e.g., local:<path>), return as-is
+  }
+
+  return normalized;
+}
+
+// ── Git helpers ────────────────────────────────────────────────────────────
+
+function isGitRepo(dir: string): boolean {
+  return existsSync(join(dir, ".git"));
+}
+
+function getGitRemote(cwd: string): string | null {
+  if (!existsSync(cwd) || !isGitRepo(cwd)) return null;
+  try {
+    const remote = execSync("git remote get-url origin", {
+      cwd,
+      encoding: "utf-8",
+      timeout: 5000,
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+    return remote || null;
+  } catch (err: any) {
+    // Expected: no remote configured, repo not found, git not installed
+    if (err?.status !== undefined) return null; // non-zero exit from git
+    if (err?.code === 'ENOENT') return null;    // git binary not found
+    throw err;
+  }
+}
+
+// ── Scanners ───────────────────────────────────────────────────────────────
+
+function scanClaudeCode(since: Date): Session[] {
+  const projectsDir = join(homedir(), ".claude", "projects");
+  if (!existsSync(projectsDir)) return [];
+
+  const sessions: Session[] = [];
+
+  let dirs: string[];
+  try {
+    dirs = readdirSync(projectsDir);
+  } catch (err: any) {
+    if (err?.code === 'ENOENT' || err?.code === 'EACCES') return [];
+    throw err;
+  }
+
+  for (const dirName of dirs) {
+    const dirPath = join(projectsDir, dirName);
+    try {
+      const stat = statSync(dirPath);
+      if (!stat.isDirectory()) continue;
+    } catch {
+      continue;
+    }
+
+    // Find JSONL files
+    let jsonlFiles: string[];
+    try {
+      jsonlFiles = readdirSync(dirPath).filter((f) => f.endsWith(".jsonl"));
+    } catch {
+      continue;
+    }
+    if (jsonlFiles.length === 0) continue;
+
+    // Coarse mtime pre-filter: check if any JSONL file is recent
+    const hasRecentFile = jsonlFiles.some((f) => {
+      try {
+        return statSync(join(dirPath, f)).mtime >= since;
+      } catch (err: any) {
+        if (err?.code === 'ENOENT' || err?.code === 'EACCES') return false;
+        throw err;
+      }
+    });
+    if (!hasRecentFile) continue;
+
+    // Resolve cwd
+    let cwd = resolveClaudeCodeCwd(dirPath, dirName, jsonlFiles);
+    if (!cwd) continue;
+
+    // Count only JSONL files modified within the window as sessions
+    const recentFiles = jsonlFiles.filter((f) => {
+      try {
+        return statSync(join(dirPath, f)).mtime >= since;
+      } catch (err: any) {
+        if (err?.code === 'ENOENT' || err?.code === 'EACCES') return false;
+        throw err;
+      }
+    });
+    for (let i = 0; i < recentFiles.length; i++) {
+      sessions.push({ tool: "claude_code", cwd });
+    }
+  }
+
+  return sessions;
+}
+
+function resolveClaudeCodeCwd(
+  dirPath: string,
+  dirName: string,
+  jsonlFiles: string[]
+): string | null {
+  // Fast-path: decode directory name
+  // e.g., -Users-garrytan-git-repo → /Users/garrytan/git/repo
+  const decoded = dirName.replace(/^-/, "/").replace(/-/g, "/");
+  if (existsSync(decoded)) return decoded;
+
+  // Fallback: read cwd from first JSONL file
+  // Sort by mtime descending, pick most recent
+  const sorted = jsonlFiles
+    .map((f) => {
+      try {
+        return { name: f, mtime: statSync(join(dirPath, f)).mtime.getTime() };
+      } catch (err: any) {
+        if (err?.code === 'ENOENT' || err?.code === 'EACCES') return null;
+        throw err;
+      }
+    })
+    .filter(Boolean)
+    .sort((a, b) => b!.mtime - a!.mtime) as { name: string; mtime: number }[];
+
+  for (const file of sorted.slice(0, 3)) {
+    const cwd = extractCwdFromJsonl(join(dirPath, file.name));
+    if (cwd && existsSync(cwd)) return cwd;
+  }
+
+  return null;
+}
+
+function extractCwdFromJsonl(filePath: string): string | null {
+  try {
+    // Read only the first 8KB to avoid loading huge JSONL files into memory
+    const fd = openSync(filePath, "r");
+    const buf = Buffer.alloc(8192);
+    const bytesRead = readSync(fd, buf, 0, 8192, 0);
+    closeSync(fd);
+    const text = buf.toString("utf-8", 0, bytesRead);
+    const lines = text.split("\n").slice(0, 15);
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      try {
+        const obj = JSON.parse(line);
+        if (obj.cwd) return obj.cwd;
+      } catch {
+        continue;
+      }
+    }
+  } catch {
+    // File read error
+  }
+  return null;
+}
+
+function scanCodex(since: Date): Session[] {
+  const sessionsDir = process.env.CODEX_SESSIONS_DIR || join(homedir(), ".codex", "sessions");
+  if (!existsSync(sessionsDir)) return [];
+
+  const sessions: Session[] = [];
+
+  // Walk YYYY/MM/DD directory structure
+  try {
+    const years = readdirSync(sessionsDir);
+    for (const year of years) {
+      const yearPath = join(sessionsDir, year);
+      if (!statSync(yearPath).isDirectory()) continue;
+
+      const months = readdirSync(yearPath);
+      for (const month of months) {
+        const monthPath = join(yearPath, month);
+        if (!statSync(monthPath).isDirectory()) continue;
+
+        const days = readdirSync(monthPath);
+        for (const day of days) {
+          const dayPath = join(monthPath, day);
+          if (!statSync(dayPath).isDirectory()) continue;
+
+          const files = readdirSync(dayPath).filter((f) =>
+            f.startsWith("rollout-") && f.endsWith(".jsonl")
+          );
+
+          for (const file of files) {
+            const filePath = join(dayPath, file);
+            try {
+              const stat = statSync(filePath);
+              if (stat.mtime < since) continue;
+            } catch {
+              continue;
+            }
+
+            // Codex session_meta lines embed the full system prompt in
+            // base_instructions (~15KB as of CLI v0.117+). A 4KB buffer
+            // truncates the line and JSON.parse fails. 128KB covers current
+            // sizes with room for growth.
+            try {
+              const fd = openSync(filePath, "r");
+              const buf = Buffer.alloc(131072);
+              const bytesRead = readSync(fd, buf, 0, 131072, 0);
+              closeSync(fd);
+              const firstLine = buf.toString("utf-8", 0, bytesRead).split("\n")[0];
+              if (!firstLine) continue;
+              const meta = JSON.parse(firstLine);
+              if (meta.type === "session_meta" && meta.payload?.cwd) {
+                sessions.push({ tool: "codex", cwd: meta.payload.cwd });
+              }
+            } catch {
+              console.error(`Warning: could not parse Codex session ${filePath}`);
+            }
+          }
+        }
+      }
+    }
+  } catch {
+    // Directory read error
+  }
+
+  return sessions;
+}
+
+function scanGemini(since: Date): Session[] {
+  const tmpDir = join(homedir(), ".gemini", "tmp");
+  if (!existsSync(tmpDir)) return [];
+
+  // Load projects.json for path mapping
+  const projectsPath = join(homedir(), ".gemini", "projects.json");
+  let projectsMap: Record<string, string> = {}; // name → path
+  if (existsSync(projectsPath)) {
+    try {
+      const data = JSON.parse(readFileSync(projectsPath, { encoding: "utf-8" }));
+      // Format: { projects: { "/path": "name" } } — we want name → path
+      const projects = data.projects || {};
+      for (const [path, name] of Object.entries(projects)) {
+        projectsMap[name as string] = path;
+      }
+    } catch {
+      console.error("Warning: could not parse ~/.gemini/projects.json");
+    }
+  }
+
+  const sessions: Session[] = [];
+  const seenTimestamps = new Map<string, Set<string>>(); // projectName → Set<startTime>
+
+  let projectDirs: string[];
+  try {
+    projectDirs = readdirSync(tmpDir);
+  } catch (err: any) {
+    if (err?.code === 'ENOENT' || err?.code === 'EACCES') return [];
+    throw err;
+  }
+
+  for (const projectName of projectDirs) {
+    const chatsDir = join(tmpDir, projectName, "chats");
+    if (!existsSync(chatsDir)) continue;
+
+    // Resolve cwd from projects.json
+    let cwd = projectsMap[projectName] || null;
+
+    // Fallback: check .project_root
+    if (!cwd) {
+      const projectRootFile = join(tmpDir, projectName, ".project_root");
+      if (existsSync(projectRootFile)) {
+        try {
+          cwd = readFileSync(projectRootFile, { encoding: "utf-8" }).trim();
+        } catch {}
+      }
+    }
+
+    if (!cwd || !existsSync(cwd)) continue;
+
+    const seen = seenTimestamps.get(projectName) || new Set<string>();
+    seenTimestamps.set(projectName, seen);
+
+    let files: string[];
+    try {
+      files = readdirSync(chatsDir).filter((f) =>
+        f.startsWith("session-") && f.endsWith(".json")
+      );
+    } catch {
+      continue;
+    }
+
+    for (const file of files) {
+      const filePath = join(chatsDir, file);
+      try {
+        const stat = statSync(filePath);
+        if (stat.mtime < since) continue;
+      } catch {
+        continue;
+      }
+
+      try {
+        const data = JSON.parse(readFileSync(filePath, { encoding: "utf-8" }));
+        const startTime = data.startTime || "";
+
+        // Deduplicate by startTime within project
+        if (startTime && seen.has(startTime)) continue;
+        if (startTime) seen.add(startTime);
+
+        sessions.push({ tool: "gemini", cwd });
+      } catch {
+        console.error(`Warning: could not parse Gemini session ${filePath}`);
+      }
+    }
+  }
+
+  return sessions;
+}
+
+// ── Deduplication ──────────────────────────────────────────────────────────
+
+async function resolveAndDeduplicate(sessions: Session[]): Promise<Repo[]> {
+  // Group sessions by cwd
+  const byCwd = new Map<string, Session[]>();
+  for (const s of sessions) {
+    const existing = byCwd.get(s.cwd) || [];
+    existing.push(s);
+    byCwd.set(s.cwd, existing);
+  }
+
+  // Resolve git remotes for each cwd
+  const cwds = Array.from(byCwd.keys());
+  const remoteMap = new Map<string, string>(); // cwd → normalized remote
+
+  for (const cwd of cwds) {
+    const raw = getGitRemote(cwd);
+    if (raw) {
+      remoteMap.set(cwd, normalizeRemoteUrl(raw));
+    } else if (existsSync(cwd) && isGitRepo(cwd)) {
+      remoteMap.set(cwd, `local:${cwd}`);
+    }
+  }
+
+  // Group by normalized remote
+  const byRemote = new Map<string, { paths: string[]; sessions: Session[] }>();
+  for (const [cwd, cwdSessions] of byCwd) {
+    const remote = remoteMap.get(cwd);
+    if (!remote) continue;
+
+    const existing = byRemote.get(remote) || { paths: [], sessions: [] };
+    if (!existing.paths.includes(cwd)) existing.paths.push(cwd);
+    existing.sessions.push(...cwdSessions);
+    byRemote.set(remote, existing);
+  }
+
+  // Build Repo objects
+  const repos: Repo[] = [];
+  for (const [remote, data] of byRemote) {
+    // Find first valid path
+    const validPath = data.paths.find((p) => existsSync(p) && isGitRepo(p));
+    if (!validPath) continue;
+
+    // Derive name from remote URL
+    let name: string;
+    if (remote.startsWith("local:")) {
+      name = basename(remote.replace("local:", ""));
+    } else {
+      try {
+        const url = new URL(remote);
+        name = basename(url.pathname);
+      } catch {
+        name = basename(remote);
+      }
+    }
+
+    const sessionCounts = { claude_code: 0, codex: 0, gemini: 0 };
+    for (const s of data.sessions) {
+      sessionCounts[s.tool]++;
+    }
+
+    repos.push({
+      name,
+      remote,
+      paths: data.paths,
+      sessions: sessionCounts,
+    });
+  }
+
+  // Sort by total sessions descending
+  repos.sort(
+    (a, b) =>
+      b.sessions.claude_code + b.sessions.codex + b.sessions.gemini -
+      (a.sessions.claude_code + a.sessions.codex + a.sessions.gemini)
+  );
+
+  return repos;
+}
+
+// ── Main ───────────────────────────────────────────────────────────────────
+
+async function main() {
+  const { since, format } = parseArgs();
+  const sinceDate = windowToDate(since);
+  const startDate = sinceDate.toISOString().split("T")[0];
+
+  // Run all scanners
+  const ccSessions = scanClaudeCode(sinceDate);
+  const codexSessions = scanCodex(sinceDate);
+  const geminiSessions = scanGemini(sinceDate);
+
+  const allSessions = [...ccSessions, ...codexSessions, ...geminiSessions];
+
+  // Summary to stderr
+  console.error(
+    `Discovered: ${ccSessions.length} CC sessions, ${codexSessions.length} Codex sessions, ${geminiSessions.length} Gemini sessions`
+  );
+
+  // Deduplicate
+  const repos = await resolveAndDeduplicate(allSessions);
+
+  console.error(`→ ${repos.length} unique repos`);
+
+  // Count per-tool repo counts
+  const ccRepos = new Set(repos.filter((r) => r.sessions.claude_code > 0).map((r) => r.remote)).size;
+  const codexRepos = new Set(repos.filter((r) => r.sessions.codex > 0).map((r) => r.remote)).size;
+  const geminiRepos = new Set(repos.filter((r) => r.sessions.gemini > 0).map((r) => r.remote)).size;
+
+  const result: DiscoveryResult = {
+    window: since,
+    start_date: startDate,
+    repos,
+    tools: {
+      claude_code: { total_sessions: ccSessions.length, repos: ccRepos },
+      codex: { total_sessions: codexSessions.length, repos: codexRepos },
+      gemini: { total_sessions: geminiSessions.length, repos: geminiRepos },
+    },
+    total_sessions: allSessions.length,
+    total_repos: repos.length,
+  };
+
+  if (format === "json") {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    // Summary format
+    console.log(`Window: ${since} (since ${startDate})`);
+    console.log(`Sessions: ${allSessions.length} total (CC: ${ccSessions.length}, Codex: ${codexSessions.length}, Gemini: ${geminiSessions.length})`);
+    console.log(`Repos: ${repos.length} unique`);
+    console.log("");
+    for (const repo of repos) {
+      const total = repo.sessions.claude_code + repo.sessions.codex + repo.sessions.gemini;
+      const tools = [];
+      if (repo.sessions.claude_code > 0) tools.push(`CC:${repo.sessions.claude_code}`);
+      if (repo.sessions.codex > 0) tools.push(`Codex:${repo.sessions.codex}`);
+      if (repo.sessions.gemini > 0) tools.push(`Gemini:${repo.sessions.gemini}`);
+      console.log(`  ${repo.name} (${total} sessions) — ${tools.join(", ")}`);
+      console.log(`    Remote: ${repo.remote}`);
+      console.log(`    Paths: ${repo.paths.join(", ")}`);
+    }
+  }
+}
+
+// Only run main when executed directly (not when imported for testing)
+if (import.meta.main) {
+  main().catch((err) => {
+    console.error(`Fatal error: ${err.message}`);
+    process.exit(1);
+  });
+}

--- a/bin/uzustack-open-url
+++ b/bin/uzustack-open-url
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# uzustack-open-url — OS 横断の URL opener
+#
+# 使い方: uzustack-open-url <url>
+set -euo pipefail
+
+URL="${1:?使い方: uzustack-open-url <url>}"
+
+case "$(uname -s)" in
+  Darwin)  open "$URL" ;;
+  Linux)   xdg-open "$URL" 2>/dev/null || echo "$URL" ;;
+  MINGW*|MSYS*|CYGWIN*) start "$URL" ;;
+  *)       echo "$URL" ;;
+esac

--- a/bin/uzustack-patch-names
+++ b/bin/uzustack-patch-names
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# uzustack-patch-names — prefix mode に合わせて SKILL.md frontmatter の name: field を patch
+# 使い方: uzustack-patch-names <uzustack-dir> <true|false|1|0>
+set -euo pipefail
+
+UZUSTACK_DIR="$1"
+DO_PREFIX="$2"
+
+# prefix 引数を正規化
+case "$DO_PREFIX" in true|1) DO_PREFIX=1 ;; *) DO_PREFIX=0 ;; esac
+
+PATCHED=0
+for skill_dir in "$UZUSTACK_DIR"/*/; do
+  [ -f "$skill_dir/SKILL.md" ] || continue
+  dir_name="$(basename "$skill_dir")"
+  [ "$dir_name" = "node_modules" ] && continue
+  cur=$(grep -m1 '^name:' "$skill_dir/SKILL.md" 2>/dev/null | sed 's/^name:[[:space:]]*//' | tr -d '[:space:]' || true)
+  [ -z "$cur" ] && continue
+  [ "$cur" = "uzustack" ] && continue  # root skill には prefix 付けない
+  if [ "$DO_PREFIX" -eq 1 ]; then
+    case "$cur" in uzustack-*) continue ;; esac
+    new="uzustack-$cur"
+  else
+    case "$cur" in uzustack-*) ;; *) continue ;; esac
+    [ "$dir_name" = "$cur" ] && continue  # 実体名そのものが prefix 付き (例: uzustack-upgrade)
+    new="${cur#uzustack-}"
+  fi
+  tmp="$(mktemp "${skill_dir}/SKILL.md.XXXXXX")"
+  sed "1,/^---$/s/^name:[[:space:]]*${cur}/name: ${new}/" "$skill_dir/SKILL.md" > "$tmp" && mv "$tmp" "$skill_dir/SKILL.md"
+  PATCHED=$((PATCHED + 1))
+done
+if [ "$PATCHED" -gt 0 ]; then
+  echo "  $PATCHED 個の skill の name: field を patch した"
+fi

--- a/bin/uzustack-relink
+++ b/bin/uzustack-relink
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# uzustack-relink — skill_prefix config に基づいて skill symlink を張り直す
+#
+# 使い方:
+#   uzustack-relink
+#
+# テスト用 env override:
+#   UZUSTACK_STATE_DIR   — ~/.uzustack state directory を上書き
+#   UZUSTACK_INSTALL_DIR — uzustack install directory を上書き
+#   UZUSTACK_SKILLS_DIR  — 配置先 skills directory を上書き
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+UZUSTACK_CONFIG="${SCRIPT_DIR}/uzustack-config"
+
+# install dir を検出
+INSTALL_DIR="${UZUSTACK_INSTALL_DIR:-}"
+if [ -z "$INSTALL_DIR" ]; then
+  if [ -d "$HOME/.claude/skills/uzustack" ]; then
+    INSTALL_DIR="$HOME/.claude/skills/uzustack"
+  elif [ -d "${SCRIPT_DIR}/.." ] && [ -f "${SCRIPT_DIR}/../setup" ]; then
+    INSTALL_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+  fi
+fi
+
+if [ -z "$INSTALL_DIR" ] || [ ! -d "$INSTALL_DIR" ]; then
+  echo "エラー: uzustack install directory が見つからない。" >&2
+  echo "実行: cd ~/.claude/skills/uzustack && ./setup" >&2
+  exit 1
+fi
+
+# 配置先 skills dir を検出
+SKILLS_DIR="${UZUSTACK_SKILLS_DIR:-$(dirname "$INSTALL_DIR")}"
+[ -d "$SKILLS_DIR" ] || mkdir -p "$SKILLS_DIR"
+
+# prefix 設定を読む
+PREFIX=$("$UZUSTACK_CONFIG" get skill_prefix 2>/dev/null || echo "false")
+
+# helper: 古い skill entry (symlink もしくは SKILL.md が symlink の実 directory) を撤去
+_cleanup_skill_entry() {
+  local entry="$1"
+  if [ -L "$entry" ]; then
+    rm -f "$entry"
+  elif [ -d "$entry" ] && [ -L "$entry/SKILL.md" ]; then
+    rm -rf "$entry"
+  fi
+}
+
+# skill 群を発見 (SKILL.md がある directory、meta dir は除外)
+SKILL_COUNT=0
+for skill_dir in "$INSTALL_DIR"/*/; do
+  [ -d "$skill_dir" ] || continue
+  skill=$(basename "$skill_dir")
+  # skill ではない directory を skip
+  case "$skill" in bin|browse|design|docs|extension|lib|node_modules|scripts|test|.git|.github) continue ;; esac
+  [ -f "$skill_dir/SKILL.md" ] || continue
+
+  if [ "$PREFIX" = "true" ]; then
+    # 既に uzustack-* 名の directory を二重 prefix しない
+    case "$skill" in
+      uzustack-*) link_name="$skill" ;;
+      *)          link_name="uzustack-$skill" ;;
+    esac
+    # 古い flat entry が残っていれば削除 (新 link と同じ名前なら残す)
+    [ "$link_name" != "$skill" ] && _cleanup_skill_entry "$SKILLS_DIR/$skill"
+  else
+    link_name="$skill"
+    # 実体名が uzustack-* (例: uzustack-upgrade) の dir は撤去しない
+    case "$skill" in
+      uzustack-*) ;; # 実体名なので prefix 付き古 link は無い
+      *)          _cleanup_skill_entry "$SKILLS_DIR/uzustack-$skill" ;;
+    esac
+  fi
+  target="$SKILLS_DIR/$link_name"
+  # 古い directory symlink を実 directory に upgrade
+  [ -L "$target" ] && rm -f "$target"
+  # SKILL.md を symlink した実 directory を作る (絶対 path)
+  mkdir -p "$target"
+  ln -snf "$INSTALL_DIR/$skill/SKILL.md" "$target/SKILL.md"
+  SKILL_COUNT=$((SKILL_COUNT + 1))
+done
+
+# prefix 設定に合わせて SKILL.md の name: field を patch
+"$INSTALL_DIR/bin/uzustack-patch-names" "$INSTALL_DIR" "$PREFIX"
+
+if [ "$PREFIX" = "true" ]; then
+  echo "$SKILL_COUNT 個の skill を uzustack-* 名で relink した"
+else
+  echo "$SKILL_COUNT 個の skill を flat 名で relink した"
+fi

--- a/bin/uzustack-uninstall
+++ b/bin/uzustack-uninstall
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# uzustack-uninstall — uzustack の skill / state / browse daemon を削除する
+#
+# 使い方:
+#   uzustack-uninstall              — 対話的アンインストール (削除前に prompt)
+#   uzustack-uninstall --force      — 確認なしで全部削除
+#   uzustack-uninstall --keep-state — skill は削除するが ~/.uzustack/ data は残す
+#
+# 削除対象:
+#   ~/.claude/skills/uzustack       — Claude global skill install (git clone or vendored)
+#   ~/.claude/skills/{skill}        — setup が作った per-skill symlink
+#   ~/.codex/skills/uzustack*       — Codex skill install + per-skill symlink
+#   ~/.factory/skills/uzustack*     — Factory Droid skill install + per-skill symlink
+#   ~/.kiro/skills/uzustack*        — Kiro skill install + per-skill symlink
+#   ~/.uzustack/                    — global state (config, analytics, sessions, projects,
+#                                     repos, installation-id, browse error logs)
+#   .claude/skills/uzustack*        — project ローカル skill install (--local install 用)
+#   .uzustack/                      — project ごとの browse state (現在の git repo)
+#   .uzustack-worktrees/            — project ごとの test worktree (現在の git repo)
+#   .agents/skills/uzustack*        — Codex/Gemini/Cursor sidecar (現在の git repo)
+#   起動中の browse daemon          — cleanup 前に SIGTERM で停止
+#
+# 削除しないもの:
+#   ~/Library/Caches/ms-playwright/  — Playwright Chromium (他 tool と共用の可能性)
+#   ~/.uzustack-dev/                 — 開発者向け eval artifact (uzustack contributor のみ)
+#
+# テスト用 env override:
+#   UZUSTACK_DIR        — 自動検出した uzustack root を上書き
+#   UZUSTACK_STATE_DIR  — ~/.uzustack state directory を上書き
+#
+# NOTE: set -uo pipefail (-e なし) — uninstall は途中で abort してはならない。
+set -uo pipefail
+
+if [ -z "${HOME:-}" ]; then
+  echo "エラー: \$HOME が設定されていない" >&2
+  exit 1
+fi
+
+UZUSTACK_DIR="${UZUSTACK_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+STATE_DIR="${UZUSTACK_STATE_DIR:-$HOME/.uzustack}"
+_GIT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+
+# ─── flag を parse ─────────────────────────────────────────────
+FORCE=0
+KEEP_STATE=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --force) FORCE=1; shift ;;
+    --keep-state) KEEP_STATE=1; shift ;;
+    -h|--help)
+      sed -n '2,/^[^#]/{ /^#/s/^# \{0,1\}//p; }' "$0"
+      exit 0
+      ;;
+    *)
+      echo "未知の option: $1" >&2
+      echo "使い方: uzustack-uninstall [--force] [--keep-state]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# ─── 確認 ────────────────────────────────────────────
+if [ "$FORCE" -eq 0 ]; then
+  echo "uzustack をシステムから削除する:"
+  { [ -d "$HOME/.claude/skills/uzustack" ] || [ -L "$HOME/.claude/skills/uzustack" ]; } && echo "  ~/.claude/skills/uzustack (+ per-skill symlink)"
+  [ -d "$HOME/.codex/skills" ] && echo "  ~/.codex/skills/uzustack*"
+  [ -d "$HOME/.factory/skills" ] && echo "  ~/.factory/skills/uzustack*"
+  [ -d "$HOME/.kiro/skills" ] && echo "  ~/.kiro/skills/uzustack*"
+  [ "$KEEP_STATE" -eq 0 ] && [ -d "$STATE_DIR" ] && echo "  $STATE_DIR"
+
+  if [ -n "$_GIT_ROOT" ]; then
+    [ -d "$_GIT_ROOT/.claude/skills/uzustack" ] && echo "  $_GIT_ROOT/.claude/skills/uzustack (project ローカル)"
+    [ -d "$_GIT_ROOT/.uzustack" ] && echo "  $_GIT_ROOT/.uzustack/ (browse state + reports)"
+    [ -d "$_GIT_ROOT/.uzustack-worktrees" ] && echo "  $_GIT_ROOT/.uzustack-worktrees/"
+    [ -d "$_GIT_ROOT/.agents/skills" ] && echo "  $_GIT_ROOT/.agents/skills/uzustack*"
+  fi
+
+  # 起動中の daemon を preview
+  if [ -n "$_GIT_ROOT" ] && [ -f "$_GIT_ROOT/.uzustack/browse.json" ]; then
+    _PREVIEW_PID="$(awk -F'[:,]' '/"pid"/ { for(i=1;i<=NF;i++) if($i ~ /"pid"/) { gsub(/[^0-9]/, "", $(i+1)); print $(i+1); exit } }' "$_GIT_ROOT/.uzustack/browse.json" 2>/dev/null || true)"
+    [ -n "$_PREVIEW_PID" ] && kill -0 "$_PREVIEW_PID" 2>/dev/null && echo "  browse daemon (PID $_PREVIEW_PID) を停止する"
+  fi
+
+  printf "\n続行しますか？ [y/N] "
+  read -r REPLY
+  case "$REPLY" in
+    y|Y|yes|YES) ;;
+    *) echo "中断した。"; exit 0 ;;
+  esac
+fi
+
+REMOVED=()
+
+# ─── 起動中の browse daemon を停止 ─────────────────────────────
+# browse server は {project}/.uzustack/browse.json に PID を書く。
+# state directory 削除前に見つけた daemon を停止する。
+stop_browse_daemon() {
+  local state_file="$1"
+  if [ ! -f "$state_file" ]; then
+    return
+  fi
+  local pid
+  pid="$(awk -F'[:,]' '/"pid"/ { for(i=1;i<=NF;i++) if($i ~ /"pid"/) { gsub(/[^0-9]/, "", $(i+1)); print $(i+1); exit } }' "$state_file" 2>/dev/null || true)"
+  if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" 2>/dev/null || true
+    # graceful shutdown を 2 秒待つ
+    local waited=0
+    while [ "$waited" -lt 4 ] && kill -0 "$pid" 2>/dev/null; do
+      sleep 0.5
+      waited=$(( waited + 1 ))
+    done
+    if kill -0 "$pid" 2>/dev/null; then
+      kill -9 "$pid" 2>/dev/null || true
+    fi
+    REMOVED+=("browse daemon (PID $pid)")
+  fi
+}
+
+# 現在の project の daemon を停止
+if [ -n "$_GIT_ROOT" ] && [ -f "$_GIT_ROOT/.uzustack/browse.json" ]; then
+  stop_browse_daemon "$_GIT_ROOT/.uzustack/browse.json"
+fi
+
+# global projects directory に登録された daemon を停止
+if [ -d "$STATE_DIR/projects" ]; then
+  while IFS= read -r _BJ; do
+    stop_browse_daemon "$_BJ"
+  done < <(find "$STATE_DIR/projects" -name browse.json -path '*/.uzustack/*' 2>/dev/null || true)
+fi
+
+# ─── global Claude skill を削除 ────────────────────────────
+CLAUDE_SKILLS="$HOME/.claude/skills"
+if [ -d "$CLAUDE_SKILLS/uzustack" ] || [ -L "$CLAUDE_SKILLS/uzustack" ]; then
+  # uzustack/ 配下を指す per-skill symlink を撤去
+  for _LINK in "$CLAUDE_SKILLS"/*; do
+    [ -L "$_LINK" ] || continue
+    _NAME="$(basename "$_LINK")"
+    [ "$_NAME" = "uzustack" ] && continue
+    _TARGET="$(readlink "$_LINK" 2>/dev/null || true)"
+    case "$_TARGET" in
+      uzustack/*|*/uzustack/*) rm -f "$_LINK"; REMOVED+=("claude/$_NAME") ;;
+    esac
+  done
+
+  rm -rf "$CLAUDE_SKILLS/uzustack"
+  REMOVED+=("~/.claude/skills/uzustack")
+fi
+
+# ─── project ローカル Claude skill を削除 (--local install 用) ──
+if [ -n "$_GIT_ROOT" ] && [ -d "$_GIT_ROOT/.claude/skills" ]; then
+  for _LINK in "$_GIT_ROOT/.claude/skills"/*; do
+    [ -L "$_LINK" ] || continue
+    _TARGET="$(readlink "$_LINK" 2>/dev/null || true)"
+    case "$_TARGET" in
+      uzustack/*|*/uzustack/*) rm -f "$_LINK"; REMOVED+=("local claude/$(basename "$_LINK")") ;;
+    esac
+  done
+  if [ -d "$_GIT_ROOT/.claude/skills/uzustack" ] || [ -L "$_GIT_ROOT/.claude/skills/uzustack" ]; then
+    rm -rf "$_GIT_ROOT/.claude/skills/uzustack"
+    REMOVED+=("$_GIT_ROOT/.claude/skills/uzustack")
+  fi
+fi
+
+# ─── Codex skill を削除 ────────────────────────────────────
+CODEX_SKILLS="$HOME/.codex/skills"
+if [ -d "$CODEX_SKILLS" ]; then
+  for _ITEM in "$CODEX_SKILLS"/uzustack*; do
+    [ -e "$_ITEM" ] || [ -L "$_ITEM" ] || continue
+    rm -rf "$_ITEM"
+    REMOVED+=("codex/$(basename "$_ITEM")")
+  done
+fi
+
+# ─── Factory Droid skill を削除 ────────────────────────────
+FACTORY_SKILLS="$HOME/.factory/skills"
+if [ -d "$FACTORY_SKILLS" ]; then
+  for _ITEM in "$FACTORY_SKILLS"/uzustack*; do
+    [ -e "$_ITEM" ] || [ -L "$_ITEM" ] || continue
+    rm -rf "$_ITEM"
+    REMOVED+=("factory/$(basename "$_ITEM")")
+  done
+fi
+
+# ─── Kiro skill を削除 ─────────────────────────────────────
+KIRO_SKILLS="$HOME/.kiro/skills"
+if [ -d "$KIRO_SKILLS" ]; then
+  for _ITEM in "$KIRO_SKILLS"/uzustack*; do
+    [ -e "$_ITEM" ] || [ -L "$_ITEM" ] || continue
+    rm -rf "$_ITEM"
+    REMOVED+=("kiro/$(basename "$_ITEM")")
+  done
+fi
+
+# ─── project ごとの .agents/ sidecar を削除 ──────────────────
+if [ -n "$_GIT_ROOT" ] && [ -d "$_GIT_ROOT/.agents/skills" ]; then
+  for _ITEM in "$_GIT_ROOT/.agents/skills"/uzustack*; do
+    [ -e "$_ITEM" ] || [ -L "$_ITEM" ] || continue
+    rm -rf "$_ITEM"
+    REMOVED+=("agents/$(basename "$_ITEM")")
+  done
+
+  rmdir "$_GIT_ROOT/.agents/skills" 2>/dev/null || true
+  rmdir "$_GIT_ROOT/.agents" 2>/dev/null || true
+fi
+
+# ─── project ごとの .factory/ sidecar を削除 ────────────────
+if [ -n "$_GIT_ROOT" ] && [ -d "$_GIT_ROOT/.factory/skills" ]; then
+  for _ITEM in "$_GIT_ROOT/.factory/skills"/uzustack*; do
+    [ -e "$_ITEM" ] || [ -L "$_ITEM" ] || continue
+    rm -rf "$_ITEM"
+    REMOVED+=("factory/$(basename "$_ITEM")")
+  done
+
+  rmdir "$_GIT_ROOT/.factory/skills" 2>/dev/null || true
+  rmdir "$_GIT_ROOT/.factory" 2>/dev/null || true
+fi
+
+# ─── project ごとの state を削除 ───────────────────────────
+if [ -n "$_GIT_ROOT" ]; then
+  if [ -d "$_GIT_ROOT/.uzustack" ]; then
+    rm -rf "$_GIT_ROOT/.uzustack"
+    REMOVED+=("$_GIT_ROOT/.uzustack/")
+  fi
+  if [ -d "$_GIT_ROOT/.uzustack-worktrees" ]; then
+    rm -rf "$_GIT_ROOT/.uzustack-worktrees"
+    REMOVED+=("$_GIT_ROOT/.uzustack-worktrees/")
+  fi
+fi
+
+# ─── Claude Code 設定から SessionStart hook を削除 ─────────
+SETTINGS_HOOK="$(dirname "$0")/uzustack-settings-hook"
+SESSION_UPDATE="$(dirname "$0")/uzustack-session-update"
+if [ -x "$SETTINGS_HOOK" ]; then
+  "$SETTINGS_HOOK" remove "$SESSION_UPDATE" 2>/dev/null && REMOVED+=("SessionStart hook") || true
+fi
+
+# ─── global state を削除 ────────────────────────────────────
+if [ "$KEEP_STATE" -eq 0 ] && [ -d "$STATE_DIR" ]; then
+  rm -rf "$STATE_DIR"
+  REMOVED+=("$STATE_DIR")
+fi
+
+# ─── temp file を片付け ─────────────────────────────────────
+for _TMP in /tmp/uzustack-latest-version /tmp/uzustack-sketch-*.html /tmp/uzustack-sketch.png /tmp/uzustack-sync-*; do
+  if [ -e "$_TMP" ]; then
+    rm -f "$_TMP"
+    REMOVED+=("$(basename "$_TMP")")
+  fi
+done
+
+# ─── まとめ ────────────────────────────────────────────────
+if [ ${#REMOVED[@]} -gt 0 ]; then
+  echo "削除済: ${REMOVED[*]}"
+  echo "uzustack をアンインストールした。"
+else
+  echo "削除対象なし — uzustack はインストールされていない。"
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Phase 3 cluster B（bin 翻訳、step-35〜39）の **5 step 目（cluster B 最終）**。連携系 binary 7 個を gstack → uzustack に翻訳し、cluster B 完了に伴い voice 規約 v1 + 運用方針 + step-37 拡張 + step-38 学び 3 点 + **規約射程拡張（step-39 で発見した穴埋め）** を CONTRIBUTING.md に集約（step-42 → step-39 完了に集約タイミング前倒し）。

step-35 で確立した **voice 規約 v1（7 項目）+ 運用方針 v1** を 7 binary に適用。**bisect 単位は 1 binary = 1 commit**、計 7 binary commit + CONTRIBUTING.md 統合 1 + 規約射程拡張 1 = **9 commit**。

## 翻訳対象 (実 7 binary、ノート見込みからの調整)

step-39 ノートでは候補 9-10 個と見込んでいたが、upstream 突き合わせで以下に確定:

- **対象外 1**: `gstack-platform-detect` は step-35 で既翻訳済 (`uzustack-platform-detect`)
- **対象外 2**: `gstack-upgrade` は upstream に存在せず (見込み外れ)
- **bash 版 global-discover 不在**: TS 版 (`gstack-global-discover.ts`) のみ存在

### 翻訳した 7 binary

- `uzustack-codex-probe` (101 行) — `/codex` / `/autoplan` skill 用 shared helper、5 関数 (auth-probe / version-check / timeout-wrapper / log-event / log-hang)
- `uzustack-relink` (90 行) — `skill_prefix` config に応じた skill symlink 張替え
- `uzustack-patch-names` (34 行) — SKILL.md frontmatter `name:` field を prefix mode に応じて patch
- `uzustack-open-url` (14 行) — OS 横断 URL opener (macOS open / Linux xdg-open / Windows start / fallback echo)
- `uzustack-global-discover.ts` (602 行 TS) — Claude Code / Codex CLI / Gemini CLI session を cross-tool で発見、git remote 正規化で重複排除
- `uzustack-uninstall` (259 行) — Claude / Codex / Factory / Kiro skill + `~/.uzustack/` state + browse daemon を削除
- `chrome-cdp` (70 行) — Chrome を CDP モードで起動。**`uzustack-` prefix なしで維持** (Chrome [外部 product] + CDP [外部 protocol] の合成は外部 identifier 命名、step-39 で確立した規約射程拡張に従う)

合計 **約 1,170 行**。cluster B 全 step 中で最小規模 (35: 7/9 binary、36: 2、37: 13、38: 21、39: 7)。

## 翻訳判断点 (issue #47 で事前合意 + step-39 で発見した規約射程拡張)

step-38 と同じ 2 軸構成 (外部 CLI 連携なし) + step-39 で 1 軸追加 (規約射程の拡張)。

### 軸 1: 名前空間の境界線

`gstack` 由来は完全置換。**例外として維持**:

- 外部 product 名 (`Codex CLI` / `Gemini CLI` / `Google Chrome`)
- 外部 path / config (`~/.codex/sessions` / `~/.gemini/projects.json` / `~/.claude/projects` / `Chrome.app` / `Default profile` / `Local State`)
- 外部 env (`CODEX_HOME` / `CODEX_API_KEY` / `OPENAI_API_KEY` / `CDP` 関連)
- `chrome-cdp` の `$B connect chrome` の `$B`: browse skill が定義する env alias、cluster D で同名維持前提
- `global-discover.ts` 内の `garrytan` sample コメント: TS は voice 翻案なし、機械置換のみ方針 (step-35 `next-version` 踏襲)

### 軸 2: 動作確認スコープ

各 binary 単独動作のみ。setup の host 別呼び出し点と bin 実体の **end-to-end 動作確認は Phase 4 以降** (33B 再評価メモへの確定回答、cluster B 全 step と一貫)。

### 軸 3: 規約射程の拡張 (step-39 で発見、cluster B 完了で穴埋め)

step-39 完了直前の audit で「voice 規約 v1 (7 項目) + step-37 拡張は **ファイル内 identifier しか射程に入れていなかった**」穴を発見。具体例: `chrome-cdp` を当初 `uzustack-chrome-cdp` に rename していたが、これは「内容は外部 identifier 維持、ファイル名だけ uzustack- prefix」という分裂状態を生んでいた。

**確立した運用ルール**: 外部 product / protocol / tool 名で構成された binary は **`uzustack-` prefix なしで維持** する。

**判断 signal**:
- upstream で `gstack-` prefix が付いていない binary は、upstream 側でも「外部 identifier 命名」と判断した signal として読む
- `_upstream/gstack/test/audit-compliance.test.ts:110` の `readFileSync(join(ROOT, 'bin/chrome-cdp'))` hardcode が **upstream 設計判断の最も強い signal** (将来 test 持ち込み時にも path 整合)

本 PR 内で `bin/uzustack-chrome-cdp` → `bin/chrome-cdp` に rebase 経由で決着 (commit `35f643c` + CONTRIBUTING への規約射程拡張 commit `468624b`)。memory `mechanize_over_scope_skip` 規律と整合。

## 動作確認

- [x] 7 binary 全 syntax check (`bash -n`) PASS、TS 1 binary は `bun build --target=bun --no-bundle` PASS
- [x] `uzustack-codex-probe`: source 後 5 関数 (`_uzustack_codex_*`) が declare されることを確認
- [x] `uzustack-relink`: error path (`UZUSTACK_INSTALL_DIR=/tmp/nonexistent`) で日本語エラー + exit 1
- [x] `uzustack-patch-names`: prefix=true round-trip (`foo` → `uzustack-foo`) + prefix=false round-trip (`uzustack-foo` → `foo`) PASS
- [x] `uzustack-open-url`: 引数なしで「使い方: uzustack-open-url <url>」表示 + exit
- [x] `uzustack-global-discover.ts`: `--help` PASS、`--since 1d --format summary` で実 invocation: 16 CC sessions / 1 unique repo (uzustack 自身) を発見
- [x] `uzustack-uninstall`: `--help` 全文日本語化済 + 対話的 abort path (`n`) で「中断した。」表示 + exit 0、prompt が `~/.claude/skills/uzustack` と `{HOME}/.uzustack` を実 install 状況として正しく検出
- [x] `chrome-cdp`: `bash -n` PASS (Chrome 起動 + 既起動 Chrome の強制 kill を伴う smoke は副作用大で skip)
- [x] setup 配置: `bin/dev-setup` で skill symlink 配置 PASS、`bin/` 全体 symlink は upstream `setup` 仕様通り (**cluster B 5 step 連続で setup 修正不要を実証**)

## CONTRIBUTING.md 統合 (cluster B 完了に伴う集約)

step-42 (Phase 3 完了判定) の判定基準「voice 翻案ガイドラインが CONTRIBUTING に追加済み」を本 PR で **先行履行**。挿入位置は「置換ルール表 v1」section の後、「新規翻訳の手順」section の前。

集約 6 sections:

1. **7 項目** (cluster B step-35 = PR #40 commit `d1b2c0f` で確立) — Section 見出し / エラー客観形 / インラインコメント / fixed identifier / bin 名 backtick / embedded code 日本語化 / 半角括弧
2. **運用方針 v1** — bash + 副言語 embedded は副言語も日本語化 (step-36) / TypeScript 主言語自体は英語維持 (step-35) / Python heredoc 内 error 文字列も日本語化 (step-37)
3. **外部 SaaS / 別プロジェクト identifier 維持** (step-37 拡張、PR #44) — 外部 CLI / 外部 path / 外部 env / 共有 config key / SaaS リソース慣習名 / OS-Tool UI 引用 / 未翻訳 skill 名
4. **step-38 学び 3 点** (PR #46) — dangling reference 機械置換伝播 / output 英語維持境界線 / judgment 軸数の動的性
5. **規約射程の拡張** (step-39 で確立、本 PR で穴埋め) — ファイル名も規約射程に含める / 外部 product / protocol / tool 名で構成された binary は uzustack- prefix なしで維持
6. **集約タイミング規律** — memory `cluster_done_consolidate` 反映 (cluster 完了直後に集約)

## 副次的成果 (cluster B 完了の総括)

- voice 規約 v1 + 運用方針 v1 が **5 step 目で完全 internalize** + **CONTRIBUTING.md 集約完了** (step-35 確立 → 36/37/38/39 適用、5 段階で立証)
- setup 修正不要を **5 度目に実証** (cluster B 全 step、`bin/` 全体 symlink で新 binary 自動 pickup)
- **規約射程の穴を cluster B 内で完全に埋めた**: ファイル内 identifier から「ファイル名 + ファイル内 identifier」へ規約射程を拡張、cluster C 着手前に決着
- step-39 規模調整: ノート見込み「約 10 個」 → 実 7 個 (upstream 突き合わせで 2 個減 + bash 版 1 個不在)
- 33B 再評価メモへの確定回答: end-to-end は step-42 にずらす方針、cluster B 全 step で「単独動作のみ」の規律を維持

## 履歴メモ (rebase + force-push 経緯)

本 PR では `bin/uzustack-chrome-cdp` で当初 commit していた 1 ファイルを、step-39 完了直前の audit で発覚した規約適用ミス (規約射程の穴) を受けて `bin/chrome-cdp` に rebase で決着。具体的には `git reset --hard 00b8fbb` で chrome-cdp commit と CONTRIBUTING 統合 commit を一旦取り消し、3 commit (chrome-cdp 新メッセージ / CONTRIBUTING 統合 cherry-pick / 規約射程拡張) として再構築、`--force-with-lease` で push。reviewer がいない段階で履歴を綺麗に保つ判断。

## 個人 Obsidian vault 同期予定 (PR merge 後)

- step-39 子ノート `frontmatter status: DONE` + `date-completed: 2026-04-29` + `pr: <merged PR#>`
- step-39 子ノート checkbox 全 `[x]` (実態反映、ノート見込みからの調整 = 対象外 2 個 + bash 版不在 1 個 + chrome-cdp 規約射程穴埋め を結果 section で記録)
- step-39 子ノート末尾「## 結果」section 追記 (cluster B 完了の総括 + 規約射程拡張の経緯含む)
- Phase Step 一覧 step-39 行 DONE 化 + リンクテキスト「PR #X merged、cluster B 5 step 目完了、CONTRIBUTING 統合 + 規約射程拡張」 + 日付更新
- uzustack草案 `# 重要` section の wiki-link 確認 (memory `obsidian_main_note_link_loss` 規律)

## scope 注記

- `/simplify` 3 並列 review は本 PR では未実施 (工藤さん明示「テスト終わるところまで」スコープ準拠 + cluster B 後半で uzustack 単独修正が 1 件まで収束する傾向: step-37 = A1/B13、step-38 = A1/B15)。merge 後 / 別タイミングで実施候補
- 結合 test (setup → host 別呼び出し → bin 実体の end-to-end) は step-42 で setup 時限的 guard 撤去と同時に 1 回で実施

## Test plan

- [x] 7 binary syntax check (`bash -n`) PASS
- [x] TS 1 binary `bun build --target=bun --no-bundle` PASS
- [x] 各 binary smoke (5 関数 declare / error path / round-trip / no-arg / --help / 実 invocation / 対話 abort)
- [x] `bin/dev-setup` で skill symlink 配置 PASS (cluster B 5 度目の setup 修正不要)
- [x] CONTRIBUTING.md 6 sections 挿入位置確認 (置換ルール表 v1 と 新規翻訳の手順 の間、規約射程拡張は step-38 学び 3 点 と 集約タイミング規律 の間)
- [x] rename 後 `bin/chrome-cdp` の path が `_upstream/gstack/test/audit-compliance.test.ts:110` の hardcode と整合

Closes #47
