### PR TITLE
feat: pair-agent Phase 6 予約スタブ — Phase 3.5 step-51 (C2 cluster 2/4)

### DIFF
--- a/pair-agent/SKILL.md
+++ b/pair-agent/SKILL.md
@@ -2,14 +2,10 @@
 name: pair-agent
 version: 0.0.0
 description: |
-  別 AI agent と browser を pair する skill。setup key を発行して、
-  もう一方の agent が follow できる instruction を出力する。
-  OpenClaw / Hermes / Codex / Cursor 等、HTTP request を送れる任意の agent と
-  連携する。remote agent には独自タブと scoped access が与えられる。
-  「pair agent」「agent を接続」「browser を共有」「remote browser」
-  「他の agent に browser を使わせる」「browser access を渡す」
+  別 AI agent と browser を pair する skill。本実装は Phase 6 で配置予定。
+  「pair agent」「agent を接続」「browser を共有」「remote browser に接続」
   と要求されたときに使用する。
-  Voice triggers (speech-to-text aliases): "agent を pair", "agent を接続", "browser を共有", "remote browser access".
+  Voice triggers (speech-to-text aliases): "agent を pair", "agent を接続", "browser を共有", "remote browser に接続".
 triggers:
   - agent と pair
   - remote agent を接続
@@ -27,9 +23,9 @@ status: phase6-reserved
 本実装される予定です。Phase 3.5 段階では skill 名予約として
 スタブのみ配置されています。
 
-upstream の `_upstream/gstack/pair-agent/SKILL.md.tmpl` に gstack 版の本実装があります
+upstream の `_upstream/gstack/pair-agent/` 配下に gstack 版の本実装があります
 （参照のみ可能、uzustack の setup / skill / bin から一切呼び出されません）。
-本 skill は別 agent と browser を share する setup key 発行が core 機能で、
+別 agent と browser を共有する setup key 発行が core 機能で、
 browse 機構 core 依存のため Phase 6 で browse 独自実装と同時設計します。
 
 ## 関連

--- a/pair-agent/SKILL.md
+++ b/pair-agent/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: pair-agent
+version: 0.0.0
+description: |
+  別 AI agent と browser を pair する skill。setup key を発行して、
+  もう一方の agent が follow できる instruction を出力する。
+  OpenClaw / Hermes / Codex / Cursor 等、HTTP request を送れる任意の agent と
+  連携する。remote agent には独自タブと scoped access が与えられる。
+  「pair agent」「agent を接続」「browser を共有」「remote browser」
+  「他の agent に browser を使わせる」「browser access を渡す」
+  と要求されたときに使用する。
+  Voice triggers (speech-to-text aliases): "agent を pair", "agent を接続", "browser を共有", "remote browser access".
+triggers:
+  - agent と pair
+  - remote agent を接続
+  - browser を共有
+status: phase6-reserved
+---
+<!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
+<!-- Regenerate: bun run gen:skill-docs -->
+
+
+
+# pair-agent — Phase 6 で対応予定
+
+このスキルは uzustack の Phase 6（browse / extension 独自実装フェーズ）で
+本実装される予定です。Phase 3.5 段階では skill 名予約として
+スタブのみ配置されています。
+
+upstream の `_upstream/gstack/pair-agent/SKILL.md.tmpl` に gstack 版の本実装があります
+（参照のみ可能、uzustack の setup / skill / bin から一切呼び出されません）。
+本 skill は別 agent と browser を share する setup key 発行が core 機能で、
+browse 機構 core 依存のため Phase 6 で browse 独自実装と同時設計します。
+
+## 関連
+
+- 上流参照：`_upstream/gstack/pair-agent/`（取り込まない、subtree 温存）

--- a/pair-agent/SKILL.md.tmpl
+++ b/pair-agent/SKILL.md.tmpl
@@ -2,18 +2,14 @@
 name: pair-agent
 version: 0.0.0
 description: |
-  別 AI agent と browser を pair する skill。setup key を発行して、
-  もう一方の agent が follow できる instruction を出力する。
-  OpenClaw / Hermes / Codex / Cursor 等、HTTP request を送れる任意の agent と
-  連携する。remote agent には独自タブと scoped access が与えられる。
-  「pair agent」「agent を接続」「browser を共有」「remote browser」
-  「他の agent に browser を使わせる」「browser access を渡す」
+  別 AI agent と browser を pair する skill。本実装は Phase 6 で配置予定。
+  「pair agent」「agent を接続」「browser を共有」「remote browser に接続」
   と要求されたときに使用する。
 voice-triggers:
   - "agent を pair"
   - "agent を接続"
   - "browser を共有"
-  - "remote browser access"
+  - "remote browser に接続"
 triggers:
   - agent と pair
   - remote agent を接続
@@ -29,9 +25,9 @@ status: phase6-reserved
 本実装される予定です。Phase 3.5 段階では skill 名予約として
 スタブのみ配置されています。
 
-upstream の `_upstream/gstack/pair-agent/SKILL.md.tmpl` に gstack 版の本実装があります
+upstream の `_upstream/gstack/pair-agent/` 配下に gstack 版の本実装があります
 （参照のみ可能、uzustack の setup / skill / bin から一切呼び出されません）。
-本 skill は別 agent と browser を share する setup key 発行が core 機能で、
+別 agent と browser を共有する setup key 発行が core 機能で、
 browse 機構 core 依存のため Phase 6 で browse 独自実装と同時設計します。
 
 ## 関連

--- a/pair-agent/SKILL.md.tmpl
+++ b/pair-agent/SKILL.md.tmpl
@@ -1,0 +1,39 @@
+---
+name: pair-agent
+version: 0.0.0
+description: |
+  別 AI agent と browser を pair する skill。setup key を発行して、
+  もう一方の agent が follow できる instruction を出力する。
+  OpenClaw / Hermes / Codex / Cursor 等、HTTP request を送れる任意の agent と
+  連携する。remote agent には独自タブと scoped access が与えられる。
+  「pair agent」「agent を接続」「browser を共有」「remote browser」
+  「他の agent に browser を使わせる」「browser access を渡す」
+  と要求されたときに使用する。
+voice-triggers:
+  - "agent を pair"
+  - "agent を接続"
+  - "browser を共有"
+  - "remote browser access"
+triggers:
+  - agent と pair
+  - remote agent を接続
+  - browser を共有
+status: phase6-reserved
+---
+
+{{PREAMBLE}}
+
+# pair-agent — Phase 6 で対応予定
+
+このスキルは uzustack の Phase 6（browse / extension 独自実装フェーズ）で
+本実装される予定です。Phase 3.5 段階では skill 名予約として
+スタブのみ配置されています。
+
+upstream の `_upstream/gstack/pair-agent/SKILL.md.tmpl` に gstack 版の本実装があります
+（参照のみ可能、uzustack の setup / skill / bin から一切呼び出されません）。
+本 skill は別 agent と browser を share する setup key 発行が core 機能で、
+browse 機構 core 依存のため Phase 6 で browse 独自実装と同時設計します。
+
+## 関連
+
+- 上流参照：`_upstream/gstack/pair-agent/`（取り込まない、subtree 温存）


### PR DESCRIPTION
## Summary

Phase 3.5 step-51 = C2 cluster（infra/wrapper 系）2 件目。pair-agent は別 agent と browser を share する setup key 発行が core 機能で、browse 機構 core 依存のため **(b) スタブ配置** として Phase 6 予約。step-46 cluster D C 8 件スタブパターン（PR #61）と同型。

Closes #69

## 変更点

- `pair-agent/SKILL.md.tmpl` 新規配置（Phase 6 予約スタブ）
- frontmatter は voice 規約 v1 + v2 + 訳語表に従い日本語化（name / description / voice-triggers / triggers / status: phase6-reserved）
- 本文は「Phase 6 で対応予定」+ 上流参照リンクのみ（connect-chrome / open-uzustack-browser と同型）
- `bun run gen:skill-docs` で `pair-agent/SKILL.md` 生成（38 行 / ~290 tokens）

## スコープ外

- 上流 SKILL.md.tmpl 全文翻訳（実装は Phase 6、本 step では skill 名予約のみ）
- browse 機構との接続（Phase 6 で browse 独自実装と同時設計）

## C2 cluster 進捗

- step-50 claude（C2 1/4、a 既存翻訳）— PR #68 merged
- **step-51 pair-agent（C2 2/4、b スタブ配置）— 本 PR**
- step-52 gstack-upgrade（C2 3/4、c migrations 付属）— TODO
- step-53 setup-gbrain（C2 4/4、a 既存翻訳）— TODO

## Test plan

- [x] `bun run gen:skill-docs` で `pair-agent/SKILL.md` が生成される
- [x] frontmatter の name / description / triggers が日本語化されている
- [x] status: phase6-reserved が設定されている
- [x] connect-chrome / open-uzustack-browser と同型のスタブ構造
- [x] /simplify を 2 周（後続 review）