### PR TITLE
feat: upstream-direct symlink 機構を導入 — Phase 3 step-43 (cluster D 着手)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,10 @@ Thumbs.db
 .claude/skills/
 .claude/settings.local.json
 .claude/*.lock
+
+# upstream-direct symlinks (Phase 3 cluster D step-43)
+# ./setup で _upstream/gstack/<dir> への symlink が作成される（生成物のため追跡しない）。
+/browse
+/design
+/make-pdf
+/extension

--- a/setup
+++ b/setup
@@ -7,10 +7,16 @@
 # `[ -f ... ]` / `[ -d ... ]` ガードで自然に no-op になる。それで足りない
 # `bun run XXX` 呼び出しと browse / Playwright 関連の処理は、setup 冒頭で
 # 1 度だけ定義する境界（_has_bun_script / HAS_BROWSE）で guard する。
-# 「これは入れる、これは外す」の都度判断は導入しない（Phase 3 規律：
-# 判断を 1 度集中、以降ゼロで機械的に手を動かし続ける）。
-# bin 翻訳が step-35〜39 で進むと、該当処理が自動的に有効化される。
-# step-42 で全体動作確認する。
+#
+# Phase 3 cluster A-C（step-31〜41）= 完了。bin 約 50 個翻訳、SKILL.md.tmpl + setup
+# 展開機構、voice 翻案ガイドライン、既存 5 skill の preamble 機構が揃った。
+#
+# Phase 3 cluster D（step-43〜、2026-04-30 新設）= upstream-direct + 限定翻訳。
+# binary infra（browse / design / make-pdf / extension）は翻訳せず upstream から
+# 直接利用する方針。詳細は uzustack memory `translation_policy_user_visible_only.md`。
+# step-43（本 PR）で uzustack/<dir> -> _upstream/gstack/<dir> の symlink を作成し、
+# step-44/45 で gen-skill-docs all-host サポートと build script を整備する。
+# step-42 retry で HAS_BROWSE / _has_bun_script を撤去 → Phase 3 totally DONE。
 
 set -e
 umask 077  # Restrict new files to owner-only (0o600 files, 0o700 dirs)
@@ -51,10 +57,25 @@ _has_bun_script() {
   [ -f "$SOURCE_UZUSTACK_DIR/package.json" ] && grep -q "\"$script_name\"" "$SOURCE_UZUSTACK_DIR/package.json"
 }
 
-# browse / Playwright / codesign / coreutils 関連は、uzustack に browse/ ディレクトリ
-# が無い間は 1 段ブロックで guard する。browse 翻訳と同時に自動的に有効化される。
+# upstream-direct symlink: binary infra（browse / design / make-pdf / extension）は
+# 翻訳せず _upstream/gstack/ から symlink で利用する（cluster D step-43 で導入）。
+# upstream の build output（dist/、extension/lib/xterm.*）は upstream-gitignored、
+# uzustack repo は汚れない。
+for _ud_dir in browse design make-pdf extension; do
+  _ud_upstream="$SOURCE_UZUSTACK_DIR/_upstream/gstack/$_ud_dir"
+  _ud_target="$SOURCE_UZUSTACK_DIR/$_ud_dir"
+  if [ -d "$_ud_upstream" ] && [ ! -e "$_ud_target" ]; then
+    ln -snf "_upstream/gstack/$_ud_dir" "$_ud_target"
+  fi
+done
+unset _ud_dir _ud_upstream _ud_target
+
+# browse / Playwright / codesign / coreutils 関連は、build script が package.json に
+# 揃うまで 1 段ブロックで guard する。step-43 で symlink により browse/ は出現するが、
+# step-45 で build script が追加されるまでは HAS_BROWSE=0 を維持する（build/Playwright
+# code path に入れない）。step-42 retry で HAS_BROWSE 自体を撤去予定。
 HAS_BROWSE=0
-if [ -d "$SOURCE_UZUSTACK_DIR/browse" ]; then
+if [ -d "$SOURCE_UZUSTACK_DIR/browse" ] && _has_bun_script build; then
   HAS_BROWSE=1
 fi
 


### PR DESCRIPTION
## Summary

Phase 3 cluster D の最初の step。binary infra（browse / design / make-pdf / extension）を upstream-direct で利用するための symlink 機構を setup script に導入する。

cluster D の方針確定経緯は [#53](https://github.com/uzumaki-inc/uzustack/issues/53) のクローズコメント + 個人 Obsidian vault `Phase 3 cluster D` plan note + memory `translation_policy_user_visible_only.md` 参照。

## 変更内容

### `setup` への symlink 作成 block 追加

SOURCE_UZUSTACK_DIR 直下に `_upstream/gstack/<dir>` への symlink を作成（browse / design / make-pdf / extension の 4 dir）。`mkdir`-style に冪等。

```sh
for _ud_dir in browse design make-pdf extension; do
  _ud_upstream="$SOURCE_UZUSTACK_DIR/_upstream/gstack/$_ud_dir"
  _ud_target="$SOURCE_UZUSTACK_DIR/$_ud_dir"
  if [ -d "$_ud_upstream" ] && [ ! -e "$_ud_target" ]; then
    ln -snf "_upstream/gstack/$_ud_dir" "$_ud_target"
  fi
done
```

### `HAS_BROWSE` を `_has_bun_script build` と AND 結合

symlink により `uzustack/browse` が出現しても、step-45 で build script が追加されるまでは `HAS_BROWSE=0` を維持（build / Playwright code path 抑止）：

```diff
 HAS_BROWSE=0
-if [ -d "$SOURCE_UZUSTACK_DIR/browse" ]; then
+if [ -d "$SOURCE_UZUSTACK_DIR/browse" ] && _has_bun_script build; then
   HAS_BROWSE=1
 fi
```

step-42 retry で HAS_BROWSE 自体を撤去予定。

### `.gitignore` に 4 symlink を追加

```
/browse
/design
/make-pdf
/extension
```

`./setup` の生成物のため追跡しない。`_upstream/gstack/.gitignore` は uzustack 側 git でも継承される（`browse/dist/`、`extension/lib/xterm.*` 等は upstream-gitignored）ので、upstream subtree pull 運用に影響なし。

### `setup` 冒頭 comment 更新

Phase 3 cluster A-C 完了 + cluster D upstream-direct 方針を明記。

## 設計判断の根拠

### upstream-direct の根本理由

「翻訳」の goal は **Garry 固有名詞撤去 + voice 翻案 + naming 置換** で、対象は **user-visible content**（skill 説明 / CLI 出力 / 命名）。`browse/` `design/` `make-pdf/` `extension/` は **内部 binary infra** で、ユーザは中身のメッセージを直接 read しない（Playwright で動く Chromium、PDF 出力、HTML 生成）。翻訳 ROI が薄いのに scope は最大、という不一致を解消する設計。

memory `translation_policy_user_visible_only.md` で規範化済。

### symlink at uzustack root（A 案採用）

代替案 B（直接 `_upstream/gstack/...` path 参照）と比べて：
- BROWSE_BIN 等の setup paths 不変
- build script paths も将来 `browse/src/...` で変更不要
- runtimeRoot.globalSymlinks も `'browse/dist'` のまま使える
- → 変更量最小、step-45 / step-42 retry での移行コスト最小

## Test plan

- [x] `bash -n setup` で syntax 検証 → OK
- [x] `bun run gen:skill-docs`（default claude）→ pass、SKILL.md diff なし
- [x] `ls uzustack/` で browse / design / make-pdf / extension が symlink として表示
- [x] `_upstream/gstack/.gitignore` 継承確認：`git check-ignore -v _upstream/gstack/browse/dist/browse` → upstream gitignore が応答
- [x] CI green（GitHub Actions）

## 未対応の pre-existing issue

`./setup --quiet` は依然 codex agents-gen の段階で fail する（`bun run gen:skill-docs --host codex` で `error: Unknown host: codex`）。これは step-43 の前から存在する問題で、cluster A-C 完了時点でも `./setup` end-to-end が完走していなかった。step-44（gen-skill-docs.ts の all-host サポート追加）で解消する予定。

## 関連

- 親 issue：[#53](https://github.com/uzumaki-inc/uzustack/issues/53)（cluster D 認識の経緯、closed）
- 親 step：step-41（PR #52、cluster C 完了）
- 後続 step：step-44（gen-skill-docs all-host）→ step-45（build script + open-uzustack-browser）→ step-42 retry → Phase 3 totally DONE
- memory：`phase3_setup_guards_temporary.md`、`translation_policy_user_visible_only.md`
