### PR TITLE
feat: context-save / context-restore に {{SLUG_SETUP}} / {{PREAMBLE}} 取り付け — Phase 3 step-41

### DIFF
--- a/context-restore/SKILL.md
+++ b/context-restore/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: context-restore
 type: translated
+preamble-tier: 2
 version: 1.0.0
 description: |
   `/context-save` で保存した作業 context を復元する skill。デフォルトで（全ブランチを跨いで）
@@ -22,6 +23,8 @@ triggers:
 ---
 <!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
 <!-- Regenerate: bun run gen:skill-docs -->
+
+
 
 # /context-restore — 保存済み context を復元
 

--- a/context-restore/SKILL.md.tmpl
+++ b/context-restore/SKILL.md.tmpl
@@ -1,6 +1,7 @@
 ---
 name: context-restore
 type: translated
+preamble-tier: 2
 version: 1.0.0
 description: |
   `/context-save` で保存した作業 context を復元する skill。デフォルトで（全ブランチを跨いで）
@@ -20,6 +21,8 @@ triggers:
   - context restore
   - context-restore
 ---
+
+{{PREAMBLE}}
 
 # /context-restore — 保存済み context を復元
 
@@ -48,7 +51,7 @@ triggers:
 ### Step 1：保存済み context を探す
 
 ```bash
-eval "$(~/.claude/skills/uzustack/bin/uzustack-slug 2>/dev/null)" && mkdir -p ~/.uzustack/projects/$SLUG
+{{SLUG_SETUP}}
 CHECKPOINT_DIR="${UZUSTACK_HOME:-$HOME/.uzustack}/projects/$SLUG/checkpoints"
 if [ ! -d "$CHECKPOINT_DIR" ]; then
   echo "NO_CHECKPOINTS"

--- a/context-save/SKILL.md
+++ b/context-save/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: context-save
 type: translated
+preamble-tier: 2
 version: 1.0.0
 description: |
   作業 context を保存する skill。git state、決定事項、残タスクを記録し、
@@ -24,6 +25,8 @@ triggers:
 ---
 <!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
 <!-- Regenerate: bun run gen:skill-docs -->
+
+
 
 # /context-save — 作業 context を保存
 

--- a/context-save/SKILL.md.tmpl
+++ b/context-save/SKILL.md.tmpl
@@ -1,6 +1,7 @@
 ---
 name: context-save
 type: translated
+preamble-tier: 2
 version: 1.0.0
 description: |
   作業 context を保存する skill。git state、決定事項、残タスクを記録し、
@@ -22,6 +23,8 @@ triggers:
   - context save
   - context-save
 ---
+
+{{PREAMBLE}}
 
 # /context-save — 作業 context を保存
 
@@ -49,7 +52,7 @@ triggers:
 ### Step 1：state を集める
 
 ```bash
-eval "$(~/.claude/skills/uzustack/bin/uzustack-slug 2>/dev/null)" && mkdir -p ~/.uzustack/projects/$SLUG
+{{SLUG_SETUP}}
 ```
 
 現在の作業 state を収集する：
@@ -104,7 +107,7 @@ fi
 パスは bash 側で計算する（LLM プロンプトでは計算しない）。これによりユーザー指定タイトルが後続コマンドに shell metacharacter を注入できないようにする。サニタイズは allowlist 方式：`a-z 0-9 - .` のみ通す。
 
 ```bash
-eval "$(~/.claude/skills/uzustack/bin/uzustack-slug 2>/dev/null)" && mkdir -p ~/.uzustack/projects/$SLUG
+{{SLUG_SETUP}}
 CHECKPOINT_DIR="${UZUSTACK_HOME:-$HOME/.uzustack}/projects/$SLUG/checkpoints"
 mkdir -p "$CHECKPOINT_DIR"
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
@@ -187,7 +190,7 @@ CONTEXT 保存完了
 ### Step 1：保存済み context を集める
 
 ```bash
-eval "$(~/.claude/skills/uzustack/bin/uzustack-slug 2>/dev/null)" && mkdir -p ~/.uzustack/projects/$SLUG
+{{SLUG_SETUP}}
 CHECKPOINT_DIR="${UZUSTACK_HOME:-$HOME/.uzustack}/projects/$SLUG/checkpoints"
 if [ -d "$CHECKPOINT_DIR" ]; then
   echo "CHECKPOINT_DIR=$CHECKPOINT_DIR"

--- a/scripts/resolvers/index.ts
+++ b/scripts/resolvers/index.ts
@@ -11,8 +11,11 @@
  */
 
 import type { ResolverFn } from './types';
+import { generateSlugSetup } from './utility';
 
 export const RESOLVERS: Record<string, ResolverFn> = {
+  // `eval "$(uzustack-slug)"` + `mkdir -p ~/.uzustack/projects/$SLUG` の single-line bash
+  SLUG_SETUP: generateSlugSetup,
   // Phase 4+ で voice + ETHOS preamble を返す予定
   PREAMBLE: (_ctx, _args) => '',
   // Phase 4+ で ~/.uzustack/projects/{SLUG}/learnings.jsonl から検索結果を返す予定（Phase 5）

--- a/scripts/resolvers/utility.ts
+++ b/scripts/resolvers/utility.ts
@@ -1,0 +1,20 @@
+/**
+ * Utility resolvers — single-line bash helpers が中心。
+ *
+ * Phase 3 では SLUG_SETUP のみ。upstream の generateSlugEval や
+ * generateBaseBranchDetect 等は uzustack 側で必要になった時点で
+ * 機械翻案して追加する（uzustack 機械翻案範囲を最大化する方針）。
+ */
+
+import type { TemplateContext } from './types';
+
+/**
+ * `eval "$(uzustack-slug)"` で SLUG / BRANCH を export し、
+ * `~/.uzustack/projects/$SLUG/` を mkdir する single-line bash を返す。
+ *
+ * checkpoint 系 skill (context-save / context-restore) や
+ * Phase 4+ で導入される learnings / gbrain 系 skill が共通で使う。
+ */
+export function generateSlugSetup(ctx: TemplateContext): string {
+  return `eval "$(${ctx.paths.binDir}/uzustack-slug 2>/dev/null)" && mkdir -p ~/.uzustack/projects/$SLUG`;
+}


### PR DESCRIPTION
## Summary

Phase 3 cluster C 最終 step。step-40 (PR #50, careful / investigate / retro の preamble 取り付け) に続いて、`context-save` / `context-restore` skill に `{{SLUG_SETUP}}` resolver と `{{PREAMBLE}}` placeholder を取り付ける。step-30 で `{{SLUG_SETUP}}` を削除して直書き bash 化していた経緯の復元。

upstream の `generateSlugSetup` を機械翻案して `scripts/resolvers/utility.ts` 新規作成。展開結果が現状の直書き bash と完全一致するため、SKILL.md regen 後の bash 部分の diff はゼロ — **純粋リファクタ**として成立。

## 変更内容

### commit 1: `feat: scripts/resolvers/utility.ts 新規 + SLUG_SETUP resolver 登録`

- `scripts/resolvers/utility.ts` 新規（`generateSlugSetup(ctx) -> "eval ... && mkdir -p ~/.uzustack/projects/$SLUG"`）
- `scripts/resolvers/index.ts` で `RESOLVERS.SLUG_SETUP = generateSlugSetup` 登録

### commit 2: `feat: context-save に preamble-tier:2 + {{PREAMBLE}} + {{SLUG_SETUP}} 取り付け`

- frontmatter に `preamble-tier: 2` 追加
- 本文先頭に `{{PREAMBLE}}` 行（Phase 3 では空展開、Phase 4+ で voice + ETHOS preamble 注入）
- 直書き bash 3 箇所（Step 1 / Step 4 / List flow Step 1）→ `{{SLUG_SETUP}}` 置換

### commit 3: `feat: context-restore に preamble-tier:2 + {{PREAMBLE}} + {{SLUG_SETUP}} 取り付け`

- 同上、直書き bash 1 箇所（Step 1）→ `{{SLUG_SETUP}}` 置換

## 純粋リファクタの根拠

- Host config (`hosts/claude.ts`) で `binDir = ~/.claude/skills/uzustack/bin`（`runtimeRoot.globalSymlinks: ['bin']`）
- 現状の直書き bash: `eval "$(~/.claude/skills/uzustack/bin/uzustack-slug 2>/dev/null)" && mkdir -p ~/.uzustack/projects/$SLUG`
- `generateSlugSetup` 展開結果: `eval "$(${ctx.paths.binDir}/uzustack-slug 2>/dev/null)" && mkdir -p ~/.uzustack/projects/$SLUG` → 上と完全一致
- 結果として `bun run gen:skill-docs` 後の SKILL.md diff は frontmatter `preamble-tier: 2` 行 + `{{PREAMBLE}}` 空展開の空行 2 つのみ。bash 部分は diff 出ず

## Test plan

- [x] `bun run gen:skill-docs` で SKILL.md 再生成、diff 確認（純粋リファクタ）
- [x] `bun test` 実行、exit 0（test failures は全て `_upstream/gstack/` 配下、uzustack 自身ではない）
- [x] CI green（GitHub Actions で確認）
- [x] post-deploy: 別 Claude Code セッションで `/context-save テスト` → `/context-restore` の round-trip 確認、`title_raw` パターン（日本語タイトル）が引き続き機能することを確認

## 関連

- 親 issue: Closes #51
- 親 step: PR #50 (`3e61e37`, step-40)
- 後続 step: step-42 — setup 動作確認 + Phase 3 完了判定（cluster D）

🤖 Generated with [Claude Code](https://claude.com/claude-code)