### PR TITLE
feat: benchmark Phase 6 予約スタブ — Phase 3.5 step-54 (C3 cluster 1/4)

### DIFF
--- a/benchmark/SKILL.md
+++ b/benchmark/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: benchmark
+version: 0.0.0
+description: |
+  ページの performance 計測 skill。本実装は Phase 6 で配置予定。
+  「performance」「performance ベンチマーク」「benchmark」「page speed」
+  「ページ速度を計測」「Core Web Vitals」「Core Web Vitals 計測」
+  「lighthouse」「web vitals」「bundle size」「bundle 容量」「load time」
+  「読み込み時間」と要求されたときに使用する。
+  Voice triggers (speech-to-text aliases): "speed test", "速度テスト", "check performance", "performance を確認".
+triggers:
+  - performance benchmark
+  - performance ベンチマーク
+  - check page speed
+  - ページ速度を計測
+  - detect performance regression
+  - performance regression 検出
+status: phase6-reserved
+---
+<!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
+<!-- Regenerate: bun run gen:skill-docs -->
+
+
+
+# benchmark — Phase 6 で対応予定
+
+このスキルは uzustack の Phase 6（browse / extension 独自実装フェーズ）で
+本実装される予定です。Phase 3.5 段階では skill 名予約として
+スタブのみ配置されています。
+
+upstream の `_upstream/gstack/benchmark/` 配下に gstack 版の本実装があります
+（参照のみ可能、uzustack の setup / skill / bin から一切呼び出されません）。
+browse daemon の `perf` command + JavaScript evaluation でページの
+performance metrics（TTFB / FCP / LCP / DOM Interactive / DOM Complete /
+Full Load / bundle size / resource size）を計測し、baseline と比較して
+regression を検出するのが core 機能です。browse 機構 core 依存のため
+Phase 6 で browse 独自実装と同時設計します。
+
+## 関連
+
+- 上流参照：`_upstream/gstack/benchmark/`（取り込まない、subtree 温存）

--- a/benchmark/SKILL.md
+++ b/benchmark/SKILL.md
@@ -3,16 +3,18 @@ name: benchmark
 version: 0.0.0
 description: |
   ページの performance 計測 skill。本実装は Phase 6 で配置予定。
-  「performance」「performance ベンチマーク」「benchmark」「page speed」
-  「ページ速度を計測」「Core Web Vitals」「Core Web Vitals 計測」
-  「lighthouse」「web vitals」「bundle size」「bundle 容量」「load time」
-  「読み込み時間」と要求されたときに使用する。
+  「performance benchmark」「performance ベンチマーク」「page speed」
+  「ページ速度を計測」「Core Web Vitals 計測」「bundle size 確認」
+  「load time 計測」「performance regression 検出」と要求されたときに使用する。
   Voice triggers (speech-to-text aliases): "speed test", "速度テスト", "check performance", "performance を確認".
 triggers:
   - performance benchmark
   - performance ベンチマーク
   - check page speed
   - ページ速度を計測
+  - Core Web Vitals 計測
+  - bundle size 確認
+  - load time 計測
   - detect performance regression
   - performance regression 検出
 status: phase6-reserved

--- a/benchmark/SKILL.md.tmpl
+++ b/benchmark/SKILL.md.tmpl
@@ -1,0 +1,43 @@
+---
+name: benchmark
+version: 0.0.0
+description: |
+  ページの performance 計測 skill。本実装は Phase 6 で配置予定。
+  「performance」「performance ベンチマーク」「benchmark」「page speed」
+  「ページ速度を計測」「Core Web Vitals」「Core Web Vitals 計測」
+  「lighthouse」「web vitals」「bundle size」「bundle 容量」「load time」
+  「読み込み時間」と要求されたときに使用する。
+voice-triggers:
+  - "speed test"
+  - "速度テスト"
+  - "check performance"
+  - "performance を確認"
+triggers:
+  - performance benchmark
+  - performance ベンチマーク
+  - check page speed
+  - ページ速度を計測
+  - detect performance regression
+  - performance regression 検出
+status: phase6-reserved
+---
+
+{{PREAMBLE}}
+
+# benchmark — Phase 6 で対応予定
+
+このスキルは uzustack の Phase 6（browse / extension 独自実装フェーズ）で
+本実装される予定です。Phase 3.5 段階では skill 名予約として
+スタブのみ配置されています。
+
+upstream の `_upstream/gstack/benchmark/` 配下に gstack 版の本実装があります
+（参照のみ可能、uzustack の setup / skill / bin から一切呼び出されません）。
+browse daemon の `perf` command + JavaScript evaluation でページの
+performance metrics（TTFB / FCP / LCP / DOM Interactive / DOM Complete /
+Full Load / bundle size / resource size）を計測し、baseline と比較して
+regression を検出するのが core 機能です。browse 機構 core 依存のため
+Phase 6 で browse 独自実装と同時設計します。
+
+## 関連
+
+- 上流参照：`_upstream/gstack/benchmark/`（取り込まない、subtree 温存）

--- a/benchmark/SKILL.md.tmpl
+++ b/benchmark/SKILL.md.tmpl
@@ -3,10 +3,9 @@ name: benchmark
 version: 0.0.0
 description: |
   ページの performance 計測 skill。本実装は Phase 6 で配置予定。
-  「performance」「performance ベンチマーク」「benchmark」「page speed」
-  「ページ速度を計測」「Core Web Vitals」「Core Web Vitals 計測」
-  「lighthouse」「web vitals」「bundle size」「bundle 容量」「load time」
-  「読み込み時間」と要求されたときに使用する。
+  「performance benchmark」「performance ベンチマーク」「page speed」
+  「ページ速度を計測」「Core Web Vitals 計測」「bundle size 確認」
+  「load time 計測」「performance regression 検出」と要求されたときに使用する。
 voice-triggers:
   - "speed test"
   - "速度テスト"
@@ -17,6 +16,9 @@ triggers:
   - performance ベンチマーク
   - check page speed
   - ページ速度を計測
+  - Core Web Vitals 計測
+  - bundle size 確認
+  - load time 計測
   - detect performance regression
   - performance regression 検出
 status: phase6-reserved


### PR DESCRIPTION
## Summary

Phase 3.5 step-54 = C3 cluster（monitoring 系）の **1 件目**。upstream `benchmark` は browse daemon の `perf` command + `$B eval` で page load / Core Web Vitals / resource size を計測する skill = browse なしでは literally 何も計測できない。**cluster D C 8 件 + step-51 pair-agent と同型** の最小スタブを `benchmark/` 配下に新規配置。

Closes #75

## 変更点

### `benchmark/SKILL.md.tmpl`（新規、~40 行）

- frontmatter：`name` / `description`（日本語化）/ `voice-triggers` / `triggers` / `status: phase6-reserved` のみ
- `type: translated` は付与しない（stub 系は upstream 全文翻訳ではない、CONTRIBUTING L211 境界条件を sibling stub 群と踏襲）
- description / triggers は **英日 paired phrase で advertise + triggers array に同期 entry を含める** 規律を最初から適用（step-53 /simplify 2 周目 fix の学び）
- 本文：「Phase 6 で対応予定」宣言 + upstream 参照注記 + 関連 link の 3 段

## C2 cluster 完遂 / C3 cluster 開始

- step-50 claude（C2 1/4、a 既存翻訳）— PR #68 merged
- step-51 pair-agent（C2 2/4、b スタブ）— PR #70 merged
- step-52 uzustack-upgrade（C2 3/4、c src 参照型）— PR #72 merged
- step-53 setup-gbrain（C2 4/4 = 完遂、a 既存翻訳）— PR #74 merged
- **step-54 benchmark（C3 1/4、b スタブ）— 本 PR**

## Test plan

- [x] `bun run gen:skill-docs` で `benchmark/SKILL.md` が生成される（~37 行）
- [x] frontmatter の name / description / triggers が日本語化されている
- [x] `status: phase6-reserved` が付与されている
- [x] description ↔ triggers の advertise が同期している（step-53 学び）
- [x] /simplify を 2 周完了（1 周目 Med 1 fix（description ↔ triggers 同期）+ 2 周目 actionable 0 = clean confirmation）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
