### PR TITLE
feat: design/ voice 翻案 — Phase 3 step-44b (cluster D A retry)

### DIFF
--- a/design/prototype.ts
+++ b/design/prototype.ts
@@ -1,9 +1,9 @@
 /**
- * Commit 0: Prototype validation
- * Sends 3 design briefs to GPT Image API via Responses API.
- * Validates: text rendering quality, layout accuracy, visual coherence.
+ * Commit 0: prototype validation
+ * 3 個の design brief を Responses API 経由で GPT Image API に送る。
+ * 検証対象：text rendering 品質、layout 精度、visual coherence。
  *
- * Run: OPENAI_API_KEY=$(cat ~/.uzustack/openai.json | python3 -c "import sys,json;print(json.load(sys.stdin)['api_key'])") bun run design/prototype.ts
+ * 実行: OPENAI_API_KEY=$(cat ~/.uzustack/openai.json | python3 -c "import sys,json;print(json.load(sys.stdin)['api_key'])") bun run design/prototype.ts
  */
 
 import fs from "fs";
@@ -13,7 +13,7 @@ const API_KEY = process.env.OPENAI_API_KEY
   || JSON.parse(fs.readFileSync(path.join(process.env.HOME!, ".uzustack/openai.json"), "utf-8")).api_key;
 
 if (!API_KEY) {
-  console.error("No API key found. Set OPENAI_API_KEY or save to ~/.uzustack/openai.json");
+  console.error("API key 未設定。OPENAI_API_KEY を設定するか ~/.uzustack/openai.json に保存。");
   process.exit(1);
 }
 
@@ -43,7 +43,7 @@ async function generateMockup(brief: { name: string; prompt: string }) {
   const startTime = Date.now();
 
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 120_000); // 2 min timeout
+  const timeout = setTimeout(() => controller.abort(), 120_000); // 2 分 timeout
 
   const response = await fetch("https://api.openai.com/v1/responses", {
     method: "POST",
@@ -73,13 +73,13 @@ async function generateMockup(brief: { name: string; prompt: string }) {
   const data = await response.json() as any;
   const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
 
-  // Find the image generation result in output
+  // output から image generation 結果を取得
   const imageItem = data.output?.find((item: any) =>
     item.type === "image_generation_call"
   );
 
   if (!imageItem?.result) {
-    console.error("No image data in response. Output types:",
+    console.error("response に image data なし。output types:",
       data.output?.map((o: any) => o.type));
     console.error("Full response:", JSON.stringify(data, null, 2).slice(0, 500));
     return null;
@@ -121,22 +121,22 @@ async function main() {
   const succeeded = results.filter(r => r.path);
   const failed = results.filter(r => !r.path);
 
-  console.log(`${succeeded.length}/${results.length} generated successfully`);
+  console.log(`${succeeded.length}/${results.length} 件生成成功`);
 
   if (failed.length > 0) {
-    console.log(`Failed: ${failed.map(f => f.name).join(", ")}`);
+    console.log(`失敗: ${failed.map(f => f.name).join(", ")}`);
   }
 
   if (succeeded.length > 0) {
-    console.log(`\nGenerated mockups:`);
+    console.log(`\n生成 mockup:`);
     for (const r of succeeded) {
       console.log(`  ${r.path}`);
     }
-    console.log(`\nOpen in Finder: open ${OUTPUT_DIR}`);
+    console.log(`\nFinder で開く: open ${OUTPUT_DIR}`);
   }
 
   if (succeeded.length === 0) {
-    console.log("\nPROTOTYPE FAILED: No mockups generated. Re-evaluate approach.");
+    console.log("\nPROTOTYPE FAILED: mockup 生成 0、approach の再検討が必要。");
     process.exit(1);
   }
 }

--- a/design/src/auth.ts
+++ b/design/src/auth.ts
@@ -1,10 +1,10 @@
 /**
- * Auth resolution for OpenAI API access.
+ * OpenAI API access のための認証解決。
  *
- * Resolution order:
+ * 解決順:
  * 1. ~/.uzustack/openai.json → { "api_key": "sk-..." }
- * 2. OPENAI_API_KEY environment variable
- * 3. null (caller handles guided setup or fallback)
+ * 2. OPENAI_API_KEY 環境変数
+ * 3. null（caller が guided setup または fallback を扱う）
  */
 
 import fs from "fs";
@@ -13,7 +13,7 @@ import path from "path";
 const CONFIG_PATH = path.join(process.env.HOME || "~", ".uzustack", "openai.json");
 
 export function resolveApiKey(): string | null {
-  // 1. Check ~/.uzustack/openai.json
+  // 1. ~/.uzustack/openai.json を確認
   try {
     if (fs.existsSync(CONFIG_PATH)) {
       const content = fs.readFileSync(CONFIG_PATH, "utf-8");
@@ -23,10 +23,10 @@ export function resolveApiKey(): string | null {
       }
     }
   } catch {
-    // Fall through to env var
+    // 環境変数 check へ fall through
   }
 
-  // 2. Check environment variable
+  // 2. 環境変数を確認
   if (process.env.OPENAI_API_KEY) {
     return process.env.OPENAI_API_KEY;
   }
@@ -35,7 +35,7 @@ export function resolveApiKey(): string | null {
 }
 
 /**
- * Save an API key to ~/.uzustack/openai.json with 0600 permissions.
+ * API key を ~/.uzustack/openai.json に 0600 permissions で保存。
  */
 export function saveApiKey(key: string): void {
   const dir = path.dirname(CONFIG_PATH);
@@ -45,18 +45,18 @@ export function saveApiKey(key: string): void {
 }
 
 /**
- * Get API key or exit with setup instructions.
+ * API key を取得、未設定なら setup 案内を出して exit。
  */
 export function requireApiKey(): string {
   const key = resolveApiKey();
   if (!key) {
-    console.error("No OpenAI API key found.");
+    console.error("OpenAI API key 未設定。");
     console.error("");
-    console.error("Run: $D setup");
-    console.error("  or save to ~/.uzustack/openai.json: { \"api_key\": \"sk-...\" }");
-    console.error("  or set OPENAI_API_KEY environment variable");
+    console.error("実行: $D setup");
+    console.error("  または ~/.uzustack/openai.json に保存: { \"api_key\": \"sk-...\" }");
+    console.error("  または OPENAI_API_KEY 環境変数を設定");
     console.error("");
-    console.error("Get a key at: https://platform.openai.com/api-keys");
+    console.error("key 取得先: https://platform.openai.com/api-keys");
     process.exit(1);
   }
   return key;

--- a/design/src/brief.ts
+++ b/design/src/brief.ts
@@ -1,5 +1,5 @@
 /**
- * Structured design brief — the interface between skill prose and image generation.
+ * 構造化された design brief — skill 側の散文と image generation の間の interface。
  */
 
 export interface DesignBrief {
@@ -8,12 +8,12 @@ export interface DesignBrief {
   style: string;          // "Dark theme, cream accents, minimal"
   elements: string[];     // ["builder name", "score badge", "narrative letter"]
   constraints?: string;   // "Max width 1024px, mobile-first"
-  reference?: string;     // DESIGN.md excerpt or style reference text
-  screenType: string;     // "desktop-dashboard" | "mobile-app" | "landing-page" | etc.
+  reference?: string;     // DESIGN.md の抜粋または style reference 文
+  screenType: string;     // "desktop-dashboard" | "mobile-app" | "landing-page" 等
 }
 
 /**
- * Convert a structured brief to a prompt string for image generation.
+ * 構造化 brief を image generation 用の prompt 文字列に変換。
  */
 export function briefToPrompt(brief: DesignBrief): string {
   const lines: string[] = [
@@ -41,17 +41,17 @@ export function briefToPrompt(brief: DesignBrief): string {
 }
 
 /**
- * Parse a brief from either a plain text string or a JSON file path.
+ * 平文 string または JSON file path から brief を parse。
  */
 export function parseBrief(input: string, isFile: boolean): string {
   if (!isFile) {
-    // Plain text prompt — use directly
+    // 平文 prompt — そのまま使用
     return input;
   }
 
-  // JSON file — parse and convert to prompt
+  // JSON file — parse して prompt 化
   const raw = Bun.file(input);
-  // We'll read it synchronously via fs since Bun.file is async
+  // Bun.file は async のため fs 経由で同期読み込み
   const fs = require("fs");
   const content = fs.readFileSync(input, "utf-8");
   const brief: DesignBrief = JSON.parse(content);

--- a/design/src/check.ts
+++ b/design/src/check.ts
@@ -1,6 +1,6 @@
 /**
- * Vision-based quality gate for generated mockups.
- * Uses GPT-4o vision to verify text readability, layout completeness, and visual coherence.
+ * 生成 mockup に対する vision-based 品質 gate。
+ * GPT-4o vision で text 可読性 / layout 完全性 / visual coherence を検証する。
  */
 
 import fs from "fs";
@@ -12,7 +12,7 @@ export interface CheckResult {
 }
 
 /**
- * Check a generated mockup against the original brief.
+ * 生成 mockup を元 brief に照らして check。
  */
 export async function checkMockup(imagePath: string, brief: string): Promise<CheckResult> {
   const apiKey = requireApiKey();
@@ -64,12 +64,12 @@ export async function checkMockup(imagePath: string, brief: string): Promise<Che
     if (!response.ok) {
       const error = await response.text();
       if (response.status === 403 && error.includes("organization must be verified")) {
-        console.error("OpenAI organization verification required. Go to https://platform.openai.com/settings/organization to verify.");
-        return { pass: true, issues: "OpenAI org not verified — vision check skipped" };
+        console.error("OpenAI organization verification 未完了。https://platform.openai.com/settings/organization で verify が必要。");
+        return { pass: true, issues: "OpenAI org 未 verified — vision check を skip" };
       }
-      // Non-blocking: if vision check fails, default to PASS with warning
+      // 非 blocking：vision check 失敗時は warning 付きで PASS にする
       console.error(`Vision check API error (${response.status}): ${error}`);
-      return { pass: true, issues: "Vision check unavailable — skipped" };
+      return { pass: true, issues: "vision check 利用不可 — skip" };
     }
 
     const data = await response.json() as any;
@@ -79,7 +79,7 @@ export async function checkMockup(imagePath: string, brief: string): Promise<Che
       return { pass: true, issues: "" };
     }
 
-    // Extract issues after "FAIL:"
+    // "FAIL:" 以降の issue を抽出
     const issues = content.replace(/^FAIL:\s*/i, "").trim();
     return { pass: false, issues: issues || content };
   } finally {
@@ -88,7 +88,7 @@ export async function checkMockup(imagePath: string, brief: string): Promise<Che
 }
 
 /**
- * Standalone check command: check an existing image against a brief.
+ * 単独 check command：既存 image を brief に照らして check。
  */
 export async function checkCommand(imagePath: string, brief: string): Promise<void> {
   const result = await checkMockup(imagePath, brief);

--- a/design/src/cli.ts
+++ b/design/src/cli.ts
@@ -1,15 +1,15 @@
 /**
- * uzustack design CLI — stateless CLI for AI-powered design generation.
+ * uzustack design CLI — AI による design 生成のための stateless CLI。
  *
- * Unlike the browse binary (persistent Chromium daemon), the design binary
- * is stateless: each invocation makes API calls and writes files. Session
- * state for multi-turn iteration is a JSON file in /tmp.
+ * browse binary（永続 Chromium daemon）と異なり、design binary は stateless で、
+ * 起動ごとに API call と file 書き込みを行う。複数ターン iteration の session 状態は
+ * /tmp 配下の JSON file で持つ。
  *
  * Flow:
- *   1. Parse command + flags from argv
- *   2. Resolve auth (~/. uzustack/openai.json → OPENAI_API_KEY → guided setup)
- *   3. Execute command (API call → write PNG/HTML)
- *   4. Print result JSON to stdout
+ *   1. argv から command + flags を parse
+ *   2. 認証を解決（~/.uzustack/openai.json → OPENAI_API_KEY → guided setup）
+ *   3. command を実行（API call → PNG/HTML 書き出し）
+ *   4. 結果 JSON を stdout に出力
  */
 
 import { COMMANDS } from "./commands";
@@ -27,7 +27,7 @@ import { serve } from "./serve";
 import { gallery } from "./gallery";
 
 function parseArgs(argv: string[]): { command: string; flags: Record<string, string | boolean> } {
-  const args = argv.slice(2); // skip bun/node and script path
+  const args = argv.slice(2); // bun/node と script path を skip
   if (args.length === 0) {
     printUsage();
     process.exit(0);
@@ -54,26 +54,26 @@ function parseArgs(argv: string[]): { command: string; flags: Record<string, str
 }
 
 function printUsage(): void {
-  console.log("uzustack design — AI-powered UI mockup generation\n");
+  console.log("uzustack design — AI による UI mockup 生成\n");
   console.log("Commands:");
   for (const [name, info] of COMMANDS) {
     console.log(`  ${name.padEnd(12)} ${info.description}`);
     console.log(`  ${"".padEnd(12)} ${info.usage}`);
   }
-  console.log("\nAuth: ~/.uzustack/openai.json or OPENAI_API_KEY env var");
+  console.log("\nAuth: ~/.uzustack/openai.json または OPENAI_API_KEY 環境変数");
   console.log("Setup: $D setup");
 }
 
 async function runSetup(): Promise<void> {
   const existing = resolveApiKey();
   if (existing) {
-    console.log("Existing API key found. Running smoke test...");
+    console.log("既存の API key を検出。smoke test を実行...");
   } else {
-    console.log("No API key found. Please enter your OpenAI API key.");
-    console.log("Get one at: https://platform.openai.com/api-keys");
-    console.log("(Needs image generation permissions)\n");
+    console.log("API key 未設定。OpenAI API key の入力が必要。");
+    console.log("取得先: https://platform.openai.com/api-keys");
+    console.log("(image generation 権限が必要)\n");
 
-    // Read from stdin
+    // stdin から読む
     process.stdout.write("API key: ");
     const reader = Bun.stdin.stream().getReader();
     const { value } = await reader.read();
@@ -81,16 +81,16 @@ async function runSetup(): Promise<void> {
     const key = new TextDecoder().decode(value).trim();
 
     if (!key || !key.startsWith("sk-")) {
-      console.error("Invalid key. Must start with 'sk-'.");
+      console.error("key 形式不正、'sk-' で始まる必要あり。");
       process.exit(1);
     }
 
     saveApiKey(key);
-    console.log("Key saved to ~/.uzustack/openai.json (0600 permissions).");
+    console.log("~/.uzustack/openai.json に保存（0600 permissions）。");
   }
 
-  // Smoke test
-  console.log("\nRunning smoke test (generating a simple image)...");
+  // smoke test
+  console.log("\nsmoke test 実行中（simple image を生成）...");
   try {
     await generate({
       brief: "A simple blue square centered on a white background. Minimal, geometric, clean.",
@@ -98,10 +98,10 @@ async function runSetup(): Promise<void> {
       size: "1024x1024",
       quality: "low",
     });
-    console.log("\nSmoke test PASSED. Design generation is working.");
+    console.log("\nSmoke test PASSED — design generation 動作確認。");
   } catch (err: any) {
     console.error(`\nSmoke test FAILED: ${err.message}`);
-    console.error("Check your API key and organization verification status.");
+    console.error("API key と organization verification status を確認。");
     process.exit(1);
   }
 }
@@ -110,7 +110,7 @@ async function main(): Promise<void> {
   const { command, flags } = parseArgs(process.argv);
 
   if (!COMMANDS.has(command)) {
-    console.error(`Unknown command: ${command}`);
+    console.error(`未知の command: ${command}`);
     printUsage();
     process.exit(1);
   }
@@ -133,12 +133,12 @@ async function main(): Promise<void> {
       break;
 
     case "compare": {
-      // Parse --images as glob or multiple files
+      // --images を glob または複数 file として parse
       const imagesArg = flags.images as string;
       const images = await resolveImagePaths(imagesArg);
       const outputPath = (flags.output as string) || "/tmp/uzustack-design-board.html";
       compare({ images, output: outputPath });
-      // If --serve flag is set, start HTTP server for the board
+      // --serve flag があれば board の HTTP server を起動
       if (flags.serve) {
         await serve({
           html: outputPath,
@@ -151,10 +151,10 @@ async function main(): Promise<void> {
     case "prompt": {
       const promptImage = flags.image as string;
       if (!promptImage) {
-        console.error("--image is required");
+        console.error("--image が必要");
         process.exit(1);
       }
-      console.error(`Generating implementation prompt from ${promptImage}...`);
+      console.error(`${promptImage} から implementation prompt を生成中...`);
       const proc2 = Bun.spawn(["git", "rev-parse", "--show-toplevel"]);
       const root = (await new Response(proc2.stdout).text()).trim();
       const d2c = await generateDesignToCodePrompt(promptImage, root || undefined);
@@ -189,10 +189,10 @@ async function main(): Promise<void> {
     case "extract": {
       const imagePath = flags.image as string;
       if (!imagePath) {
-        console.error("--image is required");
+        console.error("--image が必要");
         process.exit(1);
       }
-      console.error(`Extracting design language from ${imagePath}...`);
+      console.error(`${imagePath} から design language を抽出中...`);
       const extracted = await extractDesignLanguage(imagePath);
       const proc = Bun.spawn(["git", "rev-parse", "--show-toplevel"]);
       const repoRoot = (await new Response(proc.stdout).text()).trim();
@@ -207,10 +207,10 @@ async function main(): Promise<void> {
       const before = flags.before as string;
       const after = flags.after as string;
       if (!before || !after) {
-        console.error("--before and --after are required");
+        console.error("--before と --after が必要");
         process.exit(1);
       }
-      console.error(`Comparing ${before} vs ${after}...`);
+      console.error(`${before} と ${after} を比較中...`);
       const diffResult = await diffMockups(before, after);
       console.log(JSON.stringify(diffResult, null, 2));
       break;
@@ -220,10 +220,10 @@ async function main(): Promise<void> {
       const mockup = flags.mockup as string;
       const screenshot = flags.screenshot as string;
       if (!mockup || !screenshot) {
-        console.error("--mockup and --screenshot are required");
+        console.error("--mockup と --screenshot が必要");
         process.exit(1);
       }
-      console.error(`Verifying implementation against approved mockup...`);
+      console.error(`approved mockup に対して implementation を検証中...`);
       const verifyResult = await verifyAgainstMockup(mockup, screenshot);
       console.error(`Match: ${verifyResult.matchScore}/100 — ${verifyResult.pass ? "PASS" : "FAIL"}`);
       console.log(JSON.stringify(verifyResult, null, 2));
@@ -255,15 +255,15 @@ async function main(): Promise<void> {
 }
 
 /**
- * Resolve image paths from a glob pattern or comma-separated list.
+ * glob pattern または comma 区切り list から image paths を解決。
  */
 async function resolveImagePaths(input: string): Promise<string[]> {
   if (!input) {
-    console.error("--images is required. Provide glob pattern or comma-separated paths.");
+    console.error("--images が必要 (glob pattern または comma 区切りの path)");
     process.exit(1);
   }
 
-  // Check if it's a glob pattern
+  // glob pattern か判定
   if (input.includes("*")) {
     const glob = new Bun.Glob(input);
     const paths: string[] = [];
@@ -275,7 +275,7 @@ async function resolveImagePaths(input: string): Promise<string[]> {
     return paths.sort();
   }
 
-  // Comma-separated or single path
+  // comma 区切りまたは単一 path
   return input.split(",").map(p => p.trim());
 }
 

--- a/design/src/commands.ts
+++ b/design/src/commands.ts
@@ -1,12 +1,12 @@
 /**
- * Command registry — single source of truth for all design commands.
+ * Command registry — design command 全体の single source of truth。
  *
- * Dependency graph:
+ * 依存関係:
  *   commands.ts ──▶ cli.ts (runtime dispatch)
- *              ──▶ gen-skill-docs.ts (doc generation)
+ *              ──▶ gen-skill-docs.ts (doc 生成)
  *              ──▶ tests (validation)
  *
- * Zero side effects. Safe to import from build scripts and tests.
+ * 副作用なし。build script と test から安全に import 可能。
  */
 
 export const COMMANDS = new Map<string, {
@@ -15,67 +15,67 @@ export const COMMANDS = new Map<string, {
   flags?: string[];
 }>([
   ["generate", {
-    description: "Generate a UI mockup from a design brief",
+    description: "design brief から UI mockup を生成",
     usage: "generate --brief \"...\" --output /path.png",
     flags: ["--brief", "--brief-file", "--output", "--check", "--retry", "--size", "--quality"],
   }],
   ["variants", {
-    description: "Generate N design variants from a brief",
+    description: "brief から N 個の design variant を生成",
     usage: "variants --brief \"...\" --count 3 --output-dir /path/",
     flags: ["--brief", "--brief-file", "--count", "--output-dir", "--size", "--quality", "--viewports"],
   }],
   ["iterate", {
-    description: "Iterate on an existing mockup with feedback",
+    description: "feedback を反映して既存 mockup を改稿",
     usage: "iterate --session /path/session.json --feedback \"...\" --output /path.png",
     flags: ["--session", "--feedback", "--output"],
   }],
   ["check", {
-    description: "Vision-based quality check on a mockup",
+    description: "mockup の vision-based 品質 check",
     usage: "check --image /path.png --brief \"...\"",
     flags: ["--image", "--brief"],
   }],
   ["compare", {
-    description: "Generate HTML comparison board for user review",
+    description: "user review 用の HTML comparison board を生成",
     usage: "compare --images /path/*.png --output /path/board.html [--serve]",
     flags: ["--images", "--output", "--serve", "--timeout"],
   }],
   ["diff", {
-    description: "Visual diff between two mockups",
+    description: "2 つの mockup 間の visual diff",
     usage: "diff --before old.png --after new.png",
     flags: ["--before", "--after", "--output"],
   }],
   ["evolve", {
-    description: "Generate improved mockup from existing screenshot",
+    description: "既存 screenshot から改善版 mockup を生成",
     usage: "evolve --screenshot current.png --brief \"make it calmer\" --output /path.png",
     flags: ["--screenshot", "--brief", "--output"],
   }],
   ["verify", {
-    description: "Compare live site screenshot against approved mockup",
+    description: "live site screenshot を approved mockup と照合",
     usage: "verify --mockup approved.png --screenshot live.png",
     flags: ["--mockup", "--screenshot", "--output"],
   }],
   ["prompt", {
-    description: "Generate structured implementation prompt from approved mockup",
+    description: "approved mockup から構造化された implementation prompt を生成",
     usage: "prompt --image approved.png",
     flags: ["--image"],
   }],
   ["extract", {
-    description: "Extract design language from approved mockup into DESIGN.md",
+    description: "approved mockup から design language を抽出し DESIGN.md に反映",
     usage: "extract --image approved.png",
     flags: ["--image"],
   }],
   ["gallery", {
-    description: "Generate HTML timeline of all design explorations for a project",
+    description: "project 内の全 design exploration の HTML timeline を生成",
     usage: "gallery --designs-dir ~/.uzustack/projects/$SLUG/designs/ --output /path/gallery.html",
     flags: ["--designs-dir", "--output"],
   }],
   ["serve", {
-    description: "Serve comparison board over HTTP and collect user feedback",
+    description: "comparison board を HTTP で serve し user feedback を収集",
     usage: "serve --html /path/board.html [--timeout 600]",
     flags: ["--html", "--timeout"],
   }],
   ["setup", {
-    description: "Guided API key setup + smoke test",
+    description: "ガイド付き API key setup + smoke test",
     usage: "setup",
     flags: [],
   }],

--- a/design/src/compare.ts
+++ b/design/src/compare.ts
@@ -1,9 +1,9 @@
 /**
- * Generate HTML comparison board for user review of design variants.
- * Opens in headed Chrome via $B goto. User picks favorite, rates, comments, submits.
- * Agent reads feedback from hidden DOM element.
+ * design variant の user review 用 HTML comparison board を生成。
+ * `$B goto` で headed Chrome で開き、user が favorite を選び、評価し、
+ * comment を書き、submit する。agent は hidden DOM element から feedback を読む。
  *
- * Design spec: single column, full-width mockups, APP UI aesthetic.
+ * Design spec: 単一 column、full-width mockup、APP UI aesthetic。
  */
 
 import fs from "fs";
@@ -15,46 +15,46 @@ export interface CompareOptions {
 }
 
 /**
- * Generate the comparison board HTML page.
+ * comparison board の HTML page を生成。
  */
 export function generateCompareHtml(images: string[]): string {
   const variantLabels = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
   const variantCards = images.map((imgPath, i) => {
     const label = variantLabels[i] || `${i + 1}`;
-    // Embed images as base64 data URIs for self-contained HTML
+    // self-contained HTML 化のため image を base64 data URI で埋め込む
     const imgData = fs.readFileSync(imgPath).toString("base64");
     const ext = path.extname(imgPath).slice(1) || "png";
 
     return `
     <div class="variant" data-variant="${label}">
       <div class="variant-header">
-        <span class="variant-label">Option ${label}</span>
-        <span class="variant-desc" id="variant-desc-${label}">Design direction ${label}</span>
+        <span class="variant-label">案 ${label}</span>
+        <span class="variant-desc" id="variant-desc-${label}">方向 ${label}</span>
       </div>
-      <img src="data:image/${ext};base64,${imgData}" alt="Option ${label}" />
+      <img src="data:image/${ext};base64,${imgData}" alt="案 ${label}" />
       <div class="variant-controls">
         <label class="pick-label">
           <input type="radio" name="preferred" value="${label}" />
-          <span class="pick-text">Pick</span>
-          <span class="pick-confirm" style="display:none;">We'll move forward with Option ${label}</span>
+          <span class="pick-text">選択</span>
+          <span class="pick-confirm" style="display:none;">案 ${label} で進めます</span>
         </label>
         <div class="stars" data-variant="${label}">
           ${[1,2,3,4,5].map(n => `<span class="star" data-value="${n}">★</span>`).join("")}
         </div>
         <input type="text" class="feedback-input" data-variant="${label}"
-               placeholder="What do you like/dislike?" />
-        <button class="more-like-this" data-variant="${label}">More like this</button>
+               placeholder="気に入った点・気になる点は？" />
+        <button class="more-like-this" data-variant="${label}">これに近いものを生成</button>
       </div>
     </div>`;
   }).join("\n");
 
   return `<!DOCTYPE html>
-<html lang="en">
+<html lang="ja">
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Design Exploration</title>
+<title>Design 探索</title>
 <style>
   * { margin: 0; padding: 0; box-sizing: border-box; }
   body {
@@ -327,10 +327,10 @@ export function generateCompareHtml(images: string[]): string {
     text-align: center;
   }
 
-  /* Hidden result elements for agent polling */
+  /* agent polling 用の hidden 結果 element */
   #status, #feedback-result { display: none; }
 
-  /* Skeleton loading state */
+  /* skeleton loading state */
   .skeleton {
     background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
     background-size: 200% 100%;
@@ -347,9 +347,9 @@ export function generateCompareHtml(images: string[]): string {
 <body>
 
 <div class="header">
-  <h1>Design Exploration</h1>
+  <h1>Design 探索</h1>
   <span class="meta">
-    ${images.length} options
+    ${images.length} 案
     <span class="view-toggle">
       <button class="active" data-view="list">Large</button>
       <button data-view="grid">Grid</button>
@@ -363,35 +363,35 @@ export function generateCompareHtml(images: string[]): string {
 
 <div class="bottom-section">
   <div class="submit-column">
-    <h3>Overall direction</h3>
-    <p class="direction-hint">e.g. "Use A's layout with C's fox icon" or "Make it more minimal" or "I want the problem statement text but bigger"</p>
+    <h3>全体方針</h3>
+    <p class="direction-hint">例：「A の layout に C の fox icon」「もっと minimal に」「問題提起の文を大きく」</p>
     <textarea class="overall-textarea" id="overall-feedback"
-              placeholder="Combine elements, request changes, or describe what you want..."></textarea>
+              placeholder="element を組合せ、変更を request、または欲しい仕様を記述..."></textarea>
     <div class="submit-status" id="submit-status"></div>
-    <button class="submit-btn" id="submit-btn">Take my feedback and continue →</button>
+    <button class="submit-btn" id="submit-btn">feedback を反映して進める →</button>
   </div>
   <div class="regen-column">
-    <h3>Want to explore more?</h3>
+    <h3>もっと探索する？</h3>
     <div class="regen-controls">
-      <button class="regen-chiclet" data-action="different">Totally different</button>
-      <button class="regen-chiclet" data-action="match">Match my design</button>
+      <button class="regen-chiclet" data-action="different">全く違うもの</button>
+      <button class="regen-chiclet" data-action="match">design に合わせる</button>
     </div>
     <input type="text" class="regen-custom" id="regen-custom-input"
-           placeholder="Tell us what you want different..." />
-    <button class="regen-btn" id="regen-btn">Regenerate →</button>
+           placeholder="変更点を入力..." />
+    <button class="regen-btn" id="regen-btn">再生成 →</button>
   </div>
 </div>
 
 <div class="success-msg" id="success-msg">
-  Feedback submitted! Return to your coding agent.
+  feedback 送信完了。coding agent に戻る。
 </div>
 
-<!-- Hidden elements for agent polling -->
+<!-- agent polling 用の hidden element -->
 <div id="status"></div>
 <div id="feedback-result"></div>
 
 <script>
-  // View toggle
+  // view toggle
   document.querySelectorAll('.view-toggle button').forEach(function(btn) {
     btn.addEventListener('click', function() {
       document.querySelectorAll('.view-toggle button').forEach(function(b) { b.classList.remove('active'); });
@@ -405,22 +405,22 @@ export function generateCompareHtml(images: string[]): string {
     });
   });
 
-  // Pick confirmation
+  // pick confirmation
   document.querySelectorAll('input[name="preferred"]').forEach(function(radio) {
     radio.addEventListener('change', function() {
-      // Hide all confirmations first
+      // 確認表示を一旦全て非表示
       document.querySelectorAll('.pick-confirm').forEach(function(el) { el.style.display = 'none'; });
       document.querySelectorAll('.pick-text').forEach(function(el) { el.style.display = ''; });
-      // Show confirmation on the selected one
+      // 選択中のものに確認を表示
       var label = radio.closest('.pick-label');
       label.querySelector('.pick-text').style.display = 'none';
       label.querySelector('.pick-confirm').style.display = '';
-      // Update submit status
-      document.getElementById('submit-status').textContent = "We'll run with Option " + radio.value;
+      // submit status を更新
+      document.getElementById('submit-status').textContent = "案 " + radio.value + " で進めます";
     });
   });
 
-  // Star rating
+  // star rating
   document.querySelectorAll('.stars').forEach(starsEl => {
     const stars = starsEl.querySelectorAll('.star');
     let rating = 0;
@@ -435,7 +435,7 @@ export function generateCompareHtml(images: string[]): string {
     });
   });
 
-  // Regenerate chiclets (toggle active)
+  // regenerate chiclet（active 切替）
   document.querySelectorAll('.regen-chiclet').forEach(chiclet => {
     chiclet.addEventListener('click', () => {
       document.querySelectorAll('.regen-chiclet').forEach(c => c.classList.remove('active'));
@@ -443,19 +443,19 @@ export function generateCompareHtml(images: string[]): string {
     });
   });
 
-  // More like this buttons
+  // more like this button
   document.querySelectorAll('.more-like-this').forEach(btn => {
     btn.addEventListener('click', () => {
       const variant = btn.dataset.variant;
-      // Set regeneration context
+      // regeneration context を設定
       document.querySelectorAll('.regen-chiclet').forEach(c => c.classList.remove('active'));
-      document.getElementById('regen-custom-input').value = 'More like variant ' + variant;
-      // Trigger regenerate
+      document.getElementById('regen-custom-input').value = '案 ' + variant + ' に近い';
+      // regenerate を起動
       submitRegenerate('more_like_' + variant);
     });
   });
 
-  // Regenerate button
+  // regenerate button
   document.getElementById('regen-btn').addEventListener('click', () => {
     const activeChiclet = document.querySelector('.regen-chiclet.active');
     const customInput = document.getElementById('regen-custom-input').value;
@@ -488,15 +488,15 @@ export function generateCompareHtml(images: string[]): string {
     document.getElementById('submit-btn').style.display = 'none';
     document.getElementById('success-msg').style.display = 'block';
     document.getElementById('success-msg').innerHTML =
-      'Feedback received! Return to your coding agent.' +
-      '<br><small style="color:#666;margin-top:8px;display:block;">Want to make more changes? Run <code>/design-shotgun</code> again.</small>';
+      'feedback を受信。coding agent に戻る。' +
+      '<br><small style="color:#666;margin-top:8px;display:block;">さらに変更する？ <code>/design-shotgun</code> を再実行。</small>';
   }
 
   function showRegeneratingState() {
     disableAllInputs();
     document.querySelector('.variants').innerHTML =
       '<div style="text-align:center;padding:80px 24px;color:#666;">' +
-      '<div style="font-size:24px;margin-bottom:12px;">Generating new designs...</div>' +
+      '<div style="font-size:24px;margin-bottom:12px;">新 design を生成中...</div>' +
       '<div class="skeleton" style="width:60px;height:60px;border-radius:50%;margin:0 auto;"></div>' +
       '</div>';
     var _regenBar = document.querySelector('.regenerate-bar') || document.querySelector('.regen-column');
@@ -511,15 +511,15 @@ export function generateCompareHtml(images: string[]): string {
   function startProgressPolling() {
     if (!window.__UZUSTACK_SERVER_URL) return;
     var pollCount = 0;
-    var maxPolls = 150; // 5 min at 2s intervals
+    var maxPolls = 150; // 2s 間隔で 5 分
     var pollInterval = setInterval(function() {
       pollCount++;
       if (pollCount >= maxPolls) {
         clearInterval(pollInterval);
         document.querySelector('.variants').innerHTML =
           '<div style="text-align:center;padding:80px 24px;color:#666;">' +
-          '<div style="font-size:18px;margin-bottom:8px;">Something went wrong.</div>' +
-          '<div>Run <code>/design-shotgun</code> again in your coding agent.</div>' +
+          '<div style="font-size:18px;margin-bottom:8px;">問題が発生しました。</div>' +
+          '<div>coding agent で <code>/design-shotgun</code> を再実行。</div>' +
           '</div>';
         return;
       }
@@ -532,12 +532,12 @@ export function generateCompareHtml(images: string[]): string {
           }
         })
         .catch(function() {
-          // Server gone, stop polling
+          // server 終了、polling 停止
           clearInterval(pollInterval);
           document.querySelector('.variants').innerHTML =
             '<div style="text-align:center;padding:80px 24px;color:#666;">' +
-            '<div style="font-size:18px;margin-bottom:8px;">Connection lost.</div>' +
-            '<div>Run <code>/design-shotgun</code> again in your coding agent.</div>' +
+            '<div style="font-size:18px;margin-bottom:8px;">接続切断。</div>' +
+            '<div>coding agent で <code>/design-shotgun</code> を再実行。</div>' +
             '</div>';
         });
     }, 2000);
@@ -548,10 +548,10 @@ export function generateCompareHtml(images: string[]): string {
     var json = JSON.stringify(feedback, null, 2);
     document.getElementById('success-msg').style.display = 'block';
     document.getElementById('success-msg').innerHTML =
-      '<div style="color:#c00;margin-bottom:8px;">Connection lost. Copy your feedback below and paste it in your coding agent:</div>' +
+      '<div style="color:#c00;margin-bottom:8px;">接続切断。以下の feedback を copy して coding agent に paste:</div>' +
       '<pre style="text-align:left;background:#f5f5f5;padding:12px;border-radius:4px;font-size:12px;overflow-x:auto;cursor:pointer;" onclick="navigator.clipboard.writeText(this.textContent)">' +
       json.replace(/</g, '&lt;') + '</pre>' +
-      '<small style="color:#666;">Click to copy</small>';
+      '<small style="color:#666;">click で copy</small>';
   }
 
   function submitRegenerate(detail) {
@@ -569,7 +569,7 @@ export function generateCompareHtml(images: string[]): string {
     });
   }
 
-  // Submit button
+  // submit button
   document.getElementById('submit-btn').addEventListener('click', function() {
     var feedback = collectFeedback();
     feedback.regenerated = false;
@@ -617,7 +617,7 @@ export function generateCompareHtml(images: string[]): string {
 }
 
 /**
- * Compare command: generate comparison board HTML from image files.
+ * Compare command：image file から comparison board HTML を生成。
  */
 export function compare(options: CompareOptions): void {
   const html = generateCompareHtml(options.images);

--- a/design/src/design-to-code.ts
+++ b/design/src/design-to-code.ts
@@ -1,7 +1,7 @@
 /**
- * Design-to-Code Prompt Generator.
- * Extracts implementation instructions from an approved mockup via GPT-4o vision.
- * Produces a structured prompt the agent can use to implement the design.
+ * Design-to-Code Prompt Generator。
+ * approved mockup から GPT-4o vision で実装指示を抽出する。
+ * agent が design 実装に使える構造化された prompt を出力する。
  */
 
 import fs from "fs";
@@ -17,7 +17,7 @@ export interface DesignToCodeResult {
 }
 
 /**
- * Generate a structured implementation prompt from an approved mockup.
+ * approved mockup から構造化された実装 prompt を生成。
  */
 export async function generateDesignToCodePrompt(
   imagePath: string,
@@ -26,7 +26,7 @@ export async function generateDesignToCodePrompt(
   const apiKey = requireApiKey();
   const imageData = fs.readFileSync(imagePath).toString("base64");
 
-  // Read DESIGN.md if available for additional context
+  // 追加 context 用に DESIGN.md があれば読み込む
   const designConstraints = repoRoot ? readDesignConstraints(repoRoot) : null;
 
   const controller = new AbortController();

--- a/design/src/diff.ts
+++ b/design/src/diff.ts
@@ -1,7 +1,6 @@
 /**
- * Visual diff between two mockups using GPT-4o vision.
- * Identifies what changed between design iterations or between
- * an approved mockup and the live implementation.
+ * GPT-4o vision を使った 2 mockup 間の visual diff。
+ * design iteration 間 または approved mockup と live 実装との差分を識別する。
  */
 
 import fs from "fs";
@@ -10,11 +9,11 @@ import { requireApiKey } from "./auth";
 export interface DiffResult {
   differences: { area: string; description: string; severity: string }[];
   summary: string;
-  matchScore: number; // 0-100, how closely they match
+  matchScore: number; // 0-100、一致度
 }
 
 /**
- * Compare two images and describe the visual differences.
+ * 2 image を比較し visual difference を記述。
  */
 export async function diffMockups(
   beforePath: string,
@@ -75,7 +74,7 @@ Focus on layout, typography, colors, spacing, and element presence/absence. Igno
     if (!response.ok) {
       const error = await response.text();
       console.error(`Diff API error (${response.status}): ${error.slice(0, 200)}`);
-      return { differences: [], summary: "Diff unavailable", matchScore: -1 };
+      return { differences: [], summary: "diff 利用不可", matchScore: -1 };
     }
 
     const data = await response.json() as any;
@@ -87,8 +86,8 @@ Focus on layout, typography, colors, spacing, and element presence/absence. Igno
 }
 
 /**
- * Verify a live implementation against an approved design mockup.
- * Combines diff with a pass/fail gate.
+ * live 実装を approved design mockup に照らして検証。
+ * diff に pass/fail gate を組み合わせる。
  */
 export async function verifyAgainstMockup(
   mockupPath: string,
@@ -96,7 +95,7 @@ export async function verifyAgainstMockup(
 ): Promise<{ pass: boolean; matchScore: number; diff: DiffResult }> {
   const diff = await diffMockups(mockupPath, screenshotPath);
 
-  // Pass if matchScore >= 70 and no high-severity differences
+  // matchScore >= 70 かつ high-severity 差分なしで pass
   const highSeverity = diff.differences.filter(d => d.severity === "high");
   const pass = diff.matchScore >= 70 && highSeverity.length === 0;
 

--- a/design/src/evolve.ts
+++ b/design/src/evolve.ts
@@ -1,8 +1,7 @@
 /**
- * Screenshot-to-Mockup Evolution.
- * Takes a screenshot of the live site and generates a mockup showing
- * how it SHOULD look based on a design brief.
- * Starts from reality, not blank canvas.
+ * Screenshot-to-Mockup Evolution。
+ * live site の screenshot を元に、design brief に沿って「あるべき姿」の mockup を生成する。
+ * blank canvas からではなく現実から起点する。
  */
 
 import fs from "fs";
@@ -10,33 +9,32 @@ import path from "path";
 import { requireApiKey } from "./auth";
 
 export interface EvolveOptions {
-  screenshot: string;  // Path to current site screenshot
-  brief: string;       // What to change ("make it calmer", "fix the hierarchy")
-  output: string;      // Output path for evolved mockup
+  screenshot: string;  // 現状 site の screenshot path
+  brief: string;       // 変更指示 ("make it calmer"、"fix the hierarchy" 等)
+  output: string;      // 進化版 mockup の出力 path
 }
 
 /**
- * Generate an evolved mockup from an existing screenshot + brief.
- * Sends the screenshot as context to GPT-4o with image generation,
- * asking it to produce a new version incorporating the brief's changes.
+ * 既存 screenshot + brief から進化版 mockup を生成。
+ * screenshot を context として GPT-4o に送り、image generation tool で
+ * brief の変更を反映した新版を生成する。
  */
 export async function evolve(options: EvolveOptions): Promise<void> {
   const apiKey = requireApiKey();
   const screenshotData = fs.readFileSync(options.screenshot).toString("base64");
 
-  console.error(`Evolving ${options.screenshot} with: "${options.brief}"`);
+  console.error(`${options.screenshot} を進化、変更指示: "${options.brief}"`);
   const startTime = Date.now();
 
-  // Use the Responses API with both a text prompt referencing the screenshot
-  // and the image_generation tool to produce the evolved version.
-  // Since we can't send reference images directly to image_generation,
-  // we describe the current state in detail first via vision, then generate.
+  // Responses API で screenshot を参照する text prompt と image_generation tool を併用し
+  // 進化版を生成する。reference image を image_generation に直接渡せないため、
+  // 先に vision で現状を詳細記述してから生成する。
 
-  // Step 1: Analyze current screenshot
+  // Step 1: 現状 screenshot を分析
   const analysis = await analyzeScreenshot(apiKey, screenshotData);
-  console.error(`  Analyzed current design: ${analysis.slice(0, 100)}...`);
+  console.error(`  現状 design を分析: ${analysis.slice(0, 100)}...`);
 
-  // Step 2: Generate evolved version using analysis + brief
+  // Step 2: 分析結果 + brief で進化版を生成
   const evolvedPrompt = [
     "Generate a pixel-perfect UI mockup that is an improved version of an existing design.",
     "",
@@ -73,9 +71,9 @@ export async function evolve(options: EvolveOptions): Promise<void> {
       const error = await response.text();
       if (response.status === 403 && error.includes("organization must be verified")) {
         throw new Error(
-          "OpenAI organization verification required.\n"
-          + "Go to https://platform.openai.com/settings/organization to verify.\n"
-          + "After verification, wait up to 15 minutes for access to propagate.",
+          "OpenAI organization verification 未完了。\n"
+          + "https://platform.openai.com/settings/organization で verify が必要。\n"
+          + "verify 後、access propagation に最大 15 分かかる。",
         );
       }
       throw new Error(`API error (${response.status}): ${error.slice(0, 300)}`);
@@ -85,7 +83,7 @@ export async function evolve(options: EvolveOptions): Promise<void> {
     const imageItem = data.output?.find((item: any) => item.type === "image_generation_call");
 
     if (!imageItem?.result) {
-      throw new Error("No image data in response");
+      throw new Error("response に image data なし");
     }
 
     fs.mkdirSync(path.dirname(options.output), { recursive: true });
@@ -93,7 +91,7 @@ export async function evolve(options: EvolveOptions): Promise<void> {
     fs.writeFileSync(options.output, imageBuffer);
 
     const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
-    console.error(`Generated (${elapsed}s, ${(imageBuffer.length / 1024).toFixed(0)}KB) → ${options.output}`);
+    console.error(`生成完了 (${elapsed}s, ${(imageBuffer.length / 1024).toFixed(0)}KB) → ${options.output}`);
 
     console.log(JSON.stringify({
       outputPath: options.output,
@@ -106,7 +104,7 @@ export async function evolve(options: EvolveOptions): Promise<void> {
 }
 
 /**
- * Analyze a screenshot to produce a detailed description for re-generation.
+ * screenshot を分析して再生成用の詳細記述を生成。
  */
 async function analyzeScreenshot(apiKey: string, imageBase64: string): Promise<string> {
   const controller = new AbortController();
@@ -140,11 +138,11 @@ async function analyzeScreenshot(apiKey: string, imageBase64: string): Promise<s
     });
 
     if (!response.ok) {
-      return "Unable to analyze screenshot";
+      return "screenshot 分析不可";
     }
 
     const data = await response.json() as any;
-    return data.choices?.[0]?.message?.content?.trim() || "Unable to analyze screenshot";
+    return data.choices?.[0]?.message?.content?.trim() || "screenshot 分析不可";
   } finally {
     clearTimeout(timeout);
   }

--- a/design/src/gallery.ts
+++ b/design/src/gallery.ts
@@ -1,7 +1,7 @@
 /**
- * Design history gallery — generates an HTML timeline of all design explorations
- * for a project. Shows every approved/rejected variant, feedback notes, organized
- * by date. Self-contained HTML with base64-embedded images.
+ * Design history gallery — project の全 design exploration を HTML timeline で生成。
+ * 全 approved/rejected variant + feedback note を date 順で表示。
+ * base64 埋め込み image による self-contained HTML。
  */
 
 import fs from "fs";
@@ -17,7 +17,7 @@ interface SessionData {
   name: string;
   date: string;
   approved: any | null;
-  variants: string[]; // paths to variant PNGs
+  variants: string[]; // variant PNG の path
 }
 
 export function generateGalleryHtml(designsDir: string): string {
@@ -34,17 +34,17 @@ export function generateGalleryHtml(designsDir: string): string {
     const sessionDir = path.join(designsDir, entry.name);
     let approved: any = null;
 
-    // Read approved.json if it exists
+    // approved.json があれば読む
     const approvedPath = path.join(sessionDir, "approved.json");
     if (fs.existsSync(approvedPath)) {
       try {
         approved = JSON.parse(fs.readFileSync(approvedPath, "utf-8"));
       } catch {
-        // Corrupted JSON, skip but still show the session
+        // JSON 破損、session 自体は表示し続ける
       }
     }
 
-    // Find variant PNGs
+    // variant PNG を検索
     const variants: string[] = [];
     try {
       const files = fs.readdirSync(sessionDir);
@@ -55,10 +55,10 @@ export function generateGalleryHtml(designsDir: string): string {
       }
       variants.sort();
     } catch {
-      // Can't read directory, skip
+      // directory 読み取り不可、skip
     }
 
-    // Extract date from directory name (e.g., homepage-20260327)
+    // directory 名から date を抽出（例: homepage-20260327）
     const dateMatch = entry.name.match(/(\d{8})$/);
     const date = dateMatch
       ? `${dateMatch[1].slice(0, 4)}-${dateMatch[1].slice(4, 6)}-${dateMatch[1].slice(6, 8)}`
@@ -77,7 +77,7 @@ export function generateGalleryHtml(designsDir: string): string {
     return generateEmptyGallery();
   }
 
-  // Sort by date, newest first
+  // date 順、新しい順で sort
   sessions.sort((a, b) => b.date.localeCompare(a.date));
 
   const sessionCards = sessions.map(session => {
@@ -95,7 +95,7 @@ export function generateGalleryHtml(designsDir: string): string {
           </div>
         </div>`;
       } catch {
-        return ""; // Skip unreadable images
+        return ""; // 読めない image を skip
       }
     }).filter(Boolean).join("\n");
 
@@ -115,7 +115,7 @@ export function generateGalleryHtml(designsDir: string): string {
   }).join("\n");
 
   return `<!DOCTYPE html>
-<html lang="en">
+<html lang="ja">
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -200,7 +200,7 @@ export function generateGalleryHtml(designsDir: string): string {
 <body>
 <div class="header">
   <h1>Design History</h1>
-  <div class="meta">${sessions.length} exploration${sessions.length === 1 ? "" : "s"}</div>
+  <div class="meta">${sessions.length} 件の exploration</div>
 </div>
 <div class="gallery">
   ${sessionCards}
@@ -211,7 +211,7 @@ export function generateGalleryHtml(designsDir: string): string {
 
 function generateEmptyGallery(): string {
   return `<!DOCTYPE html>
-<html lang="en">
+<html lang="ja">
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -228,8 +228,8 @@ function generateEmptyGallery(): string {
 </head>
 <body>
 <div class="empty">
-  <h2>No design history yet</h2>
-  <p>Run <code>/design-shotgun</code> to start exploring design directions.</p>
+  <h2>design 履歴なし</h2>
+  <p><code>/design-shotgun</code> で design 探索を開始。</p>
 </div>
 </body>
 </html>`;
@@ -240,7 +240,7 @@ function escapeHtml(str: string): string {
 }
 
 /**
- * Gallery command: generate HTML timeline from design explorations.
+ * Gallery command：design exploration から HTML timeline を生成。
  */
 export function gallery(options: GalleryOptions): void {
   const html = generateGalleryHtml(options.designsDir);

--- a/design/src/generate.ts
+++ b/design/src/generate.ts
@@ -1,5 +1,5 @@
 /**
- * Generate UI mockups via OpenAI Responses API with image_generation tool.
+ * OpenAI Responses API + image_generation tool で UI mockup を生成。
  */
 
 import fs from "fs";
@@ -27,8 +27,8 @@ export interface GenerateResult {
 }
 
 /**
- * Call OpenAI Responses API with image_generation tool.
- * Returns the response ID and base64 image data.
+ * OpenAI Responses API を image_generation tool 付きで呼び出す。
+ * response ID と base64 image data を返す。
  */
 async function callImageGeneration(
   apiKey: string,
@@ -62,9 +62,9 @@ async function callImageGeneration(
       const error = await response.text();
       if (response.status === 403 && error.includes("organization must be verified")) {
         throw new Error(
-          "OpenAI organization verification required.\n"
-          + "Go to https://platform.openai.com/settings/organization to verify.\n"
-          + "After verification, wait up to 15 minutes for access to propagate.",
+          "OpenAI organization verification 未完了。\n"
+          + "https://platform.openai.com/settings/organization で verify が必要。\n"
+          + "verify 後、access propagation に最大 15 分かかる。",
         );
       }
       throw new Error(`API error (${response.status}): ${error.slice(0, 200)}`);
@@ -78,7 +78,7 @@ async function callImageGeneration(
 
     if (!imageItem?.result) {
       throw new Error(
-        `No image data in response. Output types: ${data.output?.map((o: any) => o.type).join(", ") || "none"}`
+        `response に image data なし。output types: ${data.output?.map((o: any) => o.type).join(", ") || "none"}`
       );
     }
 
@@ -92,12 +92,12 @@ async function callImageGeneration(
 }
 
 /**
- * Generate a single mockup from a brief.
+ * brief から mockup を 1 枚生成。
  */
 export async function generate(options: GenerateOptions): Promise<GenerateResult> {
   const apiKey = requireApiKey();
 
-  // Parse the brief
+  // brief を parse
   const prompt = options.briefFile
     ? parseBrief(options.briefFile, true)
     : parseBrief(options.brief!, false);
@@ -113,21 +113,21 @@ export async function generate(options: GenerateOptions): Promise<GenerateResult
       console.error(`Retry ${attempt}/${maxRetries}...`);
     }
 
-    // Generate the image
+    // image を生成
     const startTime = Date.now();
     const { responseId, imageData } = await callImageGeneration(apiKey, prompt, size, quality);
     const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
 
-    // Write to disk
+    // disk へ書き出し
     const outputDir = path.dirname(options.output);
     fs.mkdirSync(outputDir, { recursive: true });
     const imageBuffer = Buffer.from(imageData, "base64");
     fs.writeFileSync(options.output, imageBuffer);
 
-    // Create session
+    // session を作成
     const session = createSession(responseId, prompt, options.output);
 
-    console.error(`Generated (${elapsed}s, ${(imageBuffer.length / 1024).toFixed(0)}KB) → ${options.output}`);
+    console.error(`生成完了 (${elapsed}s, ${(imageBuffer.length / 1024).toFixed(0)}KB) → ${options.output}`);
 
     lastResult = {
       outputPath: options.output,
@@ -135,7 +135,7 @@ export async function generate(options: GenerateOptions): Promise<GenerateResult
       responseId,
     };
 
-    // Quality check if requested
+    // 指定があれば quality check
     if (options.check) {
       const checkResult = await checkMockup(options.output, prompt);
       lastResult.checkResult = checkResult;
@@ -146,7 +146,7 @@ export async function generate(options: GenerateOptions): Promise<GenerateResult
       } else {
         console.error(`Quality check: FAIL — ${checkResult.issues}`);
         if (attempt < maxRetries) {
-          console.error("Will retry...");
+          console.error("retry します...");
         }
       }
     } else {
@@ -154,7 +154,7 @@ export async function generate(options: GenerateOptions): Promise<GenerateResult
     }
   }
 
-  // Output result as JSON to stdout
+  // 結果を JSON で stdout 出力
   console.log(JSON.stringify(lastResult, null, 2));
   return lastResult!;
 }

--- a/design/src/iterate.ts
+++ b/design/src/iterate.ts
@@ -1,9 +1,9 @@
 /**
- * Multi-turn design iteration using OpenAI Responses API.
+ * OpenAI Responses API を使った複数ターンの design iteration。
  *
- * Primary: uses previous_response_id for conversational threading.
- * Fallback: if threading doesn't retain visual context, re-generates
- * with original brief + accumulated feedback in a single prompt.
+ * Primary: previous_response_id で会話 thread を継続。
+ * Fallback: thread が visual context を保持しない場合、元 brief +
+ * 累積 feedback を 1 つの prompt にまとめて再生成する。
  */
 
 import fs from "fs";
@@ -12,25 +12,25 @@ import { requireApiKey } from "./auth";
 import { readSession, updateSession } from "./session";
 
 export interface IterateOptions {
-  session: string;   // Path to session JSON file
-  feedback: string;  // User feedback text
-  output: string;    // Output path for new PNG
+  session: string;   // session JSON file path
+  feedback: string;  // user feedback 文
+  output: string;    // 新 PNG の出力 path
 }
 
 /**
- * Iterate on an existing design using session state.
+ * session 状態を使って既存 design を iterate。
  */
 export async function iterate(options: IterateOptions): Promise<void> {
   const apiKey = requireApiKey();
   const session = readSession(options.session);
 
-  console.error(`Iterating on session ${session.id}...`);
-  console.error(`  Previous iterations: ${session.feedbackHistory.length}`);
+  console.error(`session ${session.id} を iterate 中...`);
+  console.error(`  これまでの iteration: ${session.feedbackHistory.length}`);
   console.error(`  Feedback: "${options.feedback}"`);
 
   const startTime = Date.now();
 
-  // Try multi-turn with previous_response_id first
+  // まず previous_response_id で multi-turn を試行
   let success = false;
   let responseId = "";
 
@@ -42,10 +42,10 @@ export async function iterate(options: IterateOptions): Promise<void> {
     fs.writeFileSync(options.output, Buffer.from(result.imageData, "base64"));
     success = true;
   } catch (err: any) {
-    console.error(`  Threading failed: ${err.message}`);
-    console.error("  Falling back to re-generation with accumulated feedback...");
+    console.error(`  threading 失敗: ${err.message}`);
+    console.error("  累積 feedback で再生成に fallback...");
 
-    // Fallback: re-generate with original brief + all feedback
+    // Fallback: 元 brief + 全 feedback で再生成
     const accumulatedPrompt = buildAccumulatedPrompt(
       session.originalBrief,
       [...session.feedbackHistory, options.feedback]
@@ -62,9 +62,9 @@ export async function iterate(options: IterateOptions): Promise<void> {
   if (success) {
     const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
     const size = fs.statSync(options.output).size;
-    console.error(`Generated (${elapsed}s, ${(size / 1024).toFixed(0)}KB) → ${options.output}`);
+    console.error(`生成完了 (${elapsed}s, ${(size / 1024).toFixed(0)}KB) → ${options.output}`);
 
-    // Update session
+    // session を更新
     updateSession(session, responseId, options.feedback, options.output);
 
     console.log(JSON.stringify({
@@ -104,9 +104,9 @@ async function callWithThreading(
       const error = await response.text();
       if (response.status === 403 && error.includes("organization must be verified")) {
         throw new Error(
-          "OpenAI organization verification required.\n"
-          + "Go to https://platform.openai.com/settings/organization to verify.\n"
-          + "After verification, wait up to 15 minutes for access to propagate.",
+          "OpenAI organization verification 未完了。\n"
+          + "https://platform.openai.com/settings/organization で verify が必要。\n"
+          + "verify 後、access propagation に最大 15 分かかる。",
         );
       }
       throw new Error(`API error (${response.status}): ${error.slice(0, 300)}`);
@@ -116,7 +116,7 @@ async function callWithThreading(
     const imageItem = data.output?.find((item: any) => item.type === "image_generation_call");
 
     if (!imageItem?.result) {
-      throw new Error("No image data in threaded response");
+      throw new Error("threaded response に image data なし");
     }
 
     return { responseId: data.id, imageData: imageItem.result };
@@ -151,9 +151,9 @@ async function callFresh(
       const error = await response.text();
       if (response.status === 403 && error.includes("organization must be verified")) {
         throw new Error(
-          "OpenAI organization verification required.\n"
-          + "Go to https://platform.openai.com/settings/organization to verify.\n"
-          + "After verification, wait up to 15 minutes for access to propagate.",
+          "OpenAI organization verification 未完了。\n"
+          + "https://platform.openai.com/settings/organization で verify が必要。\n"
+          + "verify 後、access propagation に最大 15 分かかる。",
         );
       }
       throw new Error(`API error (${response.status}): ${error.slice(0, 300)}`);
@@ -163,7 +163,7 @@ async function callFresh(
     const imageItem = data.output?.find((item: any) => item.type === "image_generation_call");
 
     if (!imageItem?.result) {
-      throw new Error("No image data in fresh response");
+      throw new Error("fresh response に image data なし");
     }
 
     return { responseId: data.id, imageData: imageItem.result };
@@ -173,7 +173,7 @@ async function callFresh(
 }
 
 function buildAccumulatedPrompt(originalBrief: string, feedback: string[]): string {
-  // Cap to last 5 iterations to limit accumulation attack surface
+  // 累積 attack surface を抑えるため直近 5 iteration に cap
   const recentFeedback = feedback.slice(-5);
   const lines = [
     originalBrief,

--- a/design/src/memory.ts
+++ b/design/src/memory.ts
@@ -1,14 +1,13 @@
 /**
- * Design Memory — extract visual language from approved mockups into DESIGN.md.
+ * Design Memory — approved mockup から visual language を抽出して DESIGN.md に反映。
  *
- * After a mockup is approved, uses GPT-4o vision to extract:
- * - Color palette (hex values)
- * - Typography (font families, sizes, weights)
- * - Spacing patterns (padding, margins, gaps)
- * - Layout conventions (grid, alignment, hierarchy)
+ * mockup 承認後、GPT-4o vision で次を抽出する：
+ * - color palette（hex 値）
+ * - typography（font family、size、weight）
+ * - spacing pattern（padding、margin、gap）
+ * - layout convention（grid、alignment、hierarchy）
  *
- * If DESIGN.md exists, merges extracted patterns with existing design system.
- * If no DESIGN.md, creates one from the extracted patterns.
+ * DESIGN.md があれば抽出 pattern を既存 design system に merge、なければ新規作成する。
  */
 
 import fs from "fs";
@@ -24,7 +23,7 @@ export interface ExtractedDesign {
 }
 
 /**
- * Extract visual language from an approved mockup PNG.
+ * approved mockup PNG から visual language を抽出。
  */
 export async function extractDesignLanguage(imagePath: string): Promise<ExtractedDesign> {
   const apiKey = requireApiKey();
@@ -72,7 +71,7 @@ Extract real values from what you see. Be specific about hex colors and font siz
     });
 
     if (!response.ok) {
-      console.error(`Vision extraction failed (${response.status})`);
+      console.error(`vision 抽出失敗 (${response.status})`);
       return defaultDesign();
     }
 
@@ -80,7 +79,7 @@ Extract real values from what you see. Be specific about hex colors and font siz
     const content = data.choices?.[0]?.message?.content?.trim() || "";
     return JSON.parse(content) as ExtractedDesign;
   } catch (err: any) {
-    console.error(`Design extraction error: ${err.message}`);
+    console.error(`design 抽出 error: ${err.message}`);
     return defaultDesign();
   } finally {
     clearTimeout(timeout);
@@ -93,14 +92,14 @@ function defaultDesign(): ExtractedDesign {
     typography: [],
     spacing: [],
     layout: [],
-    mood: "Unable to extract design language",
+    mood: "design language 抽出不可",
   };
 }
 
 /**
- * Write or update DESIGN.md with extracted design patterns.
- * If DESIGN.md exists, appends an "Extracted from mockup" section.
- * If not, creates a new one.
+ * 抽出 design pattern を DESIGN.md に書き出し / 更新。
+ * DESIGN.md があれば "Extracted Design Language" section を append、
+ * なければ新規作成する。
  */
 export function updateDesignMd(
   repoRoot: string,
@@ -113,10 +112,10 @@ export function updateDesignMd(
   const section = formatExtractedSection(extracted, sourceMockup, timestamp);
 
   if (fs.existsSync(designPath)) {
-    // Append to existing DESIGN.md
+    // 既存 DESIGN.md に append
     const existing = fs.readFileSync(designPath, "utf-8");
 
-    // Check if there's already an extracted section, replace it
+    // 既に extracted section があれば置換
     const marker = "## Extracted Design Language";
     if (existing.includes(marker)) {
       const before = existing.split(marker)[0];
@@ -124,14 +123,14 @@ export function updateDesignMd(
     } else {
       fs.writeFileSync(designPath, existing.trimEnd() + "\n\n" + section);
     }
-    console.error(`Updated DESIGN.md with extracted design language`);
+    console.error(`DESIGN.md を抽出 design language で更新`);
   } else {
-    // Create new DESIGN.md
+    // DESIGN.md を新規作成
     const content = `# Design System
 
 ${section}`;
     fs.writeFileSync(designPath, content);
-    console.error(`Created DESIGN.md with extracted design language`);
+    console.error(`DESIGN.md を抽出 design language で新規作成`);
   }
 }
 
@@ -189,14 +188,14 @@ function formatExtractedSection(
 }
 
 /**
- * Read DESIGN.md and return it as a constraint string for brief construction.
- * If no DESIGN.md exists, returns null (explore wide).
+ * DESIGN.md を読んで brief 構築用の constraint 文字列として返す。
+ * DESIGN.md がなければ null（自由探索）。
  */
 export function readDesignConstraints(repoRoot: string): string | null {
   const designPath = path.join(repoRoot, "DESIGN.md");
   if (!fs.existsSync(designPath)) return null;
 
   const content = fs.readFileSync(designPath, "utf-8");
-  // Truncate to first 2000 chars to keep brief reasonable
+  // brief を妥当 size に保つため最初 2000 文字に切り詰め
   return content.slice(0, 2000);
 }

--- a/design/src/serve.ts
+++ b/design/src/serve.ts
@@ -1,12 +1,12 @@
 /**
- * HTTP server for the design comparison board feedback loop.
+ * design comparison board の feedback loop 用 HTTP server。
  *
- * Replaces the broken file:// + DOM polling approach. The server:
- * 1. Serves the comparison board HTML over HTTP
- * 2. Injects __UZUSTACK_SERVER_URL so the board POSTs feedback here
- * 3. Prints feedback JSON to stdout (agent reads it)
- * 4. Stays alive across regeneration rounds (stateful)
- * 5. Auto-opens in the user's default browser
+ * 壊れていた file:// + DOM polling 方式の置き換え。本 server は：
+ * 1. comparison board HTML を HTTP で serve
+ * 2. __UZUSTACK_SERVER_URL を inject、board からこの server に feedback POST
+ * 3. feedback JSON を stdout に出力（agent が読む）
+ * 4. 再生成サイクル間で alive を維持（stateful）
+ * 5. user の default browser で自動 open
  *
  * State machine:
  *
@@ -21,15 +21,15 @@
  *      │
  *      └──(timeout)──► exit 1
  *
- * Feedback delivery (two channels, both always active):
- *   Stdout: feedback JSON (one line per event) — for foreground mode
- *   Disk:   feedback-pending.json (regenerate/remix) or feedback.json (submit)
- *           written next to the HTML file — for background mode polling
+ * Feedback delivery（2 channel、いずれも常時 active）:
+ *   Stdout: feedback JSON（event 1 件 = 1 行）— foreground mode 用
+ *   Disk:   HTML file 隣接の feedback-pending.json (regenerate/remix) または
+ *           feedback.json (submit) — background mode polling 用
  *
- * The agent typically backgrounds $D serve and polls for feedback-pending.json.
- * When found: read it, delete it, generate new variants, POST /api/reload.
+ * agent は通常 $D serve を background 化、feedback-pending.json を polling する。
+ * 検出時：読み取り → 削除 → 新 variant 生成 → POST /api/reload。
  *
- * Stderr: structured telemetry (SERVE_STARTED, SERVE_FEEDBACK_RECEIVED, etc.)
+ * Stderr: 構造化 telemetry（SERVE_STARTED / SERVE_FEEDBACK_RECEIVED 等）。
  */
 
 import fs from "fs";
@@ -40,8 +40,8 @@ import { spawn } from "child_process";
 export interface ServeOptions {
   html: string;
   port?: number;
-  hostname?: string; // default '127.0.0.1' — localhost only
-  timeout?: number; // seconds, default 600 (10 min)
+  hostname?: string; // default '127.0.0.1' — localhost のみ
+  timeout?: number; // 秒、default 600（10 分）
 }
 
 type ServerState = "serving" | "regenerating" | "done";
@@ -49,14 +49,14 @@ type ServerState = "serving" | "regenerating" | "done";
 export async function serve(options: ServeOptions): Promise<void> {
   const { html, port = 0, hostname = "127.0.0.1", timeout = 600 } = options;
 
-  // Validate HTML file exists
+  // HTML file 存在確認
   if (!fs.existsSync(html)) {
     console.error(`SERVE_ERROR: HTML file not found: ${html}`);
     process.exit(1);
   }
 
-  // Security: anchor all file reads to the initial HTML's directory.
-  // Prevents /api/reload from reading arbitrary files via path traversal.
+  // security: file 読み取りを初期 HTML の directory に固定。
+  // /api/reload 経由 path traversal による任意 file 読み取りを防ぐ。
   const allowedDir = fs.realpathSync(path.dirname(path.resolve(html)));
 
   let htmlContent = fs.readFileSync(html, "utf-8");
@@ -69,12 +69,12 @@ export async function serve(options: ServeOptions): Promise<void> {
     fetch(req) {
       const url = new URL(req.url);
 
-      // Serve the comparison board HTML
+      // comparison board HTML を serve
       if (
         req.method === "GET" &&
         (url.pathname === "/" || url.pathname === "/index.html")
       ) {
-        // Inject the server URL so the board can POST feedback
+        // server URL を inject、board が feedback POST できるようにする
         const injected = htmlContent.replace(
           "</head>",
           `<script>window.__UZUSTACK_SERVER_URL = ${JSON.stringify(url.origin)};</script>\n</head>`,
@@ -84,17 +84,17 @@ export async function serve(options: ServeOptions): Promise<void> {
         });
       }
 
-      // Progress polling endpoint (used by board during regeneration)
+      // progress polling endpoint（regeneration 中に board が使う）
       if (req.method === "GET" && url.pathname === "/api/progress") {
         return Response.json({ status: state });
       }
 
-      // Feedback submission from the board
+      // board からの feedback 送信
       if (req.method === "POST" && url.pathname === "/api/feedback") {
         return handleFeedback(req);
       }
 
-      // Reload endpoint (used by the agent to swap in new board HTML)
+      // reload endpoint（agent が新 board HTML に差し替えるのに使う）
       if (req.method === "POST" && url.pathname === "/api/reload") {
         return handleReload(req);
       }
@@ -108,10 +108,10 @@ export async function serve(options: ServeOptions): Promise<void> {
 
   console.error(`SERVE_STARTED: port=${actualPort} html=${html}`);
 
-  // Auto-open in user's default browser
+  // user の default browser で自動 open
   openBrowser(boardUrl);
 
-  // Set timeout
+  // timeout 設定
   timeoutTimer = setTimeout(() => {
     console.error(`SERVE_TIMEOUT: after=${timeout}s`);
     server.stop();
@@ -126,7 +126,7 @@ export async function serve(options: ServeOptions): Promise<void> {
       return Response.json({ error: "Invalid JSON" }, { status: 400 });
     }
 
-    // Validate expected shape
+    // 期待 shape を validate
     if (typeof body !== "object" || body === null) {
       return Response.json({ error: "Expected JSON object" }, { status: 400 });
     }
@@ -139,11 +139,11 @@ export async function serve(options: ServeOptions): Promise<void> {
 
     console.error(`SERVE_FEEDBACK_RECEIVED: type=${action}`);
 
-    // Print feedback JSON to stdout (for foreground mode)
+    // feedback JSON を stdout 出力（foreground mode 用）
     console.log(JSON.stringify(body));
 
-    // ALWAYS write feedback to disk so the agent can poll for it
-    // (agent typically backgrounds $D serve, can't read stdout)
+    // 常に feedback を disk へ書き出し、agent が polling できるようにする
+    // （agent は通常 $D serve を background 化するため stdout を読めない）
     const feedbackDir = path.dirname(html);
     const feedbackFile = isSubmit ? "feedback.json" : "feedback-pending.json";
     const feedbackPath = path.join(feedbackDir, feedbackFile);
@@ -153,7 +153,7 @@ export async function serve(options: ServeOptions): Promise<void> {
       state = "done";
       if (timeoutTimer) clearTimeout(timeoutTimer);
 
-      // Give the response time to send before exiting
+      // exit 前に response 送信時間を確保
       setTimeout(() => {
         server.stop();
         process.exit(0);
@@ -164,7 +164,7 @@ export async function serve(options: ServeOptions): Promise<void> {
 
     if (isRegenerate) {
       state = "regenerating";
-      // Reset timeout for regeneration (agent needs time to generate new variants)
+      // regeneration 用に timeout リセット（agent は新 variant 生成の時間が必要）
       if (timeoutTimer) clearTimeout(timeoutTimer);
       timeoutTimer = setTimeout(() => {
         console.error(`SERVE_TIMEOUT: after=${timeout}s (during regeneration)`);
@@ -194,9 +194,8 @@ export async function serve(options: ServeOptions): Promise<void> {
       );
     }
 
-    // Security: resolve symlinks and validate the reload path is within the
-    // allowed directory (anchored to the initial HTML file's parent).
-    // Prevents path traversal via /api/reload reading arbitrary files.
+    // security: symlink を解決し、reload path が allowedDir 内かを validate。
+    // /api/reload 経由 path traversal による任意 file 読み取りを防ぐ。
     const resolvedReload = fs.realpathSync(path.resolve(newHtmlPath));
     if (
       !resolvedReload.startsWith(allowedDir + path.sep) &&
@@ -208,13 +207,13 @@ export async function serve(options: ServeOptions): Promise<void> {
       );
     }
 
-    // Swap the HTML content
+    // HTML content を差し替え
     htmlContent = fs.readFileSync(resolvedReload, "utf-8");
     state = "serving";
 
     console.error(`SERVE_RELOADED: html=${newHtmlPath}`);
 
-    // Reset timeout
+    // timeout リセット
     if (timeoutTimer) clearTimeout(timeoutTimer);
     timeoutTimer = setTimeout(() => {
       console.error(`SERVE_TIMEOUT: after=${timeout}s`);
@@ -225,13 +224,13 @@ export async function serve(options: ServeOptions): Promise<void> {
     return Response.json({ reloaded: true });
   }
 
-  // Keep the process alive
+  // process を生かし続ける
   await new Promise(() => {});
 }
 
 /**
- * Open a URL in the user's default browser.
- * Handles macOS (open), Linux (xdg-open), and headless environments.
+ * user の default browser で URL を open。
+ * macOS (open) / Linux (xdg-open) / headless 環境に対応。
  */
 function openBrowser(url: string): void {
   const platform = process.platform;
@@ -242,9 +241,9 @@ function openBrowser(url: string): void {
   } else if (platform === "linux") {
     cmd = "xdg-open";
   } else {
-    // Windows or unknown — just print the URL
+    // Windows または unknown — URL 出力のみ
     console.error(`SERVE_BROWSER_MANUAL: url=${url}`);
-    console.error(`Open this URL in your browser: ${url}`);
+    console.error(`browser で URL を open: ${url}`);
     return;
   }
 
@@ -256,8 +255,8 @@ function openBrowser(url: string): void {
     child.unref();
     console.error(`SERVE_BROWSER_OPENED: url=${url}`);
   } catch {
-    // open/xdg-open not available (headless CI environment)
+    // open / xdg-open 利用不可（headless CI 環境）
     console.error(`SERVE_BROWSER_MANUAL: url=${url}`);
-    console.error(`Open this URL in your browser: ${url}`);
+    console.error(`browser で URL を open: ${url}`);
   }
 }

--- a/design/src/session.ts
+++ b/design/src/session.ts
@@ -1,6 +1,6 @@
 /**
- * Session state management for multi-turn design iteration.
- * Session files are JSON in /tmp, keyed by PID + timestamp.
+ * 複数ターン design iteration のための session 状態管理。
+ * session file は PID + timestamp を key とする JSON を /tmp に置く。
  */
 
 import fs from "fs";
@@ -17,21 +17,21 @@ export interface DesignSession {
 }
 
 /**
- * Generate a unique session ID from PID + timestamp.
+ * PID + timestamp で一意な session ID を生成。
  */
 export function createSessionId(): string {
   return `${process.pid}-${Date.now()}`;
 }
 
 /**
- * Get the file path for a session.
+ * session file の path を取得。
  */
 export function sessionPath(sessionId: string): string {
   return path.join("/tmp", `design-session-${sessionId}.json`);
 }
 
 /**
- * Create a new session after initial generation.
+ * 初回生成後に新規 session を作成。
  */
 export function createSession(
   responseId: string,
@@ -54,7 +54,7 @@ export function createSession(
 }
 
 /**
- * Read an existing session from disk.
+ * disk から既存 session を読み出し。
  */
 export function readSession(sessionFilePath: string): DesignSession {
   const content = fs.readFileSync(sessionFilePath, "utf-8");
@@ -62,7 +62,7 @@ export function readSession(sessionFilePath: string): DesignSession {
 }
 
 /**
- * Update a session with new iteration data.
+ * 新しい iteration data で session を更新。
  */
 export function updateSession(
   session: DesignSession,

--- a/design/src/variants.ts
+++ b/design/src/variants.ts
@@ -1,7 +1,7 @@
 /**
- * Generate N design variants from a brief.
- * Uses staggered parallel: 1s delay between API calls to avoid rate limits.
- * Falls back to exponential backoff on 429s.
+ * brief から N 個の design variant を生成。
+ * 段階並列：API call 間に 1s delay を入れて rate limit を回避する。
+ * 429 で fallback として exponential backoff を行う。
  */
 
 import fs from "fs";
@@ -16,11 +16,11 @@ export interface VariantsOptions {
   outputDir: string;
   size?: string;
   quality?: string;
-  viewports?: string; // "desktop,tablet,mobile" — generates at multiple sizes
+  viewports?: string; // "desktop,tablet,mobile" — 複数 size で生成
 }
 
 const STYLE_VARIATIONS = [
-  "", // First variant uses the brief as-is
+  "", // 1 番目の variant は brief をそのまま使用
   "Use a bolder, more dramatic visual style with stronger contrast and larger typography.",
   "Use a calmer, more minimal style with generous whitespace and subtle colors.",
   "Use a warmer, more approachable style with rounded corners and friendly typography.",
@@ -30,7 +30,7 @@ const STYLE_VARIATIONS = [
 ];
 
 /**
- * Generate a single variant with retry on 429.
+ * variant を 1 個生成、429 で retry。
  */
 async function generateVariant(
   apiKey: string,
@@ -44,9 +44,9 @@ async function generateVariant(
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     if (attempt > 0) {
-      // Exponential backoff: 2s, 4s, 8s
+      // exponential backoff: 2s / 4s / 8s
       const delay = Math.pow(2, attempt) * 1000;
-      console.error(`  Rate limited, retrying in ${delay / 1000}s...`);
+      console.error(`  rate limited、${delay / 1000}s 後に retry...`);
       await new Promise(r => setTimeout(r, delay));
     }
 
@@ -78,7 +78,7 @@ async function generateVariant(
       if (!response.ok) {
         const error = await response.text();
         if (response.status === 403 && error.includes("organization must be verified")) {
-          return { path: outputPath, success: false, error: "OpenAI organization verification required. Go to https://platform.openai.com/settings/organization to verify." };
+          return { path: outputPath, success: false, error: "OpenAI organization verification 未完了。https://platform.openai.com/settings/organization で verify が必要。" };
         }
         return { path: outputPath, success: false, error: `API error (${response.status}): ${error.slice(0, 200)}` };
       }
@@ -87,7 +87,7 @@ async function generateVariant(
       const imageItem = data.output?.find((item: any) => item.type === "image_generation_call");
 
       if (!imageItem?.result) {
-        return { path: outputPath, success: false, error: "No image data in response" };
+        return { path: outputPath, success: false, error: "response に image data なし" };
       }
 
       fs.writeFileSync(outputPath, Buffer.from(imageItem.result, "base64"));
@@ -105,7 +105,7 @@ async function generateVariant(
 }
 
 /**
- * Generate N variants with staggered parallel execution.
+ * 段階並列で N 個の variant を生成。
  */
 export async function variants(options: VariantsOptions): Promise<void> {
   const apiKey = requireApiKey();
@@ -117,19 +117,19 @@ export async function variants(options: VariantsOptions): Promise<void> {
 
   fs.mkdirSync(options.outputDir, { recursive: true });
 
-  // If viewports specified, generate responsive variants instead of style variants
+  // viewports 指定時は style variant ではなく responsive variant を生成
   if (options.viewports) {
     await generateResponsiveVariants(apiKey, baseBrief, options.outputDir, options.viewports, quality);
     return;
   }
 
-  const count = Math.min(options.count, 7); // Cap at 7 style variations
+  const count = Math.min(options.count, 7); // style variation は 7 個に cap
   const size = options.size || "1536x1024";
 
-  console.error(`Generating ${count} variants...`);
+  console.error(`${count} 件の variant を生成中...`);
   const startTime = Date.now();
 
-  // Staggered parallel: start each call 1.5s apart
+  // 段階並列：各 call を 1.5s 間隔で開始
   const promises: Promise<{ path: string; success: boolean; error?: string }>[] = [];
 
   for (let i = 0; i < count; i++) {
@@ -140,12 +140,12 @@ export async function variants(options: VariantsOptions): Promise<void> {
 
     const outputPath = path.join(options.outputDir, `variant-${String.fromCharCode(65 + i)}.png`);
 
-    // Stagger: wait 1.5s between launches
+    // stagger: 起動間に 1.5s 待機
     const delay = i * 1500;
     promises.push(
       new Promise(resolve => setTimeout(resolve, delay))
         .then(() => {
-          console.error(`  Starting variant ${String.fromCharCode(65 + i)}...`);
+          console.error(`  variant ${String.fromCharCode(65 + i)} を開始...`);
           return generateVariant(apiKey, prompt, outputPath, size, quality);
         })
     );
@@ -170,9 +170,9 @@ export async function variants(options: VariantsOptions): Promise<void> {
     }
   }
 
-  console.error(`\n${succeeded.length}/${count} variants generated (${elapsed}s)`);
+  console.error(`\n${succeeded.length}/${count} 件の variant 生成完了 (${elapsed}s)`);
 
-  // Output structured result to stdout
+  // 構造化結果を stdout に出力
   console.log(JSON.stringify({
     outputDir: options.outputDir,
     count,
@@ -200,11 +200,11 @@ async function generateResponsiveVariants(
   const configs = viewportList.map(v => VIEWPORT_CONFIGS[v]).filter(Boolean);
 
   if (configs.length === 0) {
-    console.error(`No valid viewports. Use: desktop, tablet, mobile`);
+    console.error(`有効な viewport なし。指定可能：desktop / tablet / mobile`);
     process.exit(1);
   }
 
-  console.error(`Generating responsive variants: ${configs.map(c => c.desc).join(", ")}...`);
+  console.error(`responsive variant を生成中: ${configs.map(c => c.desc).join(", ")}...`);
   const startTime = Date.now();
 
   const promises = configs.map((config, i) => {
@@ -219,7 +219,7 @@ async function generateResponsiveVariants(
     return new Promise<{ path: string; success: boolean; error?: string }>(resolve =>
       setTimeout(resolve, delay)
     ).then(() => {
-      console.error(`  Starting ${config.desc}...`);
+      console.error(`  ${config.desc} を開始...`);
       return generateVariant(apiKey, prompt, outputPath, config.size, quality);
     });
   });
@@ -239,7 +239,7 @@ async function generateResponsiveVariants(
     }
   }
 
-  console.error(`\n${succeeded.length}/${configs.length} responsive variants generated (${elapsed}s)`);
+  console.error(`\n${succeeded.length}/${configs.length} 件の responsive variant 生成完了 (${elapsed}s)`);
   console.log(JSON.stringify({
     outputDir,
     viewports: viewportList,

--- a/design/test/gallery.test.ts
+++ b/design/test/gallery.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for the $D gallery command — design history timeline generation.
+ * $D gallery command の test — design history timeline 生成。
  */
 
 import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
@@ -32,13 +32,13 @@ describe('Gallery generation', () => {
     fs.mkdirSync(emptyDir, { recursive: true });
 
     const html = generateGalleryHtml(emptyDir);
-    expect(html).toContain('No design history yet');
+    expect(html).toContain('design 履歴なし');
     expect(html).toContain('/design-shotgun');
   });
 
   test('nonexistent directory returns "No history" page', () => {
     const html = generateGalleryHtml('/nonexistent/path');
-    expect(html).toContain('No design history yet');
+    expect(html).toContain('design 履歴なし');
   });
 
   test('single session with approved variant', () => {
@@ -58,12 +58,12 @@ describe('Gallery generation', () => {
 
     const html = generateGalleryHtml(path.join(tmpDir, 'designs'));
     expect(html).toContain('Design History');
-    expect(html).toContain('1 exploration');
+    expect(html).toContain('1 件の exploration');
     expect(html).toContain('homepage');
     expect(html).toContain('2026-03-27');
     expect(html).toContain('approved');
     expect(html).toContain('Great spacing and colors');
-    // Should have 3 variant images (base64)
+    // 3 個の variant image (base64) が含まれる
     expect(html).toContain('data:image/png;base64,');
   });
 
@@ -85,8 +85,8 @@ describe('Gallery generation', () => {
     }));
 
     const html = generateGalleryHtml(dir);
-    expect(html).toContain('2 explorations');
-    // Dashboard (Mar 15) should appear before settings (Mar 1)
+    expect(html).toContain('2 件の exploration');
+    // Dashboard (Mar 15) は settings (Mar 1) より前に出るはず
     const dashIdx = html.indexOf('dashboard');
     const settingsIdx = html.indexOf('settings');
     expect(dashIdx).toBeLessThan(settingsIdx);
@@ -101,10 +101,10 @@ describe('Gallery generation', () => {
     fs.writeFileSync(path.join(session, 'approved.json'), 'NOT VALID JSON {{{');
 
     const html = generateGalleryHtml(dir);
-    // Should still render the session, just without any variant marked as approved
+    // session 自体は表示し続ける、ただし approved variant 表示なし
     expect(html).toContain('Design History');
     expect(html).toContain('broken');
-    // The class "approved" should not appear on any variant div (only in CSS definition)
+    // どの variant div にも "approved" class が付かないこと（CSS 定義のみ）
     expect(html).not.toContain('class="gallery-variant approved"');
   });
 
@@ -118,7 +118,7 @@ describe('Gallery generation', () => {
 
     const html = generateGalleryHtml(dir);
     expect(html).toContain('draft');
-    // No variant should be marked as approved
+    // どの variant にも approved 印がつかない
     expect(html).not.toContain('class="gallery-variant approved"');
   });
 
@@ -129,11 +129,11 @@ describe('Gallery generation', () => {
     createTestPng(path.join(session, 'variant-A.png'));
 
     const html = generateGalleryHtml(dir);
-    // No external CSS/JS/image links
+    // 外部 CSS/JS/image link なし
     expect(html).not.toContain('href="http');
     expect(html).not.toContain('src="http');
     expect(html).not.toContain('<link');
-    // All images are base64
+    // 全 image が base64
     expect(html).toContain('data:image/png;base64,');
   });
 });

--- a/design/test/serve.test.ts
+++ b/design/test/serve.test.ts
@@ -1,11 +1,11 @@
 /**
- * Tests for the $D serve command — HTTP server for comparison board feedback.
+ * $D serve command の test — comparison board feedback 用 HTTP server。
  *
- * Tests the stateful server lifecycle:
+ * stateful な server lifecycle を test する：
  * - SERVING → POST submit → DONE (exit 0)
  * - SERVING → POST regenerate → REGENERATING → POST reload → SERVING
  * - Timeout → exit 1
- * - Error handling (missing HTML, malformed JSON, missing reload path)
+ * - error 処理（HTML 欠如、不正 JSON、reload path 欠如）
  */
 
 import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
@@ -16,7 +16,7 @@ import * as path from 'path';
 let tmpDir: string;
 let boardHtml: string;
 
-// Create a minimal 1x1 pixel PNG for test variants
+// test variant 用に minimal 1x1 pixel PNG を作成
 function createTestPng(filePath: string): void {
   const png = Buffer.from(
     'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/58BAwAI/AL+hc2rNAAAAABJRU5ErkJggg==',
@@ -29,7 +29,7 @@ beforeAll(() => {
   tmpDir = '/tmp/serve-test-' + Date.now();
   fs.mkdirSync(tmpDir, { recursive: true });
 
-  // Create test PNGs and generate comparison board
+  // test PNG を作成、comparison board を生成
   createTestPng(path.join(tmpDir, 'variant-A.png'));
   createTestPng(path.join(tmpDir, 'variant-B.png'));
   createTestPng(path.join(tmpDir, 'variant-C.png'));
@@ -47,7 +47,7 @@ afterAll(() => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
-// ─── Serve as HTTP module (not subprocess) ────────────────────────
+// ─── HTTP module として serve（subprocess なし）────────────────────────
 
 describe('Serve HTTP endpoints', () => {
   let server: ReturnType<typeof Bun.serve>;
@@ -124,7 +124,7 @@ describe('Serve HTTP endpoints', () => {
     const html = await res.text();
     expect(html).toContain('__UZUSTACK_SERVER_URL');
     expect(html).toContain(baseUrl);
-    expect(html).toContain('Design Exploration');
+    expect(html).toContain('Design 探索');
   });
 
   test('GET /api/progress returns current state', async () => {
@@ -154,7 +154,7 @@ describe('Serve HTTP endpoints', () => {
     expect(data.action).toBe('submitted');
     expect(state).toBe('done');
 
-    // Verify feedback.json was written
+    // feedback.json が書き込まれたか確認
     const written = JSON.parse(fs.readFileSync(path.join(tmpDir, 'feedback.json'), 'utf-8'));
     expect(written.preferred).toBe('A');
     expect(written.ratings.A).toBe(4);
@@ -162,7 +162,7 @@ describe('Serve HTTP endpoints', () => {
 
   test('POST /api/feedback with regenerate sets state and writes feedback-pending.json', async () => {
     state = 'serving';
-    // Clean up any prior pending file
+    // 既存 pending file を掃除
     const pendingPath = path.join(tmpDir, 'feedback-pending.json');
     if (fs.existsSync(pendingPath)) fs.unlinkSync(pendingPath);
 
@@ -185,12 +185,12 @@ describe('Serve HTTP endpoints', () => {
     expect(data.action).toBe('regenerate');
     expect(state).toBe('regenerating');
 
-    // Progress should reflect regenerating state
+    // progress が regenerating state を反映するはず
     const progress = await fetch(`${baseUrl}/api/progress`);
     const pd = await progress.json();
     expect(pd.status).toBe('regenerating');
 
-    // Agent can poll for feedback-pending.json
+    // agent が feedback-pending.json を polling 可能
     expect(fs.existsSync(pendingPath)).toBe(true);
     const pending = JSON.parse(fs.readFileSync(pendingPath, 'utf-8'));
     expect(pending.regenerated).toBe(true);
@@ -240,7 +240,7 @@ describe('Serve HTTP endpoints', () => {
   test('POST /api/reload swaps HTML and resets state to serving', async () => {
     state = 'regenerating';
 
-    // Create a new board HTML
+    // 新 board HTML を作成
     const newBoard = path.join(tmpDir, 'new-board.html');
     fs.writeFileSync(newBoard, '<html><body>New board content</body></html>');
 
@@ -253,7 +253,7 @@ describe('Serve HTTP endpoints', () => {
     expect(data.reloaded).toBe(true);
     expect(state).toBe('serving');
 
-    // Verify the new HTML is served
+    // 新 HTML が serve されているか確認
     const pageRes = await fetch(baseUrl);
     const pageHtml = await pageRes.text();
     expect(pageHtml).toContain('New board content');
@@ -274,7 +274,7 @@ describe('Serve HTTP endpoints', () => {
   });
 });
 
-// ─── Path traversal protection in /api/reload ─────────────────────
+// ─── /api/reload の path traversal protection ─────────────────────
 
 describe('Serve /api/reload — path traversal protection', () => {
   let server: ReturnType<typeof Bun.serve>;
@@ -283,11 +283,11 @@ describe('Serve /api/reload — path traversal protection', () => {
   let allowedDir: string;
 
   beforeAll(() => {
-    // Production-equivalent allowedDir anchored to tmpDir
+    // production と等価な allowedDir、tmpDir に固定
     allowedDir = fs.realpathSync(tmpDir);
     htmlContent = fs.readFileSync(boardHtml, 'utf-8');
 
-    // This server mirrors the production serve() with the path validation fix
+    // 本 server は production serve() を path validation 修正込みで mirror
     server = Bun.serve({
       port: 0,
       fetch(req) {
@@ -306,7 +306,7 @@ describe('Serve /api/reload — path traversal protection', () => {
             if (!body.html || !fs.existsSync(body.html)) {
               return Response.json({ error: `HTML file not found: ${body.html}` }, { status: 400 });
             }
-            // Production path validation — same as design/src/serve.ts
+            // production の path validation — design/src/serve.ts と同じ
             const resolvedReload = fs.realpathSync(path.resolve(body.html));
             if (!resolvedReload.startsWith(allowedDir + path.sep) && resolvedReload !== allowedDir) {
               return Response.json({ error: `Path must be within: ${allowedDir}` }, { status: 403 });
@@ -365,13 +365,13 @@ describe('Serve /api/reload — path traversal protection', () => {
     const data = await res.json();
     expect(data.reloaded).toBe(true);
 
-    // Verify the new content is served
+    // 新 content が serve されているか確認
     const page = await fetch(baseUrl);
     expect(await page.text()).toContain('Safe reload');
   });
 });
 
-// ─── Full lifecycle: regeneration round-trip ──────────────────────
+// ─── full lifecycle: regeneration round-trip ──────────────────────
 
 describe('Full regeneration lifecycle', () => {
   let server: ReturnType<typeof Bun.serve>;
@@ -420,7 +420,7 @@ describe('Full regeneration lifecycle', () => {
   afterAll(() => { server.stop(); });
 
   test('regenerate → reload → submit round-trip', async () => {
-    // Step 1: User clicks regenerate
+    // Step 1: user が regenerate を click
     expect(state).toBe('serving');
     const regen = await fetch(`${baseUrl}/api/feedback`, {
       method: 'POST',
@@ -430,11 +430,11 @@ describe('Full regeneration lifecycle', () => {
     expect((await regen.json()).action).toBe('regenerate');
     expect(state).toBe('regenerating');
 
-    // Step 2: Progress shows regenerating
+    // Step 2: progress が regenerating を返す
     const prog1 = await (await fetch(`${baseUrl}/api/progress`)).json();
     expect(prog1.status).toBe('regenerating');
 
-    // Step 3: Agent generates new variants and reloads
+    // Step 3: agent が新 variant を生成し reload
     const newBoard = path.join(tmpDir, 'round2-board.html');
     fs.writeFileSync(newBoard, '<html><body>Round 2 variants</body></html>');
     const reload = await fetch(`${baseUrl}/api/reload`, {
@@ -445,11 +445,11 @@ describe('Full regeneration lifecycle', () => {
     expect((await reload.json()).reloaded).toBe(true);
     expect(state).toBe('serving');
 
-    // Step 4: Progress shows serving (board would auto-refresh)
+    // Step 4: progress が serving を返す（board が auto-refresh するはず）
     const prog2 = await (await fetch(`${baseUrl}/api/progress`)).json();
     expect(prog2.status).toBe('serving');
 
-    // Step 5: User submits on round 2
+    // Step 5: user が round 2 で submit
     const submit = await fetch(`${baseUrl}/api/feedback`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## やること

[step-44 (#57、`e5019c6`、機械置換のみで merge 済)](https://github.com/uzumaki-inc/uzustack/pull/57) で抜け落ちた **voice 翻案** を後追いで履行。CONTRIBUTING.md voice 規約 v1 (cluster B 確立、L265-322) + step-37 拡張を design/ 全体に適用。

## 翻訳判断軸

### 日本語化対象

- JSDoc / 内部 logic コメント (cluster B 規約 v1 項目 6 を TS source に拡張)
- user-visible 文字列：CLI help / setup prompt / progress / error message / HTML user-visible content

### 維持対象

- TS identifier (関数名 / 型 / 変数名 / Map key / import path)
- telemetry token (`SERVE_STARTED` / `SERVE_FEEDBACK_RECEIVED` 等、step-38 学び「parser 互換重視」)
- sentinel (`PASS` / `FAIL`)
- 外部 SaaS env (`OPENAI_API_KEY`) / OS API (`process.env.HOME`)
- CLI flag (`--brief`, `--output` 等)
- OpenAI prompt content (image generation の input contract、英語前提)
- CLI section 見出し (`Commands:` / `Auth:` / `Setup:`、voice 規約 v1 項目 1)
- `$D` alias (CLI shortcut convention)

## 変更ファイル (19 files)

- `design/src/`: 16 files (auth, brief, check, cli, commands, compare, design-to-code, diff, evolve, gallery, generate, iterate, memory, serve, session, variants)
- `design/test/`: 2 files (gallery.test.ts, serve.test.ts — assertion を新 Japanese 文字列に同期)
- `design/prototype.ts`: 1 file

## 検証

- `bun build --compile design/src/cli.ts` pass (16 modules)
- `bun test design/test/{gallery,serve}.test.ts`: 42/42 pass
- `grep -rn "gstack" design/`: 0 件
- `grep -rn "Design Exploration" design/`: 0 件 (英語残存ゼロ)

## /simplify 結果

- **reuse**: 0
- **quality**: 12 件 (tone consistency、全て fix)
  - `auth.ts:26` 誤訳訂正 (path → check)
  - evolve / generate / iterate / variants の `Generated (...)` / `Threading failed` / `Iterating on session` / `rate limited` / progress 進捗 message 11 箇所
  - `compare.ts` `Design direction ${label}` → `方向 ${label}`、`More like variant ${variant}` → `案 ${variant} に近い`
- **efficiency**: 0

### Skip 判断

- **OpenAI organization verification 未完了 message が 5 ファイルで重複**：upstream gstack 由来の tech debt、`upstream_clone_simplify_discipline.md` 規律で uzustack 単独修正は保留、issue #38 cluster D 観測リスト送り
- **`Commands:` / `Setup:` CLI section 見出し**：voice 規約 v1 項目 1 で英語維持の明示判断
- **`Large` / `Grid` view-toggle**：UI mode label 略語、`data-view="list"` / `data-view="grid"` identifier と整合
- **低価値 narrating コメント削除**：voice 翻案 scope は「翻訳」、削除は別 step

## 関連

- 親 plan：Phase 3 cluster D — browse / design / make-pdf 翻訳 (A/B/C 三本立て、step-42 partial #53 closed)
- 先行：step-44 (#56 closed、PR #57 squash merged、`e5019c6`)
- 後続：step-45 (make-pdf 翻訳、voice 翻案範囲を本 step と揃える)
- 規約：CONTRIBUTING.md voice 規約 v1 (cluster B 確立、step-37 拡張)

Closes #58