### PR TITLE
feat: review 翻訳 — Phase 3.5 step-59 (C4 cluster 2/4)

### DIFF
--- a/review/SKILL.md
+++ b/review/SKILL.md
@@ -1,0 +1,290 @@
+---
+name: review
+type: translated
+preamble-tier: 4
+version: 1.0.0
+description: |
+  Pre-landing PR review。base branch との diff を SQL safety / LLM trust boundary
+  違反 / conditional side effect その他の構造的 issue で分析する。"review this PR"、
+  "code review"、"pre-landing review"、"check my diff" と要求されたときに使用する。
+  ユーザーが merge / land 直前のときに能動的に提案する。(uzustack)
+allowed-tools:
+  - Bash
+  - Read
+  - Edit
+  - Write
+  - Grep
+  - Glob
+  - Agent
+  - AskUserQuestion
+  - WebSearch
+triggers:
+  - review this pr
+  - code review
+  - check my diff
+  - pre-landing review
+  - PR レビュー
+  - コードレビュー
+  - 事前 landing レビュー
+---
+<!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
+<!-- Regenerate: bun run gen:skill-docs -->
+
+
+
+
+
+# Pre-Landing PR Review
+
+あなたは `/review` workflow を実行している。現 branch の diff を base branch に対して、test では catch されない構造的 issue について分析する。
+
+---
+
+## Step 1: branch を check
+
+1. `git branch --show-current` を実行して現 branch を取得。
+2. base branch にいる場合、出力：**「Nothing to review — you're on the base branch or have no changes against it.」** で停止。
+3. `git fetch origin <base> --quiet && git diff origin/<base> --stat` で diff を check。diff が無ければ同 message を出力して停止。
+
+---
+
+
+
+
+
+## Step 2: checklist を読む
+
+`.claude/skills/review/checklist.md` を読む。
+
+**ファイルが読めない場合は STOP して error を報告する。** checklist 無しで進めない。
+
+---
+
+## Step 2.5: Greptile review コメントを check
+
+`.claude/skills/review/greptile-triage.md` を読み、fetch / filter / classify / **escalation 検出** step に従う。
+
+**PR が無い、`gh` が失敗、API が error を返す、Greptile コメントゼロ：** 本 step を silent に skip。Greptile integration は additive — 無くても review は動く。
+
+**Greptile コメントが見つかった場合：** classifications（VALID & ACTIONABLE、VALID BUT ALREADY FIXED、FALSE POSITIVE、SUPPRESSED）を保存 — Step 5 で必要。
+
+---
+
+## Step 3: diff を取得
+
+stale なローカル状態による偽陽性を避けるため、最新 base branch を fetch：
+
+```bash
+git fetch origin <base> --quiet
+```
+
+`git diff origin/<base>` で full diff を取得。最新 base branch に対する commit 済 + 未 commit の両方を含む。
+
+## Step 3.4: Workspace-aware queue status（advisory）
+
+PR の claim した VERSION が queue 中の free slot を指しているか check。advisory のみ — review は決して block しない、landing-order risk を reviewer に伝えるだけ。
+
+```bash
+BRANCH_VERSION=$(git show HEAD:VERSION 2>/dev/null | tr -d '\r\n[:space:]' || echo "")
+BASE_BRANCH=$(gh pr view --json baseRefName -q .baseRefName 2>/dev/null || echo main)
+BASE_VERSION=$(git show origin/$BASE_BRANCH:VERSION 2>/dev/null | tr -d '\r\n[:space:]' || echo "")
+QUEUE_JSON=$(bun run bin/uzustack-next-version \
+  --base "$BASE_BRANCH" \
+  --bump patch \
+  --current-version "$BASE_VERSION" 2>/dev/null || echo '{"offline":true}')
+NEXT_SLOT=$(echo "$QUEUE_JSON" | jq -r '.version // empty')
+CLAIMED_COUNT=$(echo "$QUEUE_JSON" | jq -r '.claimed | length // 0')
+OFFLINE=$(echo "$QUEUE_JSON" | jq -r '.offline // false')
+```
+
+- `OFFLINE=true` の場合：本 section を skip（report する signal なし）。
+- それ以外、review 出力に 1 行含める：`Version claimed: v<BRANCH_VERSION>. Queue: <CLAIMED_COUNT> PR(s) ahead. <VERDICT>` ここで VERDICT は `Slot free`（`BRANCH_VERSION >= NEXT_SLOT` の場合）または `⚠ queue moved — rerun /ship to reconcile v<BRANCH_VERSION> → v<NEXT_SLOT>`。
+
+---
+
+## Step 3.5: Slop scan（advisory）
+
+変更 file に slop scan を実行し、AI コードの quality issue（empty catch、redundant `return await`、過度な抽象化）を catch する：
+
+```bash
+bun run slop:diff origin/<base> 2>/dev/null || true
+```
+
+findings が報告されたら、review 出力に informational diagnostic として含める。slop findings は advisory、決して blocking ではない。slop:diff が利用不可（例：slop-scan 未インストール）なら、本 step を silent に skip。
+
+---
+
+
+
+## Step 4: Critical pass（core review）
+
+checklist の CRITICAL カテゴリを diff に対して適用：
+SQL & Data Safety、Race Conditions & Concurrency、LLM Output Trust Boundary、Shell Injection、Enum & Value Completeness。
+
+checklist に残っている INFORMATIONAL カテゴリも適用（Async/Sync Mixing、Column/Field Name Safety、LLM Prompt Issues、Type Coercion、View/Frontend、Time Window Safety、Completeness Gaps、Distribution & CI/CD）。
+
+**Enum & Value Completeness は diff の OUTSIDE のコードを読む必要がある。** diff が新 enum 値、status、tier、type 定数を導入した場合、Grep で sibling 値を参照する全 file を見つけ、Read で各 file を読み、新値が処理されているか check する。これは within-diff review では不十分な唯一のカテゴリ。
+
+**Search-before-recommending:** fix pattern を推奨する際（特に concurrency、caching、auth、framework 固有挙動）：
+- pattern が使用中の framework version で current best practice か検証
+- workaround を推奨する前に、新 version で組み込み解決策が存在するか check
+- API 署名を current docs に対して検証（API は version 間で変わる）
+
+数秒で済み、古い pattern 推奨を防ぐ。WebSearch が利用不可なら、note して in-distribution の知識で進む。
+
+checklist 指定の出力形式に従う。suppressions を尊重する — 「DO NOT flag」section に list された項目は flag **しない**。
+
+
+
+---
+
+
+
+---
+
+## Step 5: Fix-First Review
+
+**全 finding に action — critical だけではない。**
+
+
+
+### Step 5a: 各 finding を分類
+
+各 finding を checklist.md の Fix-First Heuristic に従って AUTO-FIX または ASK に分類。Critical findings は ASK 寄り、informational findings は AUTO-FIX 寄り。
+
+**Test stub override:** `test_stub` field を持つ finding（specialist が生成）は、元の分類に関わらず ASK に再分類。ASK 項目を提示する際、提案された test file path と test code を表示。ユーザーが test 作成を承認 / skip。承認されたら fix + test file を書く。test file path は finding の `path` から project convention で derive（RSpec は `spec/`、Jest/Vitest は `__tests__/`、pytest は `test_` prefix、Go は `_test.go` suffix）。test file が既に存在すれば、新 test を append する。出力：`[FIXED + TEST] [file:line] Problem -> fix + test at [test_path]`
+
+### Step 5b: 全 AUTO-FIX 項目を auto-fix
+
+各 fix を直接適用。各々について 1 行 summary を出力：
+`[AUTO-FIXED] [file:line] Problem → 何をしたか`
+
+### Step 5c: ASK 項目を batch で確認
+
+ASK 項目が残っていれば、1 つの AskUserQuestion で提示：
+
+- 各項目を番号、severity label、問題、推奨 fix と共に list
+- 各項目の選択肢：A) 推奨通り fix、B) Skip
+- 全体の RECOMMENDATION を含める
+
+例：
+```
+I auto-fixed 5 issues. 2 need your input:
+
+1. [CRITICAL] app/models/post.rb:42 — Race condition in status transition
+   Fix: Add `WHERE status = 'draft'` to the UPDATE
+   → A) Fix  B) Skip
+
+2. [INFORMATIONAL] app/services/generator.rb:88 — LLM output not type-checked before DB write
+   Fix: Add JSON schema validation
+   → A) Fix  B) Skip
+
+RECOMMENDATION: Fix both — #1 is a real race condition, #2 prevents silent data corruption.
+```
+
+ASK 項目が 3 件以下なら、batch ではなく個別の AskUserQuestion call も可。
+
+### Step 5d: ユーザー承認した fix を適用
+
+ユーザーが「Fix」を選んだ項目について fix を適用。何を fix したか出力。
+
+ASK 項目が無ければ（全て AUTO-FIX）、質問を skip する。
+
+### 主張の検証
+
+最終 review 出力を生成する前に：
+- 「この pattern は安全」と主張するなら → 安全性を証明する具体的行を引用
+- 「これは他で処理されている」と主張するなら → handling code を読み、引用
+- 「test がこれを cover している」と主張するなら → test file と method 名を name
+- 「likely handled」「probably tested」と決して言わない — 検証するか、unknown として flag
+
+**合理化の予防:** 「これは fine そう」は finding ではない。fine である証拠を引用するか、unverified として flag するか。
+
+### Greptile コメント解決
+
+自分の findings 出力後、Step 2.5 で Greptile コメントが分類されていれば：
+
+**出力 header に Greptile summary を含める：** `+ N Greptile comments (X valid, Y fixed, Z FP)`
+
+任意のコメントに reply する前に、greptile-triage.md の **Escalation Detection** algorithm を実行し、Tier 1（friendly）または Tier 2（firm）の reply template を決定する。
+
+1. **VALID & ACTIONABLE コメント:** これらは findings に含まれる — Fix-First flow に従う（mechanical なら auto-fix、それ以外は ASK に batch）（A: 今 fix する、B: 認識する、C: 偽陽性）。ユーザーが A（fix）を選んだら、greptile-triage.md の **Fix reply template** で reply（inline diff + 説明を含む）。ユーザーが C（偽陽性）を選んだら、**False Positive reply template** で reply（証拠 + 推奨 re-rank を含む）、per-project と global の greptile-history 両方に保存。
+
+2. **FALSE POSITIVE コメント:** 各々を AskUserQuestion で提示：
+   - Greptile コメントを表示：file:line（または [top-level]）+ body summary + permalink URL
+   - なぜ偽陽性かを簡潔に説明
+   - 選択肢：
+     - A) Greptile に reply してこれが間違っている理由を説明（明らかに間違っているなら推奨）
+     - B) それでも fix する（low-effort で害が無ければ）
+     - C) Ignore — reply も fix もしない
+
+   ユーザーが A を選んだら、greptile-triage.md の **False Positive reply template** で reply（証拠 + 推奨 re-rank を含む）、per-project と global の greptile-history 両方に保存。
+
+3. **VALID BUT ALREADY FIXED コメント:** greptile-triage.md の **Already Fixed reply template** で reply — AskUserQuestion 不要：
+   - 何をしたか + fixing commit SHA を含める
+   - per-project と global の greptile-history 両方に保存
+
+4. **SUPPRESSED コメント:** silent に skip — 過去の triage で既知の偽陽性。
+
+---
+
+## Step 5.5: TODOS cross-reference
+
+repository root の `TODOS.md` を読む（存在すれば）。PR を open TODO に対して cross-reference：
+
+- **本 PR が open TODO を close するか？** Yes なら、出力に該当項目を note：「This PR addresses TODO: <title>」
+- **本 PR が TODO 化すべき作業を生むか？** Yes なら、informational finding として flag。
+- **本 review の文脈となる関連 TODO があるか？** Yes なら、関連 findings 議論時に参照する。
+
+`TODOS.md` が存在しなければ、本 step を silent に skip。
+
+---
+
+## Step 5.6: Documentation staleness check
+
+diff を documentation files に対して cross-reference する。repo root の各 `.md` file（README.md、ARCHITECTURE.md、CONTRIBUTING.md、CLAUDE.md 等）について：
+
+1. diff のコード変更が、その doc file が記述する feature / component / workflow に影響するか check。
+2. doc file が本 branch で更新されていないがそれが記述するコードが変更されていれば、INFORMATIONAL finding として flag：
+   "Documentation may be stale: [file] describes [feature/component] but code changed in this branch. Consider running `/document-release`."
+
+これは informational のみ — critical にはしない。fix action は `/document-release`。
+
+doc file が存在しなければ、本 step を silent に skip。
+
+---
+
+
+
+## Step 5.8: Eng Review 結果を永続化
+
+全 review pass 完了後、最終 `/review` 結果を永続化し、`/ship` が本 branch で Eng Review が走ったことを認識できるようにする。
+
+実行：
+
+```bash
+~/.claude/skills/uzustack/bin/uzustack-review-log '{"skill":"review","timestamp":"TIMESTAMP","status":"STATUS","issues_found":N,"critical":N,"informational":N,"quality_score":SCORE,"specialists":SPECIALISTS_JSON,"findings":FINDINGS_JSON,"commit":"COMMIT"}'
+```
+
+置換：
+- `TIMESTAMP` = ISO 8601 datetime
+- `STATUS` = Fix-First 処理と adversarial review 後に未解決 finding が無ければ `"clean"`、それ以外は `"issues_found"`
+- `issues_found` = 残り未解決 findings の総数
+- `critical` = 残り未解決 critical findings
+- `informational` = 残り未解決 informational findings
+- `quality_score` = Step 4.6 で計算した PR Quality Score（例：7.5）。specialists が skip された場合（小 diff）、`10.0` を使う
+- `specialists` = Step 4.6 で compile した per-specialist stats object。考慮された各 specialist は entry を得る：dispatched なら `{"dispatched":true/false,"findings":N,"critical":N,"informational":N}`、skip された場合は `{"dispatched":false,"reason":"scope|gated"}`。Design specialist を含める。例：`{"testing":{"dispatched":true,"findings":2,"critical":0,"informational":2},"security":{"dispatched":false,"reason":"scope"}}`
+- `findings` = Step 5 からの per-finding records 配列。各 finding（critical pass + specialists から）は以下を含む：`{"fingerprint":"path:line:category","severity":"CRITICAL|INFORMATIONAL","action":"ACTION"}`。ACTION は `"auto-fixed"`（Step 5b）、`"fixed"`（Step 5d でユーザー承認）、`"skipped"`（Step 5c でユーザーが Skip 選択）。Step 5.0 の suppressed findings は **含めない**（過去の review entry に既に記録済）。
+- `COMMIT` = `git rev-parse --short HEAD` の出力
+
+
+
+review が real review 完了前に early exit した場合（例：base branch に対する diff なし）、本 entry を **書かない**。
+
+## Important Rules
+
+- **Comment する前に diff を FULL に読む。** diff 内で既に対処済の issue は flag しない。
+- **Fix-first、read-only ではない。** AUTO-FIX 項目は直接適用。ASK 項目はユーザー承認後にのみ適用。commit / push / PR 作成は決してしない — それは /ship の仕事。
+- **簡潔に。** 1 行 problem、1 行 fix。前置き無し。
+- **真の問題のみ flag する。** 問題ないものは skip。
+- **Greptile reply template を greptile-triage.md から使う。** 全 reply は証拠を含む。曖昧な reply は決して post しない。

--- a/review/SKILL.md.tmpl
+++ b/review/SKILL.md.tmpl
@@ -1,0 +1,288 @@
+---
+name: review
+type: translated
+preamble-tier: 4
+version: 1.0.0
+description: |
+  Pre-landing PR review。base branch との diff を SQL safety / LLM trust boundary
+  違反 / conditional side effect その他の構造的 issue で分析する。"review this PR"、
+  "code review"、"pre-landing review"、"check my diff" と要求されたときに使用する。
+  ユーザーが merge / land 直前のときに能動的に提案する。(uzustack)
+allowed-tools:
+  - Bash
+  - Read
+  - Edit
+  - Write
+  - Grep
+  - Glob
+  - Agent
+  - AskUserQuestion
+  - WebSearch
+triggers:
+  - review this pr
+  - code review
+  - check my diff
+  - pre-landing review
+  - PR レビュー
+  - コードレビュー
+  - 事前 landing レビュー
+---
+
+{{PREAMBLE}}
+
+{{BASE_BRANCH_DETECT}}
+
+# Pre-Landing PR Review
+
+あなたは `/review` workflow を実行している。現 branch の diff を base branch に対して、test では catch されない構造的 issue について分析する。
+
+---
+
+## Step 1: branch を check
+
+1. `git branch --show-current` を実行して現 branch を取得。
+2. base branch にいる場合、出力：**「Nothing to review — you're on the base branch or have no changes against it.」** で停止。
+3. `git fetch origin <base> --quiet && git diff origin/<base> --stat` で diff を check。diff が無ければ同 message を出力して停止。
+
+---
+
+{{SCOPE_DRIFT}}
+
+{{PLAN_COMPLETION_AUDIT_REVIEW}}
+
+## Step 2: checklist を読む
+
+`.claude/skills/review/checklist.md` を読む。
+
+**ファイルが読めない場合は STOP して error を報告する。** checklist 無しで進めない。
+
+---
+
+## Step 2.5: Greptile review コメントを check
+
+`.claude/skills/review/greptile-triage.md` を読み、fetch / filter / classify / **escalation 検出** step に従う。
+
+**PR が無い、`gh` が失敗、API が error を返す、Greptile コメントゼロ：** 本 step を silent に skip。Greptile integration は additive — 無くても review は動く。
+
+**Greptile コメントが見つかった場合：** classifications（VALID & ACTIONABLE、VALID BUT ALREADY FIXED、FALSE POSITIVE、SUPPRESSED）を保存 — Step 5 で必要。
+
+---
+
+## Step 3: diff を取得
+
+stale なローカル状態による偽陽性を避けるため、最新 base branch を fetch：
+
+```bash
+git fetch origin <base> --quiet
+```
+
+`git diff origin/<base>` で full diff を取得。最新 base branch に対する commit 済 + 未 commit の両方を含む。
+
+## Step 3.4: Workspace-aware queue status（advisory）
+
+PR の claim した VERSION が queue 中の free slot を指しているか check。advisory のみ — review は決して block しない、landing-order risk を reviewer に伝えるだけ。
+
+```bash
+BRANCH_VERSION=$(git show HEAD:VERSION 2>/dev/null | tr -d '\r\n[:space:]' || echo "")
+BASE_BRANCH=$(gh pr view --json baseRefName -q .baseRefName 2>/dev/null || echo main)
+BASE_VERSION=$(git show origin/$BASE_BRANCH:VERSION 2>/dev/null | tr -d '\r\n[:space:]' || echo "")
+QUEUE_JSON=$(bun run bin/uzustack-next-version \
+  --base "$BASE_BRANCH" \
+  --bump patch \
+  --current-version "$BASE_VERSION" 2>/dev/null || echo '{"offline":true}')
+NEXT_SLOT=$(echo "$QUEUE_JSON" | jq -r '.version // empty')
+CLAIMED_COUNT=$(echo "$QUEUE_JSON" | jq -r '.claimed | length // 0')
+OFFLINE=$(echo "$QUEUE_JSON" | jq -r '.offline // false')
+```
+
+- `OFFLINE=true` の場合：本 section を skip（report する signal なし）。
+- それ以外、review 出力に 1 行含める：`Version claimed: v<BRANCH_VERSION>. Queue: <CLAIMED_COUNT> PR(s) ahead. <VERDICT>` ここで VERDICT は `Slot free`（`BRANCH_VERSION >= NEXT_SLOT` の場合）または `⚠ queue moved — rerun /ship to reconcile v<BRANCH_VERSION> → v<NEXT_SLOT>`。
+
+---
+
+## Step 3.5: Slop scan（advisory）
+
+変更 file に slop scan を実行し、AI コードの quality issue（empty catch、redundant `return await`、過度な抽象化）を catch する：
+
+```bash
+bun run slop:diff origin/<base> 2>/dev/null || true
+```
+
+findings が報告されたら、review 出力に informational diagnostic として含める。slop findings は advisory、決して blocking ではない。slop:diff が利用不可（例：slop-scan 未インストール）なら、本 step を silent に skip。
+
+---
+
+{{LEARNINGS_SEARCH}}
+
+## Step 4: Critical pass（core review）
+
+checklist の CRITICAL カテゴリを diff に対して適用：
+SQL & Data Safety、Race Conditions & Concurrency、LLM Output Trust Boundary、Shell Injection、Enum & Value Completeness。
+
+checklist に残っている INFORMATIONAL カテゴリも適用（Async/Sync Mixing、Column/Field Name Safety、LLM Prompt Issues、Type Coercion、View/Frontend、Time Window Safety、Completeness Gaps、Distribution & CI/CD）。
+
+**Enum & Value Completeness は diff の OUTSIDE のコードを読む必要がある。** diff が新 enum 値、status、tier、type 定数を導入した場合、Grep で sibling 値を参照する全 file を見つけ、Read で各 file を読み、新値が処理されているか check する。これは within-diff review では不十分な唯一のカテゴリ。
+
+**Search-before-recommending:** fix pattern を推奨する際（特に concurrency、caching、auth、framework 固有挙動）：
+- pattern が使用中の framework version で current best practice か検証
+- workaround を推奨する前に、新 version で組み込み解決策が存在するか check
+- API 署名を current docs に対して検証（API は version 間で変わる）
+
+数秒で済み、古い pattern 推奨を防ぐ。WebSearch が利用不可なら、note して in-distribution の知識で進む。
+
+checklist 指定の出力形式に従う。suppressions を尊重する — 「DO NOT flag」section に list された項目は flag **しない**。
+
+{{CONFIDENCE_CALIBRATION}}
+
+---
+
+{{REVIEW_ARMY}}
+
+---
+
+## Step 5: Fix-First Review
+
+**全 finding に action — critical だけではない。**
+
+{{CROSS_REVIEW_DEDUP}}
+
+### Step 5a: 各 finding を分類
+
+各 finding を checklist.md の Fix-First Heuristic に従って AUTO-FIX または ASK に分類。Critical findings は ASK 寄り、informational findings は AUTO-FIX 寄り。
+
+**Test stub override:** `test_stub` field を持つ finding（specialist が生成）は、元の分類に関わらず ASK に再分類。ASK 項目を提示する際、提案された test file path と test code を表示。ユーザーが test 作成を承認 / skip。承認されたら fix + test file を書く。test file path は finding の `path` から project convention で derive（RSpec は `spec/`、Jest/Vitest は `__tests__/`、pytest は `test_` prefix、Go は `_test.go` suffix）。test file が既に存在すれば、新 test を append する。出力：`[FIXED + TEST] [file:line] Problem -> fix + test at [test_path]`
+
+### Step 5b: 全 AUTO-FIX 項目を auto-fix
+
+各 fix を直接適用。各々について 1 行 summary を出力：
+`[AUTO-FIXED] [file:line] Problem → 何をしたか`
+
+### Step 5c: ASK 項目を batch で確認
+
+ASK 項目が残っていれば、1 つの AskUserQuestion で提示：
+
+- 各項目を番号、severity label、問題、推奨 fix と共に list
+- 各項目の選択肢：A) 推奨通り fix、B) Skip
+- 全体の RECOMMENDATION を含める
+
+例：
+```
+I auto-fixed 5 issues. 2 need your input:
+
+1. [CRITICAL] app/models/post.rb:42 — Race condition in status transition
+   Fix: Add `WHERE status = 'draft'` to the UPDATE
+   → A) Fix  B) Skip
+
+2. [INFORMATIONAL] app/services/generator.rb:88 — LLM output not type-checked before DB write
+   Fix: Add JSON schema validation
+   → A) Fix  B) Skip
+
+RECOMMENDATION: Fix both — #1 is a real race condition, #2 prevents silent data corruption.
+```
+
+ASK 項目が 3 件以下なら、batch ではなく個別の AskUserQuestion call も可。
+
+### Step 5d: ユーザー承認した fix を適用
+
+ユーザーが「Fix」を選んだ項目について fix を適用。何を fix したか出力。
+
+ASK 項目が無ければ（全て AUTO-FIX）、質問を skip する。
+
+### 主張の検証
+
+最終 review 出力を生成する前に：
+- 「この pattern は安全」と主張するなら → 安全性を証明する具体的行を引用
+- 「これは他で処理されている」と主張するなら → handling code を読み、引用
+- 「test がこれを cover している」と主張するなら → test file と method 名を name
+- 「likely handled」「probably tested」と決して言わない — 検証するか、unknown として flag
+
+**合理化の予防:** 「これは fine そう」は finding ではない。fine である証拠を引用するか、unverified として flag するか。
+
+### Greptile コメント解決
+
+自分の findings 出力後、Step 2.5 で Greptile コメントが分類されていれば：
+
+**出力 header に Greptile summary を含める：** `+ N Greptile comments (X valid, Y fixed, Z FP)`
+
+任意のコメントに reply する前に、greptile-triage.md の **Escalation Detection** algorithm を実行し、Tier 1（friendly）または Tier 2（firm）の reply template を決定する。
+
+1. **VALID & ACTIONABLE コメント:** これらは findings に含まれる — Fix-First flow に従う（mechanical なら auto-fix、それ以外は ASK に batch）（A: 今 fix する、B: 認識する、C: 偽陽性）。ユーザーが A（fix）を選んだら、greptile-triage.md の **Fix reply template** で reply（inline diff + 説明を含む）。ユーザーが C（偽陽性）を選んだら、**False Positive reply template** で reply（証拠 + 推奨 re-rank を含む）、per-project と global の greptile-history 両方に保存。
+
+2. **FALSE POSITIVE コメント:** 各々を AskUserQuestion で提示：
+   - Greptile コメントを表示：file:line（または [top-level]）+ body summary + permalink URL
+   - なぜ偽陽性かを簡潔に説明
+   - 選択肢：
+     - A) Greptile に reply してこれが間違っている理由を説明（明らかに間違っているなら推奨）
+     - B) それでも fix する（low-effort で害が無ければ）
+     - C) Ignore — reply も fix もしない
+
+   ユーザーが A を選んだら、greptile-triage.md の **False Positive reply template** で reply（証拠 + 推奨 re-rank を含む）、per-project と global の greptile-history 両方に保存。
+
+3. **VALID BUT ALREADY FIXED コメント:** greptile-triage.md の **Already Fixed reply template** で reply — AskUserQuestion 不要：
+   - 何をしたか + fixing commit SHA を含める
+   - per-project と global の greptile-history 両方に保存
+
+4. **SUPPRESSED コメント:** silent に skip — 過去の triage で既知の偽陽性。
+
+---
+
+## Step 5.5: TODOS cross-reference
+
+repository root の `TODOS.md` を読む（存在すれば）。PR を open TODO に対して cross-reference：
+
+- **本 PR が open TODO を close するか？** Yes なら、出力に該当項目を note：「This PR addresses TODO: <title>」
+- **本 PR が TODO 化すべき作業を生むか？** Yes なら、informational finding として flag。
+- **本 review の文脈となる関連 TODO があるか？** Yes なら、関連 findings 議論時に参照する。
+
+`TODOS.md` が存在しなければ、本 step を silent に skip。
+
+---
+
+## Step 5.6: Documentation staleness check
+
+diff を documentation files に対して cross-reference する。repo root の各 `.md` file（README.md、ARCHITECTURE.md、CONTRIBUTING.md、CLAUDE.md 等）について：
+
+1. diff のコード変更が、その doc file が記述する feature / component / workflow に影響するか check。
+2. doc file が本 branch で更新されていないがそれが記述するコードが変更されていれば、INFORMATIONAL finding として flag：
+   "Documentation may be stale: [file] describes [feature/component] but code changed in this branch. Consider running `/document-release`."
+
+これは informational のみ — critical にはしない。fix action は `/document-release`。
+
+doc file が存在しなければ、本 step を silent に skip。
+
+---
+
+{{ADVERSARIAL_STEP}}
+
+## Step 5.8: Eng Review 結果を永続化
+
+全 review pass 完了後、最終 `/review` 結果を永続化し、`/ship` が本 branch で Eng Review が走ったことを認識できるようにする。
+
+実行：
+
+```bash
+~/.claude/skills/uzustack/bin/uzustack-review-log '{"skill":"review","timestamp":"TIMESTAMP","status":"STATUS","issues_found":N,"critical":N,"informational":N,"quality_score":SCORE,"specialists":SPECIALISTS_JSON,"findings":FINDINGS_JSON,"commit":"COMMIT"}'
+```
+
+置換：
+- `TIMESTAMP` = ISO 8601 datetime
+- `STATUS` = Fix-First 処理と adversarial review 後に未解決 finding が無ければ `"clean"`、それ以外は `"issues_found"`
+- `issues_found` = 残り未解決 findings の総数
+- `critical` = 残り未解決 critical findings
+- `informational` = 残り未解決 informational findings
+- `quality_score` = Step 4.6 で計算した PR Quality Score（例：7.5）。specialists が skip された場合（小 diff）、`10.0` を使う
+- `specialists` = Step 4.6 で compile した per-specialist stats object。考慮された各 specialist は entry を得る：dispatched なら `{"dispatched":true/false,"findings":N,"critical":N,"informational":N}`、skip された場合は `{"dispatched":false,"reason":"scope|gated"}`。Design specialist を含める。例：`{"testing":{"dispatched":true,"findings":2,"critical":0,"informational":2},"security":{"dispatched":false,"reason":"scope"}}`
+- `findings` = Step 5 からの per-finding records 配列。各 finding（critical pass + specialists から）は以下を含む：`{"fingerprint":"path:line:category","severity":"CRITICAL|INFORMATIONAL","action":"ACTION"}`。ACTION は `"auto-fixed"`（Step 5b）、`"fixed"`（Step 5d でユーザー承認）、`"skipped"`（Step 5c でユーザーが Skip 選択）。Step 5.0 の suppressed findings は **含めない**（過去の review entry に既に記録済）。
+- `COMMIT` = `git rev-parse --short HEAD` の出力
+
+{{LEARNINGS_LOG}}
+
+review が real review 完了前に early exit した場合（例：base branch に対する diff なし）、本 entry を **書かない**。
+
+## Important Rules
+
+- **Comment する前に diff を FULL に読む。** diff 内で既に対処済の issue は flag しない。
+- **Fix-first、read-only ではない。** AUTO-FIX 項目は直接適用。ASK 項目はユーザー承認後にのみ適用。commit / push / PR 作成は決してしない — それは /ship の仕事。
+- **簡潔に。** 1 行 problem、1 行 fix。前置き無し。
+- **真の問題のみ flag する。** 問題ないものは skip。
+- **Greptile reply template を greptile-triage.md から使う。** 全 reply は証拠を含む。曖昧な reply は決して post しない。

--- a/review/TODOS-format.md
+++ b/review/TODOS-format.md
@@ -1,0 +1,62 @@
+# TODOS.md Format Reference
+
+canonical な TODOS.md 形式の共有 reference。`/ship`（Step 5.5）と `/plan-ceo-review`（TODOS.md updates section）が一貫した TODO item 構造を確保するため参照する。
+
+---
+
+## File Structure
+
+```markdown
+# TODOS
+
+## <Skill/Component>     ← 例：## Browse, ## Ship, ## Review, ## Infrastructure
+<P0 → P1 → P2 → P3 → P4 順で sort された項目>
+
+## Completed
+<完了 annotation 付きの finished items>
+```
+
+**Section:** skill / component で organize（`## Browse`、`## Ship`、`## Review`、`## QA`、`## Retro`、`## Infrastructure`）。各 section 内で priority で sort（P0 を上）。
+
+---
+
+## TODO Item 形式
+
+各項目は section 配下の H3：
+
+```markdown
+### <Title>
+
+**What:** 作業の 1 行 description。
+
+**Why:** 解決する具体的問題、または unlock する value。
+
+**Context:** 3 ヶ月後にこれを picking up する人が、motivation、現状、開始点を理解できる詳細。
+
+**Effort:** S / M / L / XL
+**Priority:** P0 / P1 / P2 / P3 / P4
+**Depends on:** <prerequisite、または "None">
+```
+
+**必須 field:** What、Why、Context、Effort、Priority
+**任意 field:** Depends on、Blocked by
+
+---
+
+## Priority 定義
+
+- **P0** — Blocking：次 release 前に必ず done
+- **P1** — Critical：本 cycle で done すべき
+- **P2** — Important：P0/P1 が clear になったら do
+- **P3** — Nice-to-have：adoption / usage data 後に revisit
+- **P4** — Someday：good idea、urgency なし
+
+---
+
+## Completed Item 形式
+
+項目が完了したら、`## Completed` section に move し、original 内容を保持しながら以下を append：
+
+```markdown
+**Completed:** vX.Y.Z (YYYY-MM-DD)
+```

--- a/review/checklist.md
+++ b/review/checklist.md
@@ -1,0 +1,176 @@
+# Pre-Landing Review Checklist
+
+## Instructions
+
+`git diff origin/main` の出力を、下記 issue について review する。具体的に — `file:line` を引用して fix を提案する。問題ないものは skip。real な問題のみ flag する。
+
+**Two-pass review:**
+- **Pass 1（CRITICAL）:** SQL & Data Safety、Race Conditions、LLM Output Trust Boundary、Shell Injection、Enum Completeness を最初に走らせる。最高 severity。
+- **Pass 2（INFORMATIONAL）:** 下記の残りカテゴリを走らせる。低 severity だが action する。
+- **Specialist カテゴリ（並列 subagent が処理、本 checklist の対象外）:** Test Gaps、Dead Code、Magic Numbers、Conditional Side Effects、Performance & Bundle Impact、Crypto & Entropy。これらは `review/specialists/` を参照。
+
+全 findings は Fix-First Review で action される：明らかに mechanical な fix は自動適用、真に曖昧な issue は 1 つの user question に batch される。
+
+**出力形式:**
+
+```
+Pre-Landing Review: N issues (X critical, Y informational)
+
+**AUTO-FIXED:**
+- [file:line] Problem → fix applied
+
+**NEEDS INPUT:**
+- [file:line] Problem description
+  Recommended fix: suggested fix
+```
+
+issue が無ければ：`Pre-Landing Review: No issues found.`
+
+簡潔に。各 issue：1 行で問題、1 行で fix。前置き、要約、「looks good overall」は無し。
+
+---
+
+## Review カテゴリ
+
+### Pass 1 — CRITICAL
+
+#### SQL & Data Safety
+- SQL の string interpolation（値が `.to_i`/`.to_f` でも）— parameterized query を使う（Rails: sanitize_sql_array/Arel; Node: prepared statements; Python: parameterized queries）
+- TOCTOU race：atomic な `WHERE` + `update_all` であるべき check-then-set pattern
+- 直接 DB write で model validations を bypass（Rails: update_column; Django: QuerySet.update(); Prisma: raw queries）
+- N+1 query：loop / view で使う関連の eager loading 欠落（Rails: .includes(); SQLAlchemy: joinedload(); Prisma: include）
+
+#### Race Conditions & Concurrency
+- uniqueness 制約や duplicate key error catch + retry なしの read-check-write（例：`where(hash:).first` してから `save!`、concurrent insert を処理せず）
+- unique DB index なしの find-or-create — concurrent call で重複生成
+- atomic な `WHERE old_status = ? UPDATE SET new_status` を使わない status transition — concurrent update で transition が skip / 二重適用される
+- ユーザー制御データに対する unsafe HTML rendering（Rails: .html_safe/raw(); React: dangerouslySetInnerHTML; Vue: v-html; Django: |safe/mark_safe）（XSS）
+
+#### LLM Output Trust Boundary
+- LLM 生成値（email、URL、name）が format 検証なしに DB write / mailer に渡る。永続化前に軽量 guard（`EMAIL_REGEXP`、`URI.parse`、`.strip`）を追加。
+- 構造化された tool 出力（array、hash）が型 / shape check なしに DB write される。
+- LLM 生成 URL が allowlist なしに fetch される — URL が内部 network を指す SSRF risk（Python: `urllib.parse.urlparse` → `requests.get`/`httpx.get` 前に hostname を blocklist で check）
+- LLM 出力が sanitization なしに knowledge base / vector DB に保存される — stored prompt injection risk
+
+#### Shell Injection（Python 固有）
+- `subprocess.run()` / `subprocess.call()` / `subprocess.Popen()` で `shell=True` AND command 文字列に f-string/`.format()` interpolation — 代わりに argument array を使う
+- 変数 interpolation を含む `os.system()` — argument array を使う `subprocess.run()` に置換
+- sandbox なしの LLM 生成コードに対する `eval()` / `exec()`
+
+#### Enum & Value Completeness
+diff が新 enum 値、status 文字列、tier 名、type 定数を導入した場合：
+- **全 consumer に traceする。** その値で switch する、filter する、display する各 file を Read（grep ではなく READ）。新値を扱わない consumer があれば flag。よくある miss：frontend dropdown には値を追加したが backend model/compute method が永続化しない。
+- **allowlist / filter array を check。** sibling 値を含む array や `%w[]` list を search（例：tier に "revise" を追加するなら、`%w[quick lfg mega]` 全てを見つけ、必要な箇所に "revise" が含まれるか検証）。
+- **`case` / `if-elsif` chain を check。** 既存コードが enum に branch していたら、新値が wrong default に落ちないか？
+これを行うには：sibling 値の全参照を Grep（例：tier consumer 全てを見つけるため "lfg" や "mega" を grep）。各 match を Read。本 step は diff の OUTSIDE のコードを読む必要がある。
+
+### Pass 2 — INFORMATIONAL
+
+#### Async/Sync Mixing（Python 固有）
+- `async def` endpoint 内の同期 `subprocess.run()`、`open()`、`requests.get()` — event loop を block する。代わりに `asyncio.to_thread()`、`aiofiles`、`httpx.AsyncClient` を使う。
+- async 関数内の `time.sleep()` — `asyncio.sleep()` を使う
+- async context での `run_in_executor()` wrap なしの sync DB call
+
+#### Column/Field Name Safety
+- ORM query（`.select()`、`.eq()`、`.gte()`、`.order()`）の column 名を実 DB schema に対して検証 — 間違った column 名は silent に空 result を返すか、swallow された error を投げる
+- query 結果に対する `.get()` call が、実際に select された column 名を使っているか check
+- 利用可能なら schema documentation と cross-reference
+
+#### Dead Code & Consistency（version/changelog のみ — 他項目は maintainability specialist が処理）
+- PR title と VERSION/CHANGELOG file 間の version mismatch
+- 変更を不正確に記述する CHANGELOG entry（例：X が存在しなかったのに「changed from X to Y」）
+
+#### LLM Prompt Issues
+- prompt 内の 0-indexed list（LLM は確実に 1-indexed を返す）
+- 利用可能な tool / capability を列挙する prompt text が、実際に `tool_classes`/`tools` array に wire up されたものと一致しない
+- 複数箇所に書かれて drift する可能性がある word/token limit
+
+#### Completeness Gaps
+- 完全版が CC 時間 30 分未満で済む shortcut 実装（例：partial enum handling、不完全な error path、追加が容易な edge case の missing）
+- 人間チーム effort のみで提示された option — 人間と CC+uzustack 両方の時間を表示すべき
+- test coverage gap で、抜けている test を追加することが「ocean」ではなく「lake」（例：negative-path test の欠落、happy-path 構造を mirror する edge case test の欠落）
+- 100% が控えめな追加コードで達成可能な状況での 80-90% 実装
+
+#### Time Window Safety
+- 「today」が 24h を cover すると仮定する date-key lookup — 8am PT の report は today key 配下で midnight→8am のみ見える
+- 関連 feature 間の時間 window mismatch — 一方が hourly bucket、他方が同データに対する daily key
+
+#### Type Coercion at Boundaries
+- Ruby→JSON→JS 境界を跨ぐ値で型が変わり得る箇所（数値 vs 文字列）— hash/digest 入力は型を normalize しなければならない
+- serialization 前に `.to_s` 等を call しない hash/digest 入力 — `{ cores: 8 }` と `{ cores: "8" }` は異なる hash を生む
+
+#### View/Frontend
+- partial 内の inline `<style>` block（render ごとに re-parse）
+- view での O(n*m) lookup（`index_by` hash の代わりに loop 中の `Array#find`）
+- DB result に対する Ruby 側 `.select{}` filter で `WHERE` 句にできるもの（leading-wildcard `LIKE` を意図的に避けている場合を除く）
+
+#### Distribution & CI/CD Pipeline
+- CI/CD workflow 変更（`.github/workflows/`）：build tool version が project 要件と合致するか、artifact 名 / path が正しいか、secret が hardcode ではなく `${{ secrets.X }}` を使っているか検証
+- 新 artifact 種別（CLI binary、library、package）：publish/release workflow が存在し正しい platform を target しているか検証
+- Cross-platform build：CI matrix が全 target OS/arch 組合せを cover しているか、または untested を documented しているか
+- version tag format consistency：`v1.2.3` vs `1.2.3` — VERSION file、git tag、publish script で match しなければならない
+- publish step idempotency：publish workflow を re-run しても fail しないこと（例：`gh release create` の前に `gh release delete`）
+
+**DO NOT flag:**
+- 既存 auto-deploy pipeline を持つ web サービス（Docker build + K8s deploy）
+- チーム外に配布されない internal tool
+- test only な CI 変更（test step 追加、publish step ではない）
+
+---
+
+## Severity 分類
+
+```
+CRITICAL (highest severity):      INFORMATIONAL (main agent):      SPECIALIST (parallel subagents):
+├─ SQL & Data Safety              ├─ Async/Sync Mixing             ├─ Testing specialist
+├─ Race Conditions & Concurrency  ├─ Column/Field Name Safety      ├─ Maintainability specialist
+├─ LLM Output Trust Boundary      ├─ Dead Code (version only)      ├─ Security specialist
+├─ Shell Injection                ├─ LLM Prompt Issues             ├─ Performance specialist
+└─ Enum & Value Completeness      ├─ Completeness Gaps             ├─ Data Migration specialist
+                                   ├─ Time Window Safety            ├─ API Contract specialist
+                                   ├─ Type Coercion at Boundaries   └─ Red Team (conditional)
+                                   ├─ View/Frontend
+                                   └─ Distribution & CI/CD Pipeline
+
+全 findings は Fix-First Review で action される。Severity が
+提示順序と AUTO-FIX vs ASK の分類を決める — critical findings は
+ASK 寄り（より risky）、informational findings は AUTO-FIX 寄り
+（より mechanical）。
+```
+
+---
+
+## Fix-First Heuristic
+
+本 heuristic は `/review` と `/ship` の両方が参照する。agent が finding を auto-fix するかユーザーに ask するかを決定する。
+
+```
+AUTO-FIX (agent fixes without asking):     ASK (needs human judgment):
+├─ Dead code / 未使用変数                  ├─ Security (auth, XSS, injection)
+├─ N+1 query (eager loading 欠落)          ├─ Race condition
+├─ コードと矛盾する古いコメント            ├─ Design 決定
+├─ Magic number → 名前付き定数             ├─ 大きい fix（>20 行）
+├─ LLM output validation 欠落              ├─ Enum completeness
+├─ Version/path mismatch                   ├─ 機能の削除
+├─ assign されたが never read な変数       └─ user-visible な挙動を変える全て
+└─ Inline style、O(n*m) view lookup
+```
+
+**Rule of thumb:** fix が mechanical で、senior engineer が議論なしに適用するなら AUTO-FIX。reasonable な engineer が fix について意見が割れ得るなら ASK。
+
+**Critical findings は ASK 寄り**（本質的に risky）。
+**Informational findings は AUTO-FIX 寄り**（より mechanical）。
+
+---
+
+## Suppressions — flag しない
+
+- 「X は Y と冗長」だが冗長性が無害で可読性を助ける場合（例：`length > 20` と冗長な `present?`）
+- 「この threshold/定数が選ばれた理由を説明する comment を追加せよ」 — threshold は tuning 中に変わり、comment は腐る
+- 「この assertion はもっと tight にできる」だが既に挙動を cover している場合
+- consistency-only な変更を提案（他定数が guard されている形に合わせて値を conditional で wrap）
+- 「regex が edge case X を扱わない」だが入力が constrained で X が実際には起こらない場合
+- 「test が複数 guard を同時に実行している」 — それは fine、test は全 guard を isolate する必要は無い
+- eval threshold 変更（max_actionable、min score）— 経験的に tuning され constantly 変わる
+- 無害な no-op（例：array に never いない要素に対する `.reject`）
+- review 中の diff で **既に対処済の全て** — comment 前に diff を FULL に読む

--- a/review/design-checklist.md
+++ b/review/design-checklist.md
@@ -1,0 +1,134 @@
+# Design Review Checklist (Lite)
+
+> **DESIGN_METHODOLOGY のサブセット** — 本ファイルに項目を追加する際、`scripts/gen-skill-docs.ts` の `generateDesignMethodology()` も update する（逆も同様）。
+
+## Instructions
+
+本 checklist は **diff 内のソースコード** に適用する — render された出力ではない。変更された frontend file（diff hunk だけでなく full file）を読み、anti-pattern を flag する。
+
+**Trigger:** diff が frontend file に触れている場合のみ本 checklist を走らせる。`uzustack-diff-scope` で検出：
+
+```bash
+source <(~/.claude/skills/uzustack/bin/uzustack-diff-scope <base> 2>/dev/null)
+```
+
+`SCOPE_FRONTEND=false` なら、design review 全体を silent に skip。
+
+**DESIGN.md calibration:** repo root に `DESIGN.md` または `design-system.md` が存在すれば、最初に読む。全 findings は project の宣言された design system に対して calibrate される。DESIGN.md で明示的に bless された pattern は flag **しない**。DESIGN.md が無ければ universal な design 原則を使う。
+
+---
+
+## Confidence Tier
+
+各項目は検出 confidence level で tag される：
+
+- **[HIGH]** — grep / pattern match で確実に検出可能。確定的 findings。
+- **[MEDIUM]** — pattern aggregation や heuristic で検出可能。findings として flag するが、ノイズあり想定。
+- **[LOW]** — visual intent の理解が必要。提示形式："Possible issue — visually に検証するか /design-review を走らせる。"
+
+---
+
+## 分類
+
+**AUTO-FIX**（mechanical な CSS fix のみ — HIGH confidence、design judgment 不要）:
+- replacement なしの `outline: none` → `outline: revert` または `&:focus-visible { outline: 2px solid currentColor; }` を追加
+- 新 CSS の `!important` → 削除して specificity を fix
+- body text の `font-size` < 16px → 16px に bump
+
+**ASK**（それ以外全て — design judgment が必要）:
+- AI slop findings 全て、typography 構造、spacing 選択、interaction state gap、DESIGN.md 違反
+
+**LOW confidence 項目** → "Possible: [description]. Visually に検証するか /design-review を走らせる。" で提示。AUTO-FIX しない。
+
+---
+
+## 出力形式
+
+```
+Design Review: N issues (X auto-fixable, Y need input, Z possible)
+
+**AUTO-FIXED:**
+- [file:line] Problem → fix applied
+
+**NEEDS INPUT:**
+- [file:line] Problem description
+  Recommended fix: suggested fix
+
+**POSSIBLE (verify visually):**
+- [file:line] Possible issue — verify with /design-review
+```
+
+任意：`test_stub` — 本 finding に対する project の test framework を使った skeleton test code。
+
+issue が無ければ：`Design Review: No issues found.`
+
+frontend file が変更されていなければ：silent に skip、出力なし。
+
+---
+
+## カテゴリ
+
+### 1. AI Slop 検出（6 項目） — 最優先
+
+これらは respected studio の designer が ship しない、AI 生成 UI の telltale sign である。
+
+- **[MEDIUM]** Purple/violet/indigo の gradient background、または blue-to-purple の color scheme。`#6366f1`–`#8b5cf6` 範囲の値を持つ `linear-gradient`、または purple/violet に解決される CSS custom property を探す。
+
+- **[LOW]** 3-column feature grid：colored circle 内の icon + 太字 title + 2 行 description が対称に 3x 繰り返される pattern。grid/flex container でちょうど 3 children を持ち、各 child が circular element + heading + paragraph を含むものを探す。
+
+- **[HIGH]** section 装飾として colored circle 内の icon。`border-radius: 50%` + 装飾 container として使われる icon 用 background color を持つ要素を探す。
+
+- **[HIGH]** 全て中央寄せ：全 heading、description、card に `text-align: center`。`text-align: center` の密度を grep — text container の >60% が center alignment を使っていれば flag。
+
+- **[MEDIUM]** 全要素に uniform に bubbly な border-radius：card、button、input、container 全てに同じ大きい radius（16px+）が一律適用。`border-radius` 値を aggregate — >80% が同値 ≥16px を使っていれば flag。
+
+- **[MEDIUM]** Generic な hero copy："Welcome to [X]"、"Unlock the power of..."、"Your all-in-one solution for..."、"Revolutionize your..."、"Streamline your workflow"。HTML/JSX content をこれらの pattern で grep。
+
+### 2. Typography（4 項目）
+
+- **[HIGH]** Body text の `font-size` < 16px。`body`、`p`、`.text`、または base style の `font-size` 宣言を grep。16px 未満（base が 16px なら 1rem 未満）の値は flag。
+
+- **[HIGH]** diff で 3 を超える font family 導入。distinct な `font-family` 宣言を数える。変更された file 全体で 3 を超える unique family が現れたら flag。
+
+- **[HIGH]** Heading hierarchy の level skip：同じ file/component 内で `h1` の後に `h2` 無く `h3`。HTML/JSX で heading tag を check。
+
+- **[HIGH]** Blacklist された font：Papyrus、Comic Sans、Lobster、Impact、Jokerman。`font-family` をこれらの名前で grep。
+
+### 3. Spacing & Layout（4 項目）
+
+- **[MEDIUM]** DESIGN.md が spacing scale を指定する場合、4px / 8px scale でない arbitrary spacing 値。`margin`、`padding`、`gap` 値を宣言された scale に対して check。DESIGN.md が scale を define している場合のみ flag。
+
+- **[MEDIUM]** responsive 処理なしの fixed width：container に `width: NNNpx`、`max-width` も `@media` breakpoint も無い。mobile で水平 scroll の risk。
+
+- **[MEDIUM]** text container に `max-width` 欠落：body text や paragraph container に `max-width` が設定されておらず、行が >75 文字になる。text wrapper の `max-width` を check。
+
+- **[HIGH]** 新 CSS rule の `!important`。追加行で `!important` を grep。ほぼ常に specificity の escape hatch であり、適切に fix されるべき。
+
+### 4. Interaction State（3 項目）
+
+- **[MEDIUM]** Interactive element（button、link、input）に hover/focus state 欠落。新 interactive element style に `:hover` と `:focus` または `:focus-visible` の pseudo-class が存在するか check。
+
+- **[HIGH]** `outline: none` または `outline: 0` で replacement focus indicator なし。`outline:\s*none` または `outline:\s*0` を grep。これは keyboard accessibility を奪う。
+
+- **[LOW]** Interactive element の touch target < 44px。button と link の `min-height`/`min-width`/`padding` を check。複数 property から effective size を計算する必要があり — コードのみでは low confidence。
+
+### 5. DESIGN.md 違反（3 項目、conditional）
+
+`DESIGN.md` または `design-system.md` が存在する場合のみ適用：
+
+- **[MEDIUM]** 宣言された palette に無い color。変更 CSS の color 値を DESIGN.md で define された palette と比較。
+
+- **[MEDIUM]** 宣言された typography section に無い font。`font-family` 値を DESIGN.md の font list と比較。
+
+- **[MEDIUM]** 宣言された scale 外の spacing 値。`margin`/`padding`/`gap` 値を DESIGN.md の spacing scale と比較。
+
+---
+
+## Suppressions
+
+flag しない：
+- DESIGN.md で意図的選択として明示的に documented された pattern
+- Third-party / vendor CSS file（node_modules、vendor directory）
+- CSS reset や normalize stylesheet
+- Test fixture file
+- Generated / minified CSS

--- a/review/greptile-triage.md
+++ b/review/greptile-triage.md
@@ -1,0 +1,220 @@
+# Greptile Comment Triage
+
+GitHub PR 上の Greptile review コメントを fetch / filter / classify する共有 reference。`/review`（Step 2.5）と `/ship`（Step 3.75）の両方が本 doc を参照する。
+
+---
+
+## Fetch
+
+PR を検出してコメントを fetch する以下のコマンドを実行する。両 API call は並列に走る。
+
+```bash
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null)
+PR_NUMBER=$(gh pr view --json number --jq '.number' 2>/dev/null)
+```
+
+**いずれかが失敗または空：** Greptile triage を silent に skip。本 integration は additive — 無くても workflow は動く。
+
+```bash
+# 行レベルの review コメントと top-level PR コメントを並列 fetch
+gh api repos/$REPO/pulls/$PR_NUMBER/comments \
+  --jq '.[] | select(.user.login == "greptile-apps[bot]") | select(.position != null) | {id: .id, path: .path, line: .line, body: .body, html_url: .html_url, source: "line-level"}' > /tmp/greptile_line.json &
+gh api repos/$REPO/issues/$PR_NUMBER/comments \
+  --jq '.[] | select(.user.login == "greptile-apps[bot]") | {id: .id, body: .body, html_url: .html_url, source: "top-level"}' > /tmp/greptile_top.json &
+wait
+```
+
+**API error または両 endpoint で Greptile コメントゼロ：** silent に skip。
+
+行レベルコメントの `position != null` filter は、force-push されたコードからの outdated コメントを自動的に skip する。
+
+---
+
+## Suppressions Check
+
+project 固有の history path を derive：
+```bash
+REMOTE_SLUG=$(browse/bin/remote-slug 2>/dev/null || ~/.claude/skills/uzustack/browse/bin/remote-slug 2>/dev/null || basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")
+PROJECT_HISTORY="$HOME/.uzustack/projects/$REMOTE_SLUG/greptile-history.md"
+```
+
+`$PROJECT_HISTORY` が存在すれば読む（per-project な suppressions）。各行は過去の triage 結果を記録：
+
+```
+<date> | <repo> | <type:fp|fix|already-fixed> | <file-pattern> | <category>
+```
+
+**カテゴリ**（固定 set）：`race-condition`、`null-check`、`error-handling`、`style`、`type-safety`、`security`、`performance`、`correctness`、`other`
+
+各 fetched コメントを以下を満たす entry に対して match：
+- `type == fp`（既知の偽陽性のみ suppress、過去に fix された real な issue は対象外）
+- `repo` が現 repo に match
+- `file-pattern` がコメントの file path に match
+- `category` がコメントの issue type に match
+
+match した comment は **SUPPRESSED** として skip。
+
+history file が存在しない、または parse 不可な行があれば、その行を skip して continue — 不正な history file で決して fail しない。
+
+---
+
+## Classify
+
+非 suppressed な各コメントについて：
+
+1. **行レベルコメント:** 指定された `path:line` の file と周辺 context（±10 行）を読む
+2. **Top-level コメント:** コメント body 全文を読む
+3. コメントを full diff（`git diff origin/main`）と review checklist に対して cross-reference
+4. 分類：
+   - **VALID & ACTIONABLE** — 現コードに存在する real bug、race condition、security issue、correctness problem
+   - **VALID BUT ALREADY FIXED** — branch 上の subsequent commit で対処済の real issue。fixing commit SHA を特定。
+   - **FALSE POSITIVE** — コメントがコードを誤解、他で処理されているものを flag、または stylistic noise
+   - **SUPPRESSED** — 上の suppressions check で既に filter
+
+---
+
+## Reply API
+
+Greptile コメントに reply する際、コメント source に応じた endpoint を使う：
+
+**行レベルコメント**（`pulls/$PR/comments` 由来）：
+```bash
+gh api repos/$REPO/pulls/$PR_NUMBER/comments/$COMMENT_ID/replies \
+  -f body="<reply text>"
+```
+
+**Top-level コメント**（`issues/$PR/comments` 由来）：
+```bash
+gh api repos/$REPO/issues/$PR_NUMBER/comments \
+  -f body="<reply text>"
+```
+
+**reply POST が fail した場合**（例：PR が close 済、write permission なし）：警告して continue。fail した reply で workflow を停止しない。
+
+---
+
+## Reply Template
+
+全 Greptile reply にこれらの template を使う。常に具体的な evidence を含む — 曖昧な reply は決して post しない。
+
+### Tier 1（First response） — friendly、evidence 込み
+
+**FIXES（ユーザーが issue を fix することを選択）:**
+
+```
+**Fixed** in `<commit-sha>`.
+
+\`\`\`diff
+- <old problematic line(s)>
++ <new fixed line(s)>
+\`\`\`
+
+**Why:** <何が wrong だったか、fix がどう対処するかの 1 文説明>
+```
+
+**ALREADY FIXED（branch の prior commit で対処済）:**
+
+```
+**Already fixed** in `<commit-sha>`.
+
+**What was done:** <既存 commit がこの issue にどう対処するかの 1-2 文>
+```
+
+**FALSE POSITIVE（コメントが間違っている）:**
+
+```
+**Not a bug.** <なぜ間違っているかを直接述べる 1 文>
+
+**Evidence:**
+- <pattern が安全/正しいことを示す具体的コード参照>
+- <例：「nil check は `ActiveRecord::FinderMethods#find` が処理する、これは nil ではなく RecordNotFound を raise する」>
+
+**Suggested re-rank:** これは `<style|noise|misread>` issue であり、`<Greptile が呼んだもの>` ではないと思われる。severity を下げることを検討してほしい。
+```
+
+### Tier 2（Greptile が prior reply 後に re-flag） — firm、overwhelming evidence
+
+下記の escalation detection が同じ thread での先の uzustack reply を識別したときに Tier 2 を使う。議論を closing するため最大 evidence を含める。
+
+```
+**This has been reviewed and confirmed as [intentional/already-fixed/not-a-bug].**
+
+\`\`\`diff
+<変更または safe pattern を示す full diff>
+\`\`\`
+
+**Evidence chain:**
+1. <safe pattern または fix を示す file:line permalink>
+2. <該当する場合、対処された commit SHA>
+3. <該当する場合、architecture rationale または design 決定>
+
+**Suggested re-rank:** Please recalibrate — これは `<actual category>` issue であり `<claimed category>` ではない。[該当する file 変更 permalink へのリンク]
+```
+
+---
+
+## Escalation Detection
+
+reply を作成する前に、本コメント thread に prior uzustack reply が存在するか check：
+
+1. **行レベルコメント:** `gh api repos/$REPO/pulls/$PR_NUMBER/comments/$COMMENT_ID/replies` で reply を fetch。任意の reply body に uzustack marker が含まれるか check：`**Fixed**`、`**Not a bug.**`、`**Already fixed**`。
+
+2. **Top-level コメント:** Greptile コメント後に post された reply を fetched issue comments から scan、uzustack marker を含むかチェック。
+
+3. **prior uzustack reply が存在し AND Greptile が同じ file+category に再度 post：** Tier 2（firm）template を使う。
+
+4. **prior uzustack reply が存在しない:** Tier 1（friendly）template を使う。
+
+escalation detection が fail（API error、曖昧 thread）した場合、Tier 1 に fallback。曖昧さで escalation しない。
+
+---
+
+## Severity Assessment & Re-ranking
+
+コメント分類時に、Greptile の暗黙 severity が現実と合致しているかも assess する：
+
+- Greptile が **security/correctness/race-condition** issue として flag したが、実際には **style/performance** nit な場合：reply に `**Suggested re-rank:**` を含め、category 訂正を求める。
+- Greptile が低 severity の style issue を critical のように flag したら：reply で push back する。
+- re-ranking が warranted な理由を常に具体的に — 意見ではなくコードと行番号を引用。
+
+---
+
+## History File 書き込み
+
+書き込み前に両 directory が存在することを確保：
+```bash
+REMOTE_SLUG=$(browse/bin/remote-slug 2>/dev/null || ~/.claude/skills/uzustack/browse/bin/remote-slug 2>/dev/null || basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")
+mkdir -p "$HOME/.uzustack/projects/$REMOTE_SLUG"
+mkdir -p ~/.uzustack
+```
+
+各 triage 結果につき **両** file（per-project は suppressions 用、global は retro 用）に 1 行 append：
+- `~/.uzustack/projects/$REMOTE_SLUG/greptile-history.md`（per-project）
+- `~/.uzustack/greptile-history.md`（global aggregate）
+
+形式：
+```
+<YYYY-MM-DD> | <owner/repo> | <type> | <file-pattern> | <category>
+```
+
+例：
+```
+2026-03-13 | uzumaki-inc/myapp | fp | app/services/auth_service.rb | race-condition
+2026-03-13 | uzumaki-inc/myapp | fix | app/models/user.rb | null-check
+2026-03-13 | uzumaki-inc/myapp | already-fixed | lib/payments.rb | error-handling
+```
+
+---
+
+## 出力形式
+
+出力 header に Greptile summary を含める：
+```
++ N Greptile comments (X valid, Y fixed, Z FP)
+```
+
+各分類済コメントについて、表示：
+- 分類 tag：`[VALID]`、`[FIXED]`、`[FALSE POSITIVE]`、`[SUPPRESSED]`
+- file:line 参照（行レベル）または `[top-level]`（top-level）
+- 1 行 body summary
+- Permalink URL（`html_url` field）

--- a/review/specialists/api-contract.md
+++ b/review/specialists/api-contract.md
@@ -1,0 +1,49 @@
+# API Contract Specialist Review Checklist
+
+Scope: SCOPE_API=true のとき
+Output: JSON object、1 finding 1 行。Schema:
+{"severity":"CRITICAL|INFORMATIONAL","confidence":N,"path":"file","line":N,"category":"api-contract","summary":"...","fix":"...","fingerprint":"path:line:api-contract","specialist":"api-contract"}
+任意：line、fix、fingerprint、evidence、test_stub。
+findings なし：`NO FINDINGS` のみ出力。
+
+---
+
+## カテゴリ
+
+### Breaking Changes
+- response body から field 削除（client が依存しているかも）
+- field の型変更（string → number、object → array）
+- 既存 endpoint に新規必須 parameter を追加
+- HTTP method 変更（GET → POST）または status code 変更（200 → 201）
+- 旧 path を redirect/alias として残さず endpoint 名変更
+- 認証要件の変更（public → authenticated）
+
+### Versioning Strategy
+- version bump（v1 → v2）なしの破壊的変更
+- 同 API 内に複数の versioning 戦略を混在（URL vs header vs query param）
+- sunset timeline / migration guide 無しの deprecated endpoint
+- controller 全体に散らばる version-specific logic、中央集約されていない
+
+### Error Response Consistency
+- 既存と異なる error format を返す新 endpoint
+- 標準 field（error code、message、details）を欠く error response
+- error type に match しない HTTP status code（error に 200、validation に 500）
+- 内部実装詳細を leak する error message（stack trace、SQL）
+
+### Rate Limiting & Pagination
+- 類似 endpoint に rate limit があるのに新 endpoint には欠落
+- backwards compatibility なしの pagination 変更（offset → cursor）
+- 文書化なしの page size / default limit 変更
+- paginated response に total count や next-page indicator が欠落
+
+### Documentation Drift
+- 新 endpoint や変更 param に合わせて update されていない OpenAPI/Swagger spec
+- 変更後も旧挙動を記述する README / API doc
+- 動かなくなった example request/response
+- 新 endpoint や変更 parameter の文書化欠落
+
+### Backwards Compatibility
+- 旧 version の client：壊れるか？
+- force-update できない mobile app：API はまだ動くか？
+- 購読者通知なしの webhook payload 変更
+- 新機能利用に必要な SDK / client library 変更

--- a/review/specialists/data-migration.md
+++ b/review/specialists/data-migration.md
@@ -1,0 +1,48 @@
+# Data Migration Specialist Review Checklist
+
+Scope: SCOPE_MIGRATIONS=true のとき
+Output: JSON object、1 finding 1 行。Schema:
+{"severity":"CRITICAL|INFORMATIONAL","confidence":N,"path":"file","line":N,"category":"data-migration","summary":"...","fix":"...","fingerprint":"path:line:data-migration","specialist":"data-migration"}
+任意：line、fix、fingerprint、evidence、test_stub。
+findings なし：`NO FINDINGS` のみ出力。
+
+---
+
+## カテゴリ
+
+### Reversibility
+- 本 migration はデータ損失なしで rollback できるか？
+- 対応する down/rollback migration があるか？
+- rollback が実際に変更を undo するか、それとも no-op か？
+- rollback すると現アプリケーションコードが壊れないか？
+
+### Data Loss Risk
+- データを保持する column を削除（先に deprecation 期間を）
+- データを切り詰める column 型変更（varchar(255) → varchar(50)）
+- 参照コードが無いことを検証せずに table を削除
+- 全参照（ORM、raw SQL、view）を更新せずに column rename
+- 既存 NULL 値を持つ column に NOT NULL 制約を追加（先に backfill 必要）
+
+### Lock Duration
+- 大 table に対する CONCURRENTLY なしの ALTER TABLE（PostgreSQL）
+- 100K 超 row の table に対する CONCURRENTLY なしの index 追加
+- 1 つの lock 取得に combine できる複数 ALTER TABLE
+- peak traffic 時間帯に exclusive lock を取得する schema 変更
+
+### Backfill Strategy
+- DEFAULT 値なしの新 NOT NULL column（制約前に backfill 必要）
+- batch 投入が必要な computed default を持つ新 column
+- 既存 record 用 backfill script / rake task が欠落
+- batch せず全 row を一度に update する backfill（table を lock）
+
+### Index Creation
+- production table への CONCURRENTLY なし CREATE INDEX
+- 重複 index（新 index が既存と同 column を cover）
+- 新 foreign key column に index 欠落
+- full index の方が有用な箇所での partial index（または逆）
+
+### Multi-Phase Safety
+- application code と特定順序で deploy する必要がある migration
+- 現 running code を壊す schema 変更（先にコード deploy、その後 migrate）
+- deploy 境界を仮定する migration（旧コード + 新 schema = crash）
+- rolling deploy 中の旧/新コード混在を扱う feature flag が欠落

--- a/review/specialists/maintainability.md
+++ b/review/specialists/maintainability.md
@@ -1,0 +1,46 @@
+# Maintainability Specialist Review Checklist
+
+Scope: 常時（全 review）
+Output: JSON object、1 finding 1 行。Schema:
+{"severity":"INFORMATIONAL","confidence":N,"path":"file","line":N,"category":"maintainability","summary":"...","fix":"...","fingerprint":"path:line:maintainability","specialist":"maintainability"}
+任意：line、fix、fingerprint、evidence、test_stub。
+findings なし：`NO FINDINGS` のみ出力。
+
+---
+
+## カテゴリ
+
+### Dead Code & Unused Imports
+- 変更 file 内で assign されたが never read な変数
+- define されたが never call な function/method（repo 全体に対して Grep で check）
+- 変更後参照されなくなった import/require
+- comment-out されたコードブロック（削除するか、なぜ存在するか説明）
+
+### Magic Numbers & String Coupling
+- logic で使われる bare な数値リテラル（threshold、limit、retry count）— 名前付き定数にすべき
+- query filter / 条件として他所で使われる error message 文字列
+- config にすべき hardcode された URL、port、hostname
+- 複数 file 間で重複するリテラル値
+
+### Stale Comments & Docstrings
+- 本 diff でコードが変更された後も旧挙動を記述する comment
+- 完了済の作業を参照する TODO/FIXME comment
+- 現関数 signature と一致しない parameter list の docstring
+- もはやコード flow と一致しない comment 内 ASCII 図
+
+### DRY Violations
+- diff 内で複数回現れる類似コードブロック（3 行以上）
+- 共有 helper の方が clean な copy-paste pattern
+- test file 間で重複する config / setup logic
+- lookup table / map にできる繰り返し条件 chain
+
+### Conditional Side Effects
+- 条件で branch するが片方の branch で side effect を忘れたコード path
+- action 発生を主張するが action が条件的に skip された log message
+- 一方の branch が関連 record を update するが他方が update しない state transition
+- happy path のみ fire し、error / edge path で missing な event 発火
+
+### Module Boundary Violations
+- 別 module の内部実装に reach（private-by-convention method への access）
+- service/model を経由すべきが controller/view 内で直接 DB query
+- interface 経由で通信すべき component 間の tight coupling

--- a/review/specialists/performance.md
+++ b/review/specialists/performance.md
@@ -1,0 +1,52 @@
+# Performance Specialist Review Checklist
+
+Scope: SCOPE_BACKEND=true OR SCOPE_FRONTEND=true のとき
+Output: JSON object、1 finding 1 行。Schema:
+{"severity":"CRITICAL|INFORMATIONAL","confidence":N,"path":"file","line":N,"category":"performance","summary":"...","fix":"...","fingerprint":"path:line:performance","specialist":"performance"}
+任意：line、fix、fingerprint、evidence、test_stub。
+findings なし：`NO FINDINGS` のみ出力。
+
+---
+
+## カテゴリ
+
+### N+1 Queries
+- eager loading（.includes、joinedload、include）なしに loop で traverse される ActiveRecord/ORM 関連
+- batch 化できる iteration block（each、map、forEach）内の DB query
+- lazy-loaded 関連を trigger する nested serializer
+- batch せず field ごとに query する GraphQL resolver（DataLoader 利用を check）
+
+### Missing Database Indexes
+- index なしの column に対する新 WHERE 句（migration file / schema を check）
+- index されていない column に対する新 ORDER BY
+- composite index なしの composite query（WHERE a AND b）
+- index なしで追加された foreign key column
+
+### Algorithmic Complexity
+- O(n^2) 以上の pattern：collection に対する nested loop、Array.map 内の Array.find
+- hash/map/set lookup を使えば良い反復線形 search
+- loop 内の string concatenation（join や StringBuilder を使う）
+- 1 回で済む大 collection の sort/filter を複数回行う
+
+### Bundle Size Impact (Frontend)
+- 既知の重い production dependency 追加（moment.js、lodash full、jquery）
+- deep import（'library/specific' から）ではなく barrel import（'library' から）
+- 最適化なしで commit された大 static asset（image、font）
+- route レベル chunk の code splitting 欠落
+
+### Rendering Performance (Frontend)
+- Fetch waterfall：parallel（Promise.all）にできる sequential API call
+- unstable な参照（render 内の新 object/array）からの不要 re-render
+- 高コスト computation での React.memo、useMemo、useCallback 欠落
+- loop で DOM property を read してから write することによる layout thrashing
+- below-fold image での `loading="lazy"` 欠落
+
+### Missing Pagination
+- unbounded result を返す list endpoint（LIMIT なし、pagination param なし）
+- データ量と共に成長する LIMIT なし DB query
+- ID と expansion ではなく full nested object を embed する API response
+
+### Blocking in Async Contexts
+- async 関数内の synchronous I/O（file read、subprocess、HTTP request）
+- event-loop based handler 内の time.sleep() / Thread.sleep()
+- worker offload なしに main thread を block する CPU 集約 computation

--- a/review/specialists/red-team.md
+++ b/review/specialists/red-team.md
@@ -1,0 +1,45 @@
+# Red Team Review
+
+Scope: diff > 200 行 OR security specialist が CRITICAL findings を発見したとき。他 specialists の AFTER に走る。
+Output: JSON object、1 finding 1 行。Schema:
+{"severity":"CRITICAL|INFORMATIONAL","confidence":N,"path":"file","line":N,"category":"red-team","summary":"...","fix":"...","fingerprint":"path:line:red-team","specialist":"red-team"}
+任意：line、fix、fingerprint、evidence、test_stub。
+findings なし：`NO FINDINGS` のみ出力。
+
+---
+
+これは checklist review **ではない**。adversarial 分析である。
+
+他 specialists の findings に access できる（prompt で提供される）。あなたの仕事は彼らが **見逃した** ものを見つけること。攻撃者、chaos engineer、敵対的 QA tester として同時に考える。
+
+## Approach
+
+### 1. Happy Path を攻撃
+- 通常 load の 10 倍下で何が起きるか？
+- 同 resource に同時に 2 request が当たるとどうなるか？
+- DB が遅い（query >5 秒）ときどうなるか？
+- 外部サービスが garbage を返すとどうなるか？
+
+### 2. Silent Failure を見つける
+- 例外を swallow する error handling（log だけの catch-all）
+- 部分的に complete し得る operation（5 件中 3 件処理してから crash）
+- failure 時に inconsistent state に record を残す state transition
+- 誰にも alert せず fail する background job
+
+### 3. 信頼の前提を Exploit する
+- frontend で validate されたが backend では未検証なデータ
+- 認証なしに call される internal API（「自分のコードしか call しない」前提）
+- 存在を仮定するが validate されない config 値
+- 入力 sanitization なしに user input から構築される file path や URL
+
+### 4. Edge Case を破る
+- 最大入力 size でどうなるか？
+- ゼロ件、空文字列、null 値でどうなるか？
+- 史上初の run（既存データなし）でどうなるか？
+- ユーザーが 100ms で button を 2 回 click したらどうなるか？
+
+### 5. 他 Specialists が見逃したものを探す
+- 各 specialist の findings を review。彼らのカテゴリ間の gap は？
+- cross-category issue を探す（例：security でもある performance issue）
+- integration 境界（2 system が接続する箇所）の issue を探す
+- 特定 deploy 構成でのみ manifest する issue を探す

--- a/review/specialists/security.md
+++ b/review/specialists/security.md
@@ -1,0 +1,61 @@
+# Security Specialist Review Checklist
+
+Scope: SCOPE_AUTH=true OR (SCOPE_BACKEND=true AND diff > 100 行) のとき
+Output: JSON object、1 finding 1 行。Schema:
+{"severity":"CRITICAL|INFORMATIONAL","confidence":N,"path":"file","line":N,"category":"security","summary":"...","fix":"...","fingerprint":"path:line:security","specialist":"security"}
+任意：line、fix、fingerprint、evidence、test_stub。
+findings なし：`NO FINDINGS` のみ出力。
+
+---
+
+本 checklist は main CRITICAL pass より深く入る。main agent は既に SQL injection、race condition、LLM trust、enum completeness を check 済。本 specialist は auth/authz pattern、cryptographic 誤用、attack surface 拡張に focus する。
+
+## カテゴリ
+
+### Input Validation at Trust Boundaries
+- controller/handler レベルで validation なしに受け入れられる user input
+- DB query / file path で直接使われる query parameter
+- 型 check / schema validation なしに受け入れられる request body field
+- 型/size/content 検証なしの file upload
+- signature verification なしに処理される webhook payload
+
+### Auth & Authorization Bypass
+- 認証 middleware を欠く endpoint（route 定義を check）
+- 「deny」ではなく「allow」を default とする authorization check
+- role 昇格 path（user が自身の role/permission を modify できる）
+- 直接 object reference 脆弱性（user A が ID 変更で user B のデータに access）
+- session fixation / session hijacking の機会
+- 期限切れを check しない token / API key validation
+
+### Injection Vector（SQL 以外）
+- user 制御 argument を持つ subprocess call による command injection
+- user input を含む template injection（Jinja2、ERB、Handlebars）
+- directory query での LDAP injection
+- user 制御 URL を経由した SSRF（fetch、redirect、webhook target）
+- user 制御 file path 経由の path traversal（../../etc/passwd）
+- HTTP header の user 制御値経由の header injection
+
+### Cryptographic Misuse
+- security-sensitive 操作に弱い hash algorithm（MD5、SHA1）
+- token / secret に予測可能な乱数（Math.random、rand()）
+- secret / token / digest に対する非定数時間比較（==）
+- hardcode された暗号化 key / IV
+- password hash の salt 欠落
+
+### Secrets Exposure
+- ソースコード（comment 内も）の API key、token、password
+- アプリケーション log や error message に log される secret
+- URL 内の credential（query parameter または URL の basic auth）
+- user に返される error response 内の sensitive data
+- 暗号化が想定される PII の plaintext 保存
+
+### XSS via Escape Hatch
+- Rails: user 制御データへの .html_safe、raw()
+- React: user content への dangerouslySetInnerHTML
+- Vue: user content への v-html
+- Django: user input への |safe、mark_safe()
+- 一般：未 sanitize データへの innerHTML 代入
+
+### Deserialization
+- untrusted data の deserialization（pickle、Marshal、YAML.load、executable type の JSON.parse）
+- schema validation なしに user input / 外部 API から serialize された object を受け入れ

--- a/review/specialists/testing.md
+++ b/review/specialists/testing.md
@@ -1,0 +1,46 @@
+# Testing Specialist Review Checklist
+
+Scope: 常時（全 review）
+Output: JSON object、1 finding 1 行。Schema:
+{"severity":"CRITICAL|INFORMATIONAL","confidence":N,"path":"file","line":N,"category":"testing","summary":"...","fix":"...","fingerprint":"path:line:testing","specialist":"testing"}
+任意：line、fix、fingerprint、evidence、test_stub。
+findings なし：`NO FINDINGS` のみ出力。
+
+---
+
+## カテゴリ
+
+### Missing Negative-Path Tests
+- error / rejection / 不正 input を扱う新コード path で対応 test 無し
+- guard clause / early return が untested
+- try/catch、rescue、error boundary 内の error branch で failure-path test 無し
+- コードで assert される permission / auth check で「denied」case が決して test されない
+
+### Missing Edge-Case Coverage
+- 境界値：ゼロ、負、max-int、空文字列、空 array、nil/null/undefined
+- 単一要素 collection（loop の off-by-one）
+- user 向け input の Unicode と特殊文字
+- race condition test 無しの concurrent access pattern
+
+### Test Isolation Violations
+- mutable state（class 変数、global singleton、cleanup されない DB record）を共有する test
+- 順序依存 test（順番通りなら pass、randomize すると fail）
+- system clock、timezone、locale に依存する test
+- stub/mock を使わず実 network call を行う test
+
+### Flaky Test Patterns
+- timing 依存 assertion（sleep、setTimeout、tight timeout 付き waitFor）
+- unordered result の順序に対する assertion（hash key、Set iteration、async resolution 順）
+- fallback なしに外部サービス（API、DB）に依存する test
+- seed 制御なしの randomized test data
+
+### Security Enforcement Tests Missing
+- 「unauthorized」case test 無しの controller の auth/authz check
+- 実際に block することを証明する test 無しの rate limiting logic
+- malicious input test 無しの input sanitization
+- integration test 無しの CSRF/CORS 設定
+
+### Coverage Gaps
+- test coverage ゼロの新 public method/function
+- 既存 test が旧挙動のみ cover し新 branch を cover しない変更 method
+- 複数箇所から call されるが間接的にしか test されない utility 関数

--- a/scripts/resolvers/index.ts
+++ b/scripts/resolvers/index.ts
@@ -44,4 +44,14 @@ export const RESOLVERS: Record<string, ResolverFn> = {
   PLAN_FILE_REVIEW_REPORT: (_ctx, _args) => '',
   // Phase 4+ で finding の信頼度評価 calibration 指示文を返す予定（Phase 4 / cso・review・ship 等の severity 評価系 skill 連携）
   CONFIDENCE_CALIBRATION: (_ctx, _args) => '',
+  // Phase 4+ で adversarial step（red-team / failure-mode 探索）指示文を返す予定（Phase 4 / review・ship 連携）
+  ADVERSARIAL_STEP: (_ctx, _args) => '',
+  // Phase 4+ で cross-review 間の重複 finding 統合指示文を返す予定（Phase 4 / review 内の specialists / external review 連携）
+  CROSS_REVIEW_DEDUP: (_ctx, _args) => '',
+  // Phase 4+ で plan 完了 audit（review 文脈）指示文を返す予定（Phase 4 / plan file 連鎖、review skill 用）
+  PLAN_COMPLETION_AUDIT_REVIEW: (_ctx, _args) => '',
+  // Phase 4+ で specialists 群（testing / security / performance 等）並列起動指示文を返す予定（Phase 4 / review skill の review army 機構）
+  REVIEW_ARMY: (_ctx, _args) => '',
+  // Phase 4+ で plan からのスコープ drift 検出指示文を返す予定（Phase 4 / review・ship 連携の scope guard）
+  SCOPE_DRIFT: (_ctx, _args) => '',
 };


### PR DESCRIPTION
## Summary

Phase 3.5 step-59 = `review` skill 翻訳。C4 cluster 2/4。

`_upstream/gstack/review/` を Type 1 として翻訳し、repo top の `review/` に配置。
SKILL.md.tmpl 288 行 + 4 top docs（checklist 176 / design-checklist 134 / greptile-triage 220 / TODOS-format 62）+ 7 specialists（45-61 行/件）= 計 12 doc。

## scripts/resolvers/index.ts 変更
- 5 件の Phase 4+ stub 追加：ADVERSARIAL_STEP / CROSS_REVIEW_DEDUP / PLAN_COMPLETION_AUDIT_REVIEW / REVIEW_ARMY / SCOPE_DRIFT

## 翻訳判断

- 業界固有 identifier（SQL / TOCTOU / N+1 / SSRF / XSS / CSRF / OWASP / DataLoader 等）= 英語維持
- inline marker（CRITICAL / INFORMATIONAL / VALID / AUTO-FIXED 等）= 英語維持
- specialist Schema JSON identifier = 英語維持
- triggers = 英語 + 日本語拡張、`allowed-tools` 9 件保持（step-58 学び）
- Greptile reply marker（**Fixed** / **Already fixed** 等）= 英語維持（GitHub PR 公開コメント）
- gstack → uzustack 機械置換：`gstack-diff-scope` / `bin/gstack-next-version` / `gstack-review-log` / `~/.gstack/projects/` / `~/.gstack/greptile-history.md` / example owner `garrytan/myapp` → `uzumaki-inc/myapp` / Tier 2 escalation marker `GStack` → `uzustack`

## 動作確認

- `bun run gen:skill-docs --host claude` → review/SKILL.md GENERATED
- `bun test test/skill-validation.test.ts` → 318 pass
- gstack 残存ゼロ確認

## Test plan

- [x] SKILL.md.tmpl + 4 top docs + 7 specialists 翻訳
- [x] scripts/resolvers/index.ts に 5 stub 追加
- [x] gen:skill-docs / skill-validation 通過
- [x] gstack → uzustack 機械置換漏れなし
- [x] frontmatter allowed-tools 9 件保持
- [x] /simplify を 2 周完了（1 周目 clean / 2 周目 clean、frontmatter allowed-tools 9 件保持確認）

Closes #85
