### PR TITLE
feat: uzustack-upgrade 翻訳 — Phase 3.5 step-52 (C2 cluster 3/4)

### DIFF
--- a/uzustack-upgrade/SKILL.md
+++ b/uzustack-upgrade/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: uzustack-upgrade
+type: translated
 version: 1.1.0
 description: |
   uzustack を最新版に upgrade する。global vs vendored install を判別し、

--- a/uzustack-upgrade/SKILL.md
+++ b/uzustack-upgrade/SKILL.md
@@ -1,0 +1,276 @@
+---
+name: uzustack-upgrade
+version: 1.1.0
+description: |
+  uzustack を最新版に upgrade する。global vs vendored install を判別し、
+  upgrade を実行して新機能を表示する。
+  「uzustack を upgrade」「uzustack を update」「最新版を取得」
+  と要求されたときに使用する。
+  Voice triggers (speech-to-text aliases): "uzustack を upgrade", "uzustack を update", "uzustack アップグレード".
+triggers:
+  - upgrade uzustack
+  - update uzustack version
+  - get latest uzustack
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - AskUserQuestion
+---
+<!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
+<!-- Regenerate: bun run gen:skill-docs -->
+
+# /uzustack-upgrade
+
+uzustack を最新版に upgrade して、新機能を表示する。
+
+## Inline upgrade flow
+
+本 section は、すべての skill preamble が `UPGRADE_AVAILABLE` を検知したときに参照する。
+
+### Step 1: ユーザーに確認（または auto-upgrade）
+
+まず auto-upgrade が有効か確認する：
+```bash
+_AUTO=""
+[ "${UZUSTACK_AUTO_UPGRADE:-}" = "1" ] && _AUTO="true"
+[ -z "$_AUTO" ] && _AUTO=$(~/.claude/skills/uzustack/bin/uzustack-config get auto_upgrade 2>/dev/null || true)
+echo "AUTO_UPGRADE=$_AUTO"
+```
+
+**`AUTO_UPGRADE=true` または `AUTO_UPGRADE=1` の場合**：AskUserQuestion を skip。「Auto-upgrading uzustack v{old} → v{new}...」をログに出して Step 2 に直接進む。auto-upgrade 中に `./setup` が失敗した場合、backup（`.bak` ディレクトリ）から復元してユーザーに警告する：「Auto-upgrade failed — restored previous version. Run `/uzustack-upgrade` manually to retry.」
+
+**それ以外の場合**、AskUserQuestion を使う：
+- 質問：「uzustack **v{new}** が利用可能です（現在 v{old}）。今 upgrade しますか？」
+- 選択肢：["Yes, upgrade now", "Always keep me up to date", "Not now", "Never ask again"]
+
+**「Yes, upgrade now」の場合**：Step 2 に進む。
+
+**「Always keep me up to date」の場合**：
+```bash
+~/.claude/skills/uzustack/bin/uzustack-config set auto_upgrade true
+```
+ユーザーに伝える：「Auto-upgrade enabled. Future updates will install automatically.」その後 Step 2 に進む。
+
+**「Not now」の場合**：snooze state を escalating backoff（初回 = 24h、2 回目 = 48h、3 回目以降 = 1 週間）で書き出し、現在の skill を継続する。upgrade のことは二度と言わない。
+```bash
+_SNOOZE_FILE="$HOME/.uzustack/update-snoozed"
+_REMOTE_VER="{new}"
+_CUR_LEVEL=0
+if [ -f "$_SNOOZE_FILE" ]; then
+  _SNOOZED_VER=$(awk '{print $1}' "$_SNOOZE_FILE")
+  if [ "$_SNOOZED_VER" = "$_REMOTE_VER" ]; then
+    _CUR_LEVEL=$(awk '{print $2}' "$_SNOOZE_FILE")
+    case "$_CUR_LEVEL" in *[!0-9]*) _CUR_LEVEL=0 ;; esac
+  fi
+fi
+_NEW_LEVEL=$((_CUR_LEVEL + 1))
+[ "$_NEW_LEVEL" -gt 3 ] && _NEW_LEVEL=3
+echo "$_REMOTE_VER $_NEW_LEVEL $(date +%s)" > "$_SNOOZE_FILE"
+```
+注：`{new}` は `UPGRADE_AVAILABLE` output の remote 版 — update check 結果から代入する。
+
+ユーザーに snooze duration を伝える：「Next reminder in 24h」（または 48h / 1 週間、level 次第）。Tip：「`~/.uzustack/config.yaml` で `auto_upgrade: true` を設定すると自動 upgrade される。」
+
+**「Never ask again」の場合**：
+```bash
+~/.claude/skills/uzustack/bin/uzustack-config set update_check false
+```
+ユーザーに伝える：「Update checks disabled. Run `~/.claude/skills/uzustack/bin/uzustack-config set update_check true` to re-enable.」
+現在の skill を継続する。
+
+### Step 2: install type を判別
+
+```bash
+if [ -d "$HOME/.claude/skills/uzustack/.git" ]; then
+  INSTALL_TYPE="global-git"
+  INSTALL_DIR="$HOME/.claude/skills/uzustack"
+elif [ -d "$HOME/.uzustack/repos/uzustack/.git" ]; then
+  INSTALL_TYPE="global-git"
+  INSTALL_DIR="$HOME/.uzustack/repos/uzustack"
+elif [ -d ".claude/skills/uzustack/.git" ]; then
+  INSTALL_TYPE="local-git"
+  INSTALL_DIR=".claude/skills/uzustack"
+elif [ -d ".agents/skills/uzustack/.git" ]; then
+  INSTALL_TYPE="local-git"
+  INSTALL_DIR=".agents/skills/uzustack"
+elif [ -d ".claude/skills/uzustack" ]; then
+  INSTALL_TYPE="vendored"
+  INSTALL_DIR=".claude/skills/uzustack"
+elif [ -d "$HOME/.claude/skills/uzustack" ]; then
+  INSTALL_TYPE="vendored-global"
+  INSTALL_DIR="$HOME/.claude/skills/uzustack"
+else
+  echo "ERROR: uzustack not found"
+  exit 1
+fi
+echo "Install type: $INSTALL_TYPE at $INSTALL_DIR"
+```
+
+判別された install type と directory path は、以降の Step すべてで使用する。
+
+### Step 3: 旧 version を保存
+
+Step 2 output の install directory を使う：
+
+```bash
+OLD_VERSION=$(cat "$INSTALL_DIR/VERSION" 2>/dev/null || echo "unknown")
+```
+
+### Step 4: Upgrade
+
+Step 2 で判別した install type と directory を使う：
+
+**git installs**（global-git, local-git）：
+```bash
+cd "$INSTALL_DIR"
+STASH_OUTPUT=$(git stash 2>&1)
+git fetch origin
+git reset --hard origin/main
+./setup
+```
+`$STASH_OUTPUT` に "Saved working directory" が含まれる場合、ユーザーに警告する：「Note: local changes were stashed. Run `git stash pop` in the skill directory to restore them.」
+
+**vendored installs**（vendored, vendored-global）：
+```bash
+PARENT=$(dirname "$INSTALL_DIR")
+TMP_DIR=$(mktemp -d)
+git clone --depth 1 https://github.com/uzumaki-inc/uzustack.git "$TMP_DIR/uzustack"
+mv "$INSTALL_DIR" "$INSTALL_DIR.bak"
+mv "$TMP_DIR/uzustack" "$INSTALL_DIR"
+cd "$INSTALL_DIR" && ./setup
+rm -rf "$INSTALL_DIR.bak" "$TMP_DIR"
+```
+
+### Step 4.5: local vendored copy を扱う
+
+Step 2 の install directory を使う。local vendored copy があるか、team mode が有効かを確認する：
+
+```bash
+_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+LOCAL_UZUSTACK=""
+if [ -n "$_ROOT" ] && [ -d "$_ROOT/.claude/skills/uzustack" ]; then
+  _RESOLVED_LOCAL=$(cd "$_ROOT/.claude/skills/uzustack" && pwd -P)
+  _RESOLVED_PRIMARY=$(cd "$INSTALL_DIR" && pwd -P)
+  if [ "$_RESOLVED_LOCAL" != "$_RESOLVED_PRIMARY" ]; then
+    LOCAL_UZUSTACK="$_ROOT/.claude/skills/uzustack"
+  fi
+fi
+_TEAM_MODE=$(~/.claude/skills/uzustack/bin/uzustack-config get team_mode 2>/dev/null || echo "false")
+echo "LOCAL_UZUSTACK=$LOCAL_UZUSTACK"
+echo "TEAM_MODE=$_TEAM_MODE"
+```
+
+**`LOCAL_UZUSTACK` が non-empty かつ `TEAM_MODE` が `true` の場合**：vendored copy を削除する。team mode は global install を single source of truth とする。
+
+```bash
+cd "$_ROOT"
+git rm -r --cached .claude/skills/uzustack/ 2>/dev/null || true
+if ! grep -qF '.claude/skills/uzustack/' .gitignore 2>/dev/null; then
+  echo '.claude/skills/uzustack/' >> .gitignore
+fi
+rm -rf "$LOCAL_UZUSTACK"
+```
+ユーザーに伝える：「Removed vendored copy at `$LOCAL_UZUSTACK` (team mode active — global install is the source of truth). Commit the `.gitignore` change when ready.」
+
+**`LOCAL_UZUSTACK` が non-empty かつ `TEAM_MODE` が `true` でない場合**：upgrade 直後の primary install から copy して update する（README vendored install と同じ approach）：
+```bash
+mv "$LOCAL_UZUSTACK" "$LOCAL_UZUSTACK.bak"
+cp -Rf "$INSTALL_DIR" "$LOCAL_UZUSTACK"
+rm -rf "$LOCAL_UZUSTACK/.git"
+cd "$LOCAL_UZUSTACK" && ./setup
+rm -rf "$LOCAL_UZUSTACK.bak"
+```
+ユーザーに伝える：「Also updated vendored copy at `$LOCAL_UZUSTACK` — commit `.claude/skills/uzustack/` when you're ready.」
+
+`./setup` が失敗した場合、backup から復元してユーザーに警告する：
+```bash
+rm -rf "$LOCAL_UZUSTACK"
+mv "$LOCAL_UZUSTACK.bak" "$LOCAL_UZUSTACK"
+```
+ユーザーに伝える：「Sync failed — restored previous version at `$LOCAL_UZUSTACK`. Run `/uzustack-upgrade` manually to retry.」
+
+### Step 4.75: version migration を実行
+
+`./setup` 完了後、旧版と新版の間にある migration script を実行する。migration は `./setup` だけでは扱えない state fix（stale config / orphaned files / directory structure 変更）を担う。
+
+```bash
+MIGRATIONS_DIR="$INSTALL_DIR/uzustack-upgrade/migrations"
+if [ -d "$MIGRATIONS_DIR" ]; then
+  for migration in $(find "$MIGRATIONS_DIR" -maxdepth 1 -name 'v*.sh' -type f 2>/dev/null | sort -V); do
+    # ファイル名から version を抽出: v0.15.2.0.sh → 0.15.2.0
+    m_ver="$(basename "$migration" .sh | sed 's/^v//')"
+    # この migration version が旧 version より新しい場合に実行
+    # （同セグメント数の dotted version は単純な string compare で OK）
+    if [ "$OLD_VERSION" != "unknown" ] && [ "$(printf '%s\n%s' "$OLD_VERSION" "$m_ver" | sort -V | head -1)" = "$OLD_VERSION" ] && [ "$OLD_VERSION" != "$m_ver" ]; then
+      echo "Running migration $m_ver..."
+      bash "$migration" || echo "  Warning: migration $m_ver had errors (non-fatal)"
+    fi
+  done
+fi
+```
+
+migration は `uzustack-upgrade/migrations/` 配下の idempotent な bash script。各 file 名は `v{VERSION}.sh`、旧版から upgrade するときのみ実行される。新規 migration の追加方法は CONTRIBUTING.md を参照。
+
+### Step 5: marker を書く + cache を消す
+
+```bash
+mkdir -p ~/.uzustack
+echo "$OLD_VERSION" > ~/.uzustack/just-upgraded-from
+rm -f ~/.uzustack/last-update-check
+rm -f ~/.uzustack/update-snoozed
+```
+
+### Step 6: What's New を表示
+
+`$INSTALL_DIR/CHANGELOG.md` を読む。旧版と新版の間にあるすべての version entry を見つける。テーマ別に 5-7 bullets で要約する。詰め込まない — user-facing な変更にフォーカスする。internal refactor は重要なものでない限り skip。
+
+Format：
+```
+uzustack v{new} — upgraded from v{old}!
+
+What's new:
+- [bullet 1]
+- [bullet 2]
+- ...
+
+Happy shipping!
+```
+
+### Step 7: 継続
+
+What's New を表示した後、ユーザーが元々呼び出していた skill を継続する。upgrade は完了 — それ以上のアクション不要。
+
+---
+
+## Standalone usage
+
+`/uzustack-upgrade` を直接呼び出した場合（preamble 経由でない場合）：
+
+1. fresh な update check を強制（cache を bypass）：
+```bash
+~/.claude/skills/uzustack/bin/uzustack-update-check --force 2>/dev/null || \
+.claude/skills/uzustack/bin/uzustack-update-check --force 2>/dev/null || true
+```
+output から upgrade が利用可能か判定する。
+
+2. `UPGRADE_AVAILABLE <old> <new>` の場合：上記 Steps 2-6 を follow する。
+
+3. output なし（primary が最新）の場合：stale な local vendored copy を check する。
+
+上記 Step 2 の bash block を実行して primary install type と directory（`INSTALL_TYPE` と `INSTALL_DIR`）を判別する。次に上記 Step 4.5 の判別 bash block を実行して local vendored copy（`LOCAL_UZUSTACK`）と team mode 状態（`TEAM_MODE`）を check する。
+
+**`LOCAL_UZUSTACK` が empty の場合**（local vendored copy なし）：ユーザーに「You're already on the latest version (v{version}).」と伝える。
+
+**`LOCAL_UZUSTACK` が non-empty かつ `TEAM_MODE` が `true` の場合**：上記 Step 4.5 の team-mode 削除 bash block を使って vendored copy を削除する。ユーザーに伝える：「Global v{version} is up to date. Removed stale vendored copy (team mode active). Commit the `.gitignore` change when ready.」
+
+**`LOCAL_UZUSTACK` が non-empty かつ `TEAM_MODE` が `true` でない場合**、version を比較する：
+```bash
+PRIMARY_VER=$(cat "$INSTALL_DIR/VERSION" 2>/dev/null || echo "unknown")
+LOCAL_VER=$(cat "$LOCAL_UZUSTACK/VERSION" 2>/dev/null || echo "unknown")
+echo "PRIMARY=$PRIMARY_VER LOCAL=$LOCAL_VER"
+```
+
+**version が異なる場合**：上記 Step 4.5 の sync bash block を使って primary から local copy を update する。ユーザーに伝える：「Global v{PRIMARY_VER} is up to date. Updated local vendored copy from v{LOCAL_VER} → v{PRIMARY_VER}. Commit `.claude/skills/uzustack/` when you're ready.」
+
+**version が一致する場合**：ユーザーに「You're on the latest version (v{PRIMARY_VER}). Global and local vendored copy are both up to date.」と伝える。

--- a/uzustack-upgrade/SKILL.md.tmpl
+++ b/uzustack-upgrade/SKILL.md.tmpl
@@ -1,5 +1,6 @@
 ---
 name: uzustack-upgrade
+type: translated
 version: 1.1.0
 description: |
   uzustack を最新版に upgrade する。global vs vendored install を判別し、

--- a/uzustack-upgrade/SKILL.md.tmpl
+++ b/uzustack-upgrade/SKILL.md.tmpl
@@ -1,0 +1,277 @@
+---
+name: uzustack-upgrade
+version: 1.1.0
+description: |
+  uzustack を最新版に upgrade する。global vs vendored install を判別し、
+  upgrade を実行して新機能を表示する。
+  「uzustack を upgrade」「uzustack を update」「最新版を取得」
+  と要求されたときに使用する。
+voice-triggers:
+  - "uzustack を upgrade"
+  - "uzustack を update"
+  - "uzustack アップグレード"
+triggers:
+  - upgrade uzustack
+  - update uzustack version
+  - get latest uzustack
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - AskUserQuestion
+---
+
+# /uzustack-upgrade
+
+uzustack を最新版に upgrade して、新機能を表示する。
+
+## Inline upgrade flow
+
+本 section は、すべての skill preamble が `UPGRADE_AVAILABLE` を検知したときに参照する。
+
+### Step 1: ユーザーに確認（または auto-upgrade）
+
+まず auto-upgrade が有効か確認する：
+```bash
+_AUTO=""
+[ "${UZUSTACK_AUTO_UPGRADE:-}" = "1" ] && _AUTO="true"
+[ -z "$_AUTO" ] && _AUTO=$(~/.claude/skills/uzustack/bin/uzustack-config get auto_upgrade 2>/dev/null || true)
+echo "AUTO_UPGRADE=$_AUTO"
+```
+
+**`AUTO_UPGRADE=true` または `AUTO_UPGRADE=1` の場合**：AskUserQuestion を skip。「Auto-upgrading uzustack v{old} → v{new}...」をログに出して Step 2 に直接進む。auto-upgrade 中に `./setup` が失敗した場合、backup（`.bak` ディレクトリ）から復元してユーザーに警告する：「Auto-upgrade failed — restored previous version. Run `/uzustack-upgrade` manually to retry.」
+
+**それ以外の場合**、AskUserQuestion を使う：
+- 質問：「uzustack **v{new}** が利用可能です（現在 v{old}）。今 upgrade しますか？」
+- 選択肢：["Yes, upgrade now", "Always keep me up to date", "Not now", "Never ask again"]
+
+**「Yes, upgrade now」の場合**：Step 2 に進む。
+
+**「Always keep me up to date」の場合**：
+```bash
+~/.claude/skills/uzustack/bin/uzustack-config set auto_upgrade true
+```
+ユーザーに伝える：「Auto-upgrade enabled. Future updates will install automatically.」その後 Step 2 に進む。
+
+**「Not now」の場合**：snooze state を escalating backoff（初回 = 24h、2 回目 = 48h、3 回目以降 = 1 週間）で書き出し、現在の skill を継続する。upgrade のことは二度と言わない。
+```bash
+_SNOOZE_FILE="$HOME/.uzustack/update-snoozed"
+_REMOTE_VER="{new}"
+_CUR_LEVEL=0
+if [ -f "$_SNOOZE_FILE" ]; then
+  _SNOOZED_VER=$(awk '{print $1}' "$_SNOOZE_FILE")
+  if [ "$_SNOOZED_VER" = "$_REMOTE_VER" ]; then
+    _CUR_LEVEL=$(awk '{print $2}' "$_SNOOZE_FILE")
+    case "$_CUR_LEVEL" in *[!0-9]*) _CUR_LEVEL=0 ;; esac
+  fi
+fi
+_NEW_LEVEL=$((_CUR_LEVEL + 1))
+[ "$_NEW_LEVEL" -gt 3 ] && _NEW_LEVEL=3
+echo "$_REMOTE_VER $_NEW_LEVEL $(date +%s)" > "$_SNOOZE_FILE"
+```
+注：`{new}` は `UPGRADE_AVAILABLE` output の remote 版 — update check 結果から代入する。
+
+ユーザーに snooze duration を伝える：「Next reminder in 24h」（または 48h / 1 週間、level 次第）。Tip：「`~/.uzustack/config.yaml` で `auto_upgrade: true` を設定すると自動 upgrade される。」
+
+**「Never ask again」の場合**：
+```bash
+~/.claude/skills/uzustack/bin/uzustack-config set update_check false
+```
+ユーザーに伝える：「Update checks disabled. Run `~/.claude/skills/uzustack/bin/uzustack-config set update_check true` to re-enable.」
+現在の skill を継続する。
+
+### Step 2: install type を判別
+
+```bash
+if [ -d "$HOME/.claude/skills/uzustack/.git" ]; then
+  INSTALL_TYPE="global-git"
+  INSTALL_DIR="$HOME/.claude/skills/uzustack"
+elif [ -d "$HOME/.uzustack/repos/uzustack/.git" ]; then
+  INSTALL_TYPE="global-git"
+  INSTALL_DIR="$HOME/.uzustack/repos/uzustack"
+elif [ -d ".claude/skills/uzustack/.git" ]; then
+  INSTALL_TYPE="local-git"
+  INSTALL_DIR=".claude/skills/uzustack"
+elif [ -d ".agents/skills/uzustack/.git" ]; then
+  INSTALL_TYPE="local-git"
+  INSTALL_DIR=".agents/skills/uzustack"
+elif [ -d ".claude/skills/uzustack" ]; then
+  INSTALL_TYPE="vendored"
+  INSTALL_DIR=".claude/skills/uzustack"
+elif [ -d "$HOME/.claude/skills/uzustack" ]; then
+  INSTALL_TYPE="vendored-global"
+  INSTALL_DIR="$HOME/.claude/skills/uzustack"
+else
+  echo "ERROR: uzustack not found"
+  exit 1
+fi
+echo "Install type: $INSTALL_TYPE at $INSTALL_DIR"
+```
+
+判別された install type と directory path は、以降の Step すべてで使用する。
+
+### Step 3: 旧 version を保存
+
+Step 2 output の install directory を使う：
+
+```bash
+OLD_VERSION=$(cat "$INSTALL_DIR/VERSION" 2>/dev/null || echo "unknown")
+```
+
+### Step 4: Upgrade
+
+Step 2 で判別した install type と directory を使う：
+
+**git installs**（global-git, local-git）：
+```bash
+cd "$INSTALL_DIR"
+STASH_OUTPUT=$(git stash 2>&1)
+git fetch origin
+git reset --hard origin/main
+./setup
+```
+`$STASH_OUTPUT` に "Saved working directory" が含まれる場合、ユーザーに警告する：「Note: local changes were stashed. Run `git stash pop` in the skill directory to restore them.」
+
+**vendored installs**（vendored, vendored-global）：
+```bash
+PARENT=$(dirname "$INSTALL_DIR")
+TMP_DIR=$(mktemp -d)
+git clone --depth 1 https://github.com/uzumaki-inc/uzustack.git "$TMP_DIR/uzustack"
+mv "$INSTALL_DIR" "$INSTALL_DIR.bak"
+mv "$TMP_DIR/uzustack" "$INSTALL_DIR"
+cd "$INSTALL_DIR" && ./setup
+rm -rf "$INSTALL_DIR.bak" "$TMP_DIR"
+```
+
+### Step 4.5: local vendored copy を扱う
+
+Step 2 の install directory を使う。local vendored copy があるか、team mode が有効かを確認する：
+
+```bash
+_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+LOCAL_UZUSTACK=""
+if [ -n "$_ROOT" ] && [ -d "$_ROOT/.claude/skills/uzustack" ]; then
+  _RESOLVED_LOCAL=$(cd "$_ROOT/.claude/skills/uzustack" && pwd -P)
+  _RESOLVED_PRIMARY=$(cd "$INSTALL_DIR" && pwd -P)
+  if [ "$_RESOLVED_LOCAL" != "$_RESOLVED_PRIMARY" ]; then
+    LOCAL_UZUSTACK="$_ROOT/.claude/skills/uzustack"
+  fi
+fi
+_TEAM_MODE=$(~/.claude/skills/uzustack/bin/uzustack-config get team_mode 2>/dev/null || echo "false")
+echo "LOCAL_UZUSTACK=$LOCAL_UZUSTACK"
+echo "TEAM_MODE=$_TEAM_MODE"
+```
+
+**`LOCAL_UZUSTACK` が non-empty かつ `TEAM_MODE` が `true` の場合**：vendored copy を削除する。team mode は global install を single source of truth とする。
+
+```bash
+cd "$_ROOT"
+git rm -r --cached .claude/skills/uzustack/ 2>/dev/null || true
+if ! grep -qF '.claude/skills/uzustack/' .gitignore 2>/dev/null; then
+  echo '.claude/skills/uzustack/' >> .gitignore
+fi
+rm -rf "$LOCAL_UZUSTACK"
+```
+ユーザーに伝える：「Removed vendored copy at `$LOCAL_UZUSTACK` (team mode active — global install is the source of truth). Commit the `.gitignore` change when ready.」
+
+**`LOCAL_UZUSTACK` が non-empty かつ `TEAM_MODE` が `true` でない場合**：upgrade 直後の primary install から copy して update する（README vendored install と同じ approach）：
+```bash
+mv "$LOCAL_UZUSTACK" "$LOCAL_UZUSTACK.bak"
+cp -Rf "$INSTALL_DIR" "$LOCAL_UZUSTACK"
+rm -rf "$LOCAL_UZUSTACK/.git"
+cd "$LOCAL_UZUSTACK" && ./setup
+rm -rf "$LOCAL_UZUSTACK.bak"
+```
+ユーザーに伝える：「Also updated vendored copy at `$LOCAL_UZUSTACK` — commit `.claude/skills/uzustack/` when you're ready.」
+
+`./setup` が失敗した場合、backup から復元してユーザーに警告する：
+```bash
+rm -rf "$LOCAL_UZUSTACK"
+mv "$LOCAL_UZUSTACK.bak" "$LOCAL_UZUSTACK"
+```
+ユーザーに伝える：「Sync failed — restored previous version at `$LOCAL_UZUSTACK`. Run `/uzustack-upgrade` manually to retry.」
+
+### Step 4.75: version migration を実行
+
+`./setup` 完了後、旧版と新版の間にある migration script を実行する。migration は `./setup` だけでは扱えない state fix（stale config / orphaned files / directory structure 変更）を担う。
+
+```bash
+MIGRATIONS_DIR="$INSTALL_DIR/uzustack-upgrade/migrations"
+if [ -d "$MIGRATIONS_DIR" ]; then
+  for migration in $(find "$MIGRATIONS_DIR" -maxdepth 1 -name 'v*.sh' -type f 2>/dev/null | sort -V); do
+    # ファイル名から version を抽出: v0.15.2.0.sh → 0.15.2.0
+    m_ver="$(basename "$migration" .sh | sed 's/^v//')"
+    # この migration version が旧 version より新しい場合に実行
+    # （同セグメント数の dotted version は単純な string compare で OK）
+    if [ "$OLD_VERSION" != "unknown" ] && [ "$(printf '%s\n%s' "$OLD_VERSION" "$m_ver" | sort -V | head -1)" = "$OLD_VERSION" ] && [ "$OLD_VERSION" != "$m_ver" ]; then
+      echo "Running migration $m_ver..."
+      bash "$migration" || echo "  Warning: migration $m_ver had errors (non-fatal)"
+    fi
+  done
+fi
+```
+
+migration は `uzustack-upgrade/migrations/` 配下の idempotent な bash script。各 file 名は `v{VERSION}.sh`、旧版から upgrade するときのみ実行される。新規 migration の追加方法は CONTRIBUTING.md を参照。
+
+### Step 5: marker を書く + cache を消す
+
+```bash
+mkdir -p ~/.uzustack
+echo "$OLD_VERSION" > ~/.uzustack/just-upgraded-from
+rm -f ~/.uzustack/last-update-check
+rm -f ~/.uzustack/update-snoozed
+```
+
+### Step 6: What's New を表示
+
+`$INSTALL_DIR/CHANGELOG.md` を読む。旧版と新版の間にあるすべての version entry を見つける。テーマ別に 5-7 bullets で要約する。詰め込まない — user-facing な変更にフォーカスする。internal refactor は重要なものでない限り skip。
+
+Format：
+```
+uzustack v{new} — upgraded from v{old}!
+
+What's new:
+- [bullet 1]
+- [bullet 2]
+- ...
+
+Happy shipping!
+```
+
+### Step 7: 継続
+
+What's New を表示した後、ユーザーが元々呼び出していた skill を継続する。upgrade は完了 — それ以上のアクション不要。
+
+---
+
+## Standalone usage
+
+`/uzustack-upgrade` を直接呼び出した場合（preamble 経由でない場合）：
+
+1. fresh な update check を強制（cache を bypass）：
+```bash
+~/.claude/skills/uzustack/bin/uzustack-update-check --force 2>/dev/null || \
+.claude/skills/uzustack/bin/uzustack-update-check --force 2>/dev/null || true
+```
+output から upgrade が利用可能か判定する。
+
+2. `UPGRADE_AVAILABLE <old> <new>` の場合：上記 Steps 2-6 を follow する。
+
+3. output なし（primary が最新）の場合：stale な local vendored copy を check する。
+
+上記 Step 2 の bash block を実行して primary install type と directory（`INSTALL_TYPE` と `INSTALL_DIR`）を判別する。次に上記 Step 4.5 の判別 bash block を実行して local vendored copy（`LOCAL_UZUSTACK`）と team mode 状態（`TEAM_MODE`）を check する。
+
+**`LOCAL_UZUSTACK` が empty の場合**（local vendored copy なし）：ユーザーに「You're already on the latest version (v{version}).」と伝える。
+
+**`LOCAL_UZUSTACK` が non-empty かつ `TEAM_MODE` が `true` の場合**：上記 Step 4.5 の team-mode 削除 bash block を使って vendored copy を削除する。ユーザーに伝える：「Global v{version} is up to date. Removed stale vendored copy (team mode active). Commit the `.gitignore` change when ready.」
+
+**`LOCAL_UZUSTACK` が non-empty かつ `TEAM_MODE` が `true` でない場合**、version を比較する：
+```bash
+PRIMARY_VER=$(cat "$INSTALL_DIR/VERSION" 2>/dev/null || echo "unknown")
+LOCAL_VER=$(cat "$LOCAL_UZUSTACK/VERSION" 2>/dev/null || echo "unknown")
+echo "PRIMARY=$PRIMARY_VER LOCAL=$LOCAL_VER"
+```
+
+**version が異なる場合**：上記 Step 4.5 の sync bash block を使って primary から local copy を update する。ユーザーに伝える：「Global v{PRIMARY_VER} is up to date. Updated local vendored copy from v{LOCAL_VER} → v{PRIMARY_VER}. Commit `.claude/skills/uzustack/` when you're ready.」
+
+**version が一致する場合**：ユーザーに「You're on the latest version (v{PRIMARY_VER}). Global and local vendored copy are both up to date.」と伝える。

--- a/uzustack-upgrade/migrations/v0.15.2.0.sh
+++ b/uzustack-upgrade/migrations/v0.15.2.0.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Migration: v0.15.2.0 — unprefixed discovery 用に skill ディレクトリ構造を修復
+#
+# 注：本 migration は upstream gstack の v0.15.2.0 path 由来。uzustack では
+# 該当する binary（bin/uzustack-relink）が未実装 = 実 trigger なし。Phase 6+
+# で uzustack 独自の release 機構と同時設計するまで型として在庫。
+#
+# 何が変わったか：setup が directory symlink ではなく実 directory + SKILL.md
+# symlink を内側に作るようになった。旧 pattern（qa -> uzustack/qa）は --no-prefix
+# でも Claude Code が skill を "uzustack-qa" と auto-prefix する原因だった
+# （Claude が symlink target の親 dir 名を見るため）。
+#
+# 何をするか：uzustack-relink を実行して全 skill entry を新しい実 directory
+# pattern で再作成する。冪等 — 何度実行しても安全。
+#
+# 影響範囲：v0.15.2.0 より前に --no-prefix で uzustack を install したユーザー
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+
+if [ -x "$SCRIPT_DIR/bin/uzustack-relink" ]; then
+  echo "  [v0.15.2.0] skill directory 構造を修復中..."
+  "$SCRIPT_DIR/bin/uzustack-relink" 2>/dev/null || true
+fi

--- a/uzustack-upgrade/migrations/v0.16.2.0.sh
+++ b/uzustack-upgrade/migrations/v0.16.2.0.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Migration: v0.16.2.0 — per-project resource log を builder profile に統合
+#
+# 注：本 migration は upstream gstack の v0.16.2.0 path 由来。uzustack では
+# 該当機構（per-project resources-shown.jsonl / builder-profile.jsonl）が
+# 未実装 = 実 trigger なし。Phase 6+ で uzustack 独自 builder profile 機構と
+# 同時設計するまで型として在庫。
+#
+# 何が変わったか：resource dedup が per-project resources-shown.jsonl から
+# global builder-profile.jsonl に移った（全 closing state の single source of truth）。
+#
+# 何をするか：すべての per-project resources-shown.jsonl を見つけ、URL を
+# builder profile の stub entry にマージして既存ユーザーが dedup history を
+# 失わないようにする。冪等 — 何度実行しても安全。
+#
+# 影響範囲：本 version より前に /office-hours を実行したユーザー
+set -euo pipefail
+
+UZUSTACK_HOME="${UZUSTACK_HOME:-$HOME/.uzustack}"
+PROFILE_FILE="$UZUSTACK_HOME/builder-profile.jsonl"
+
+# すべての per-project resource log を見つける
+RESOURCE_FILES=$(find "$UZUSTACK_HOME/projects" -name "resources-shown.jsonl" 2>/dev/null || true)
+
+if [ -z "$RESOURCE_FILES" ]; then
+  # per-project resource ファイルが存在しない — clean install、移行不要
+  exit 0
+fi
+
+echo "  [v0.16.2.0] per-project resource log を builder profile に移行中..."
+
+# すべての per-project ファイルから unique URL を集める
+ALL_URLS=$(echo "$RESOURCE_FILES" | while read -r f; do
+  [ -f "$f" ] && cat "$f" 2>/dev/null || true
+done | grep -o '"url":"[^"]*"' | sed 's/"url":"//;s/"//' | sort -u)
+
+if [ -z "$ALL_URLS" ]; then
+  exit 0
+fi
+
+# builder-profile が既に resource data を持っているか確認（冪等性）
+if [ -f "$PROFILE_FILE" ] && grep -q "resources_shown" "$PROFILE_FILE" 2>/dev/null; then
+  # 既に resource data あり、移行対象 URL が含まれているか確認
+  EXISTING_URLS=$(grep -o '"resources_shown":\[[^]]*\]' "$PROFILE_FILE" 2>/dev/null | grep -o 'https://[^"]*' | sort -u)
+  NEW_URLS=$(comm -23 <(echo "$ALL_URLS") <(echo "$EXISTING_URLS") 2>/dev/null || echo "$ALL_URLS")
+  if [ -z "$NEW_URLS" ]; then
+    # すべての URL が既に存在 — 何もしない
+    exit 0
+  fi
+fi
+
+# URL の JSON array を build
+URL_ARRAY=$(echo "$ALL_URLS" | awk 'BEGIN{printf "["} NR>1{printf ","} {printf "\"%s\"", $0} END{printf "]"}')
+
+# builder profile に migration stub entry を append
+mkdir -p "$UZUSTACK_HOME"
+echo "{\"date\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"mode\":\"migration\",\"project_slug\":\"_migrated\",\"signal_count\":0,\"signals\":[],\"design_doc\":\"\",\"assignment\":\"\",\"resources_shown\":$URL_ARRAY,\"topics\":[]}" >> "$PROFILE_FILE"
+
+echo "  [v0.16.2.0] $(echo "$ALL_URLS" | wc -l | tr -d ' ') 個の resource URL を builder profile に移行した。"

--- a/uzustack-upgrade/migrations/v1.0.0.0.sh
+++ b/uzustack-upgrade/migrations/v1.0.0.0.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Migration: v1.0.0.0 — V1 writing style prompt
+#
+# 注：本 migration は upstream gstack の v1.0.0.0 path 由来。uzustack では
+# 該当機構（writing-style prompt / explain_level config）が未実装 = 実 trigger
+# なし。Phase 6+ で uzustack 独自の writing style 機構と同時設計するまで
+# 型として在庫。
+#
+# 何が変わったか：tier-≥2 skill が ELI10 writing style をデフォルトに採用
+# （初出 jargon を解説、outcome 軸の質問、短文）。旧 V0 prose を好む power user は
+# `uzustack-config set explain_level terse` で opt-in できる。
+#
+# 何をするか：「pending prompt」flag ファイルを書く。upgrade 後の最初の
+# tier-≥2 skill 起動時、preamble が flag を読んで「新デフォルトを残すか
+# terse mode に切り替えるか」を一度だけ尋ねる。ユーザー回答後に flag は削除。
+# 冪等 — 何度実行しても安全。
+#
+# 影響範囲：v0.19.x 以下から v1.x に upgrade する全ユーザー
+set -euo pipefail
+
+UZUSTACK_HOME="${UZUSTACK_HOME:-$HOME/.uzustack}"
+PROMPTED_FLAG="$UZUSTACK_HOME/.writing-style-prompted"
+PENDING_FLAG="$UZUSTACK_HOME/.writing-style-prompt-pending"
+
+mkdir -p "$UZUSTACK_HOME"
+
+# ユーザーが既に prompt に答えていたら skip
+if [ -f "$PROMPTED_FLAG" ]; then
+  exit 0
+fi
+
+# ユーザーが既に explain_level を明示設定済みなら、それを「回答」とみなして skip
+EXPLAIN_LEVEL_SET="$("${HOME}/.claude/skills/uzustack/bin/uzustack-config" get explain_level 2>/dev/null || true)"
+if [ -n "$EXPLAIN_LEVEL_SET" ]; then
+  touch "$PROMPTED_FLAG"
+  exit 0
+fi
+
+# pending flag を書く — preamble が次の tier-≥2 skill 起動時に検知する
+touch "$PENDING_FLAG"
+
+echo "  [v1.0.0.0] V1 writing style: 次回 skill 起動時に「新デフォルト（jargon 解説、outcome 軸）」と「旧 terse prose」のいずれを使うかを一度だけ尋ねる。"

--- a/uzustack-upgrade/migrations/v1.1.3.0.sh
+++ b/uzustack-upgrade/migrations/v1.1.3.0.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Migration: v1.1.3.0 — stale な /checkpoint skill install を削除
+#
+# 注：本 migration は upstream gstack の v1.1.3.0 path 由来。uzustack では
+# 該当 install（旧 checkpoint skill）が未実装 = 実 trigger なし。Phase 6+ で
+# uzustack 独自の skill rename 機構と同時設計するまで型として在庫。
+#
+# Claude Code は /checkpoint を /rewind の native alias として ship したため、
+# 旧 uzustack checkpoint skill が shadow されていた。本 skill は
+# /context-save + /context-restore に分割済み。本 migration は旧 install を
+# on-disk から削除し、Claude Code の native /checkpoint が shadow されないようにする。
+#
+# 所有権 guard：install を **uzustack が所有していると判定できた場合のみ** 削除する。
+# つまり directory または SKILL.md が ~/.claude/skills/uzustack/ 配下を指す
+# symlink である場合のみ。ユーザー独自の /checkpoint skill（普通の file、または
+# 別の場所を指す symlink）は保持する。
+#
+# 対応する 3 種類の install shape：
+#   1. ~/.claude/skills/checkpoint が uzustack 内部を指す directory symlink
+#   2. ~/.claude/skills/checkpoint が普通の directory で、その中身が
+#      uzustack 内部を指す SKILL.md symlink 1 件のみ（uzustack の prefix-install shape）
+#   3. それ以外 → 触らず通知だけ
+#
+# 冪等：path が無い場合は no-op
+set -euo pipefail
+
+# Guard: HOME が unset / empty の場合は中止。`set -u` で unset HOME は error
+# になるが、HOME=""（sudo-without-H、systemd unit、一部の CI runner で発生）は
+# 生き残って "/.claude/skills/..." のような危険な絶対 path を作る。clean に abort する。
+if [ -z "${HOME:-}" ]; then
+  echo "  [v1.1.3.0] HOME が unset / empty — migration を skip。" >&2
+  exit 0
+fi
+
+SKILLS_DIR="${HOME}/.claude/skills"
+OLD_TOPLEVEL="${SKILLS_DIR}/checkpoint"
+OLD_NAMESPACED="${SKILLS_DIR}/uzustack/checkpoint"
+UZUSTACK_ROOT_REAL=""
+
+# Helper: target を canonical path に正規化（symlink-safe）。解決済み path を表示、
+# 失敗（broken symlink、ENOENT、ELOOP）時は空文字列を返す。realpath と python3
+# fallback の両方を試す — 単一 tool の失敗で ownership check が破綻しないように。
+# 両方失敗したら空文字列を返す。
+resolve_real() {
+  local target="$1"
+  local out=""
+  if command -v realpath >/dev/null 2>&1; then
+    out=$(realpath "$target" 2>/dev/null || true)
+  fi
+  if [ -z "$out" ] && command -v python3 >/dev/null 2>&1; then
+    out=$(python3 -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' "$target" 2>/dev/null || true)
+  fi
+  printf '%s' "$out"
+}
+
+# uzustack skills root の canonical path を解決。uzustack が install されていなければ
+# 移行対象なし。
+if [ -d "${SKILLS_DIR}/uzustack" ]; then
+  UZUSTACK_ROOT_REAL=$(resolve_real "${SKILLS_DIR}/uzustack")
+fi
+
+# Helper: $1（canonical path）が $2（canonical path）の配下か？
+path_inside() {
+  local inner="$1"
+  local outer="$2"
+  [ -n "$inner" ] && [ -n "$outer" ] || return 1
+  case "$inner" in
+    "$outer"|"$outer"/*) return 0;;
+    *) return 1;;
+  esac
+}
+
+removed_any=0
+
+# --- Shape 1: top-level ~/.claude/skills/checkpoint
+if [ -L "$OLD_TOPLEVEL" ]; then
+  # Directory symlink（または file symlink）。canonicalize して所有権を確認。
+  target_real=$(resolve_real "$OLD_TOPLEVEL")
+  if [ -n "$UZUSTACK_ROOT_REAL" ] && path_inside "$target_real" "$UZUSTACK_ROOT_REAL"; then
+    rm -- "$OLD_TOPLEVEL"
+    echo "  [v1.1.3.0] stale な /checkpoint symlink を削除（Claude Code の /rewind alias を shadow していた）。"
+    removed_any=1
+  else
+    echo "  [v1.1.3.0] $OLD_TOPLEVEL は触らない — symlink target が uzustack 外（または解決不能）。"
+  fi
+elif [ -d "$OLD_TOPLEVEL" ]; then
+  # 普通の directory。SKILL.md が uzustack 内を指す symlink 1 件のみの場合に限り削除
+  # （uzustack の prefix-install shape）。find で実 file 数を数え、.DS_Store（macOS sidecar）は無視。
+  file_count=$(find "$OLD_TOPLEVEL" -maxdepth 1 -type f -not -name '.DS_Store' -not -name '._*' 2>/dev/null | wc -l | tr -d ' ')
+  symlink_count=$(find "$OLD_TOPLEVEL" -maxdepth 1 -type l 2>/dev/null | wc -l | tr -d ' ')
+  if [ "$file_count" = "0" ] && [ "$symlink_count" = "1" ] && [ -L "$OLD_TOPLEVEL/SKILL.md" ]; then
+    target_real=$(resolve_real "$OLD_TOPLEVEL/SKILL.md")
+    if [ -n "$UZUSTACK_ROOT_REAL" ] && path_inside "$target_real" "$UZUSTACK_ROOT_REAL"; then
+      # macOS sidecar を先に削除（user content ではない）、その後 dir を削除
+      find "$OLD_TOPLEVEL" -maxdepth 1 \( -name '.DS_Store' -o -name '._*' \) -type f -delete 2>/dev/null || true
+      rm -r -- "$OLD_TOPLEVEL"
+      echo "  [v1.1.3.0] stale な /checkpoint install directory を削除（uzustack prefix-mode）。"
+      removed_any=1
+    else
+      echo "  [v1.1.3.0] $OLD_TOPLEVEL は触らない — SKILL.md symlink target が uzustack 外。"
+    fi
+  else
+    echo "  [v1.1.3.0] $OLD_TOPLEVEL は触らない — uzustack 所有の install ではない（独自 content あり）。"
+  fi
+fi
+# 不在 → no-op（冪等）
+
+# --- Shape 2: ~/.claude/skills/uzustack/checkpoint/
+# 所有権 guard はここでも適用：uzustack skills root 内に解決される場合のみ削除。
+# ユーザーが directory を別の場所（fork 等）を指す symlink に置き換えていたら尊重する。
+if [ -L "$OLD_NAMESPACED" ]; then
+  target_real=$(resolve_real "$OLD_NAMESPACED")
+  if [ -n "$UZUSTACK_ROOT_REAL" ] && path_inside "$target_real" "$UZUSTACK_ROOT_REAL"; then
+    rm -- "$OLD_NAMESPACED"
+    echo "  [v1.1.3.0] stale な ~/.claude/skills/uzustack/checkpoint symlink を削除。"
+    removed_any=1
+  else
+    echo "  [v1.1.3.0] $OLD_NAMESPACED は触らない — symlink target が uzustack 外。"
+  fi
+elif [ -d "$OLD_NAMESPACED" ]; then
+  # 普通の directory。uzustack-prefix install location。uzustack root 内に解決されるか確認
+  # （手で tree を編集していない限り常に true のはず）。
+  target_real=$(resolve_real "$OLD_NAMESPACED")
+  if [ -n "$UZUSTACK_ROOT_REAL" ] && path_inside "$target_real" "$UZUSTACK_ROOT_REAL"; then
+    rm -rf -- "$OLD_NAMESPACED"
+    echo "  [v1.1.3.0] stale な ~/.claude/skills/uzustack/checkpoint/ を削除（context-save + context-restore に置き換え済み）。"
+    removed_any=1
+  else
+    echo "  [v1.1.3.0] $OLD_NAMESPACED は触らない — uzustack 外に解決される。"
+  fi
+fi
+
+if [ "$removed_any" = "1" ]; then
+  echo "  [v1.1.3.0] /checkpoint は Claude Code の native /rewind alias になった。state 保存は /context-save、再開は /context-restore を使う。"
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Phase 3.5 step-52 = C2 cluster（infra/wrapper 系）3 件目。upstream gstack-upgrade（10.7 KB / 282 行）+ migrations/*.sh 4 件を翻訳して `uzustack-upgrade/` 配下に配置。skill 名 / dir 名 / 内部 path / repo URL を `gstack-` → `uzustack-` 機械置換、voice 規約 v1 に従い日本語化。

Closes #71

## 変更点

### `uzustack-upgrade/SKILL.md.tmpl`（277 行）

- upstream `_upstream/gstack/gstack-upgrade/SKILL.md.tmpl`（282 行）を翻訳
- 命名置換：
  - skill 名 / dir 名：`gstack-upgrade` → `uzustack-upgrade`
  - 内部 path：`~/.gstack/` → `~/.uzustack/`、`~/.claude/skills/gstack/` → `~/.claude/skills/uzustack/`
  - bin：`gstack-config` / `gstack-update-check` → `uzustack-config` / `uzustack-update-check`
  - env：`GSTACK_AUTO_UPGRADE` → `UZUSTACK_AUTO_UPGRADE`
  - repo URL：`garrytan/gstack` → `uzumaki-inc/uzustack`
- voice 規約 v1：日本語化、`STOP / OK / ERROR` 等の sentinel は英語維持、user-facing 文字列は英語維持（CLI 慣習）

### `migrations/*.sh` 4 件

各 migration は upstream gstack の version path 由来。uzustack では該当機構が未実装のため **実 trigger なし**（OLD_VERSION ガードで走らない）。Phase 6+ で uzustack 独自 release 機構と同時設計するまで型として在庫。

| File | upstream 機能 | uzustack 該当機構 |
|---|---|---|
| `v0.15.2.0.sh` | `gstack-relink` skill dir 構造修復 | `uzustack-relink` 未実装 |
| `v0.16.2.0.sh` | per-project resources-shown.jsonl → builder-profile.jsonl 統合 | builder-profile / resources-shown 未実装 |
| `v1.0.0.0.sh` | V1 writing style prompt flag | writing-style prompt / explain_level 未実装 |
| `v1.1.3.0.sh` | stale /checkpoint skill remove | 旧 checkpoint skill 未 install |

各 file 冒頭に「本 migration は upstream version path 由来、uzustack では実 trigger なし、Phase 6+ で再判定」注記を追加。bash logic は upstream のまま機械置換のみ（`gstack-` → `uzustack-`）、コメント日本語化。

## C2 cluster 進捗

- step-50 claude（C2 1/4、a 既存翻訳）— PR #68 merged
- step-51 pair-agent（C2 2/4、b スタブ配置）— PR #70 merged
- **step-52 gstack-upgrade（C2 3/4、c src 参照型 + 命名置換）— 本 PR**
- step-53 setup-gbrain（C2 4/4、a 既存翻訳）— TODO

## Test plan

- [x] `bun run gen:skill-docs` で `uzustack-upgrade/SKILL.md` が生成される（277 行 / ~2477 tokens）
- [x] frontmatter の name / description / triggers が日本語化されている
- [x] migrations/*.sh は executable
- [x] 命名置換が漏れなく適用されている（gstack-, ~/.gstack/, GSTACK_, garrytan/gstack）
- [x] /simplify を 2 周（後続 review）