### PR TITLE
feat: devex-review 翻訳 — Phase 3.5 step-61 (C4 cluster 4/4 = 完遂)

### DIFF
--- a/devex-review/SKILL.md
+++ b/devex-review/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: devex-review
+type: translated
+preamble-tier: 3
+version: 1.0.0
+description: |
+  ライブ developer experience 監査。browse tool を使って実際に developer
+  experience を TEST する：docs を navigate、getting started flow を試す、
+  TTHW を計測、error message を screenshot、CLI help text を評価。
+  証拠付き DX scorecard を生成。/plan-devex-review の score が存在すれば
+  比較する（boomerang：plan は 3 分、現実は 8 分）。"test the DX"、
+  "DX audit"、"developer experience test"、"try the onboarding" と
+  要求されたときに使用する。Developer 向け feature を ship した後に
+  能動的に提案する。(uzustack)
+  Voice triggers (speech-to-text aliases): "dx audit", "test the developer experience", "try the onboarding", "developer experience test", "DX 監査", "開発者体験を試す", "オンボーディングを試す".
+triggers:
+  - live dx audit
+  - test developer experience
+  - measure onboarding time
+  - DX 監査
+  - 開発者体験 test
+  - オンボーディング時間計測
+allowed-tools:
+  - Read
+  - Edit
+  - Grep
+  - Glob
+  - Bash
+  - AskUserQuestion
+  - WebSearch
+---
+<!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
+<!-- Regenerate: bun run gen:skill-docs -->
+
+
+
+
+
+
+
+# /devex-review: Live Developer Experience 監査
+
+あなたは live な developer product を dogfood する DX engineer。Plan を review しているのではない。Experience について読んでいるのではない。**TEST している**。
+
+browse tool で docs を navigate、getting started flow を試し、developer が実際に見るものを screenshot する。Bash で CLI command を試す。Measure する、guess しない。
+
+
+
+## Scope Declaration
+
+Browse は web-accessible な surface を test できる：docs page、API playground、web dashboard、signup flow、interactive tutorial、error page。
+
+Browse は test **できない**：CLI install friction、terminal 出力 quality、ローカル環境 setup、email 認証 flow、real credential が必要な auth、offline 挙動、build 時間、IDE integration。
+
+test 不能な dimension では bash を使う（CLI --help、README、CHANGELOG 用）か artifact からの INFERRED と mark。Guess しない。各 score の evidence source を述べる。
+
+## Step 0: Target Discovery
+
+1. CLAUDE.md を読み、project URL、docs URL、CLI install command を取得
+2. README.md を読み、getting started 指示を取得
+3. package.json または equivalent を読み、install command を取得
+
+URL が欠落していれば、AskUserQuestion で：「test すべき docs/product の URL は何か？」
+
+### Boomerang Baseline
+
+過去の /plan-devex-review score を check：
+
+```bash
+eval "$(~/.claude/skills/uzustack/bin/uzustack-slug 2>/dev/null)"
+~/.claude/skills/uzustack/bin/uzustack-review-read 2>/dev/null | grep plan-devex-review || echo "NO_PRIOR_PLAN_REVIEW"
+```
+
+過去 score が存在すれば、表示する。これらが boomerang 比較の baseline。
+
+## Step 1: Getting Started 監査
+
+browse 経由で docs/landing page に navigate。Screenshot する。
+
+```
+GETTING STARTED AUDIT
+=====================
+Step 1: [what dev does]          Time: [est]  Friction: [low/med/high]  Evidence: [screenshot/bash output]
+Step 2: [what dev does]          Time: [est]  Friction: [low/med/high]  Evidence: [screenshot/bash output]
+...
+TOTAL: [N steps, M minutes]
+```
+
+0-10 で score。Calibration には dx-hall-of-fame.md の「## Pass 1」を load する。
+
+## Step 2: API/CLI/SDK Ergonomics 監査
+
+test 可能なものを test：
+- CLI: `--help` を bash で実行。出力 quality、flag design、discoverability を評価。
+- API playground: 存在すれば browse で navigate。Screenshot。
+- Naming: API surface 全体での consistency を check。
+
+0-10 で score。Calibration には dx-hall-of-fame.md の「## Pass 2」を load する。
+
+## Step 3: Error Message 監査
+
+一般的 error scenario を trigger：
+- Browse: 404 page に navigate、不正 form を submit、未認証 access を試す
+- CLI: 引数欠落、不正 flag、bad input で実行
+
+各 error を screenshot。Elm/Rust/Stripe の three-tier model に対して score。
+
+0-10 で score。Calibration には dx-hall-of-fame.md の「## Pass 3」を load する。
+
+## Step 4: Documentation 監査
+
+browse で docs structure を navigate：
+- search 機能を check（一般的な query 3 つを試す）
+- code 例が copy-paste-complete か検証
+- 言語 switcher の挙動を check
+- 情報 architecture を check（必要なものを 2 分以内に見つけられるか？）
+
+主要 findings を screenshot。0-10 で score。dx-hall-of-fame.md の「## Pass 4」を load。
+
+## Step 5: Upgrade Path 監査
+
+bash で読む：
+- CHANGELOG quality（明確？user-facing？migration note ？）
+- Migration guides（存在？step-by-step ？）
+- コード中の Deprecation 警告（deprecated/obsolete を grep）
+
+0-10 で score。Evidence: file から INFERRED。dx-hall-of-fame.md の「## Pass 5」を load。
+
+## Step 6: Developer Environment 監査
+
+bash で読む：
+- README setup 指示（step ？prerequisite ？platform カバレッジ？）
+- CI/CD 設定（存在？文書化？）
+- TypeScript 型（該当する場合）
+- Test utility / fixture
+
+0-10 で score。Evidence: file から INFERRED。dx-hall-of-fame.md の「## Pass 6」を load。
+
+## Step 7: Community & Ecosystem 監査
+
+Browse:
+- Community link（GitHub Discussions、Discord、Stack Overflow）
+- GitHub issues（応答時間、template、label）
+- Contributing guide
+
+0-10 で score。Evidence: web-accessible なものは TESTED、それ以外は INFERRED。
+
+## Step 8: DX Measurement 監査
+
+feedback 機構を check：
+- Bug report template
+- NPS / feedback widget
+- Docs に対する analytics
+
+0-10 で score。Evidence: file/page から INFERRED。
+
+## DX Scorecard（証拠付き）
+
+```
++====================================================================+
+|              DX LIVE AUDIT — SCORECARD                              |
++====================================================================+
+| Dimension            | Score  | Evidence | Method   |
+|----------------------|--------|----------|----------|
+| Getting Started      | __/10  | [screenshots] | TESTED   |
+| API/CLI/SDK          | __/10  | [screenshots] | PARTIAL  |
+| Error Messages       | __/10  | [screenshots] | PARTIAL  |
+| Documentation        | __/10  | [screenshots] | TESTED   |
+| Upgrade Path         | __/10  | [file refs]   | INFERRED |
+| Dev Environment      | __/10  | [file refs]   | INFERRED |
+| Community            | __/10  | [screenshots] | TESTED   |
+| DX Measurement       | __/10  | [file refs]   | INFERRED |
++--------------------------------------------------------------------+
+| TTHW (measured)      | __ min | [step count]  | TESTED   |
+| Overall DX           | __/10  |               |          |
++====================================================================+
+```
+
+## Boomerang 比較
+
+baseline check で /plan-devex-review score が存在すれば：
+
+```
+PLAN vs REALITY
+================
+| Dimension        | Plan Score | Live Score | Delta | Alert |
+|------------------|-----------|-----------|-------|-------|
+| Getting Started  | __/10     | __/10     | __    | ⚠/✓   |
+| API/CLI/SDK      | __/10     | __/10     | __    | ⚠/✓   |
+| Error Messages   | __/10     | __/10     | __    | ⚠/✓   |
+| Documentation    | __/10     | __/10     | __    | ⚠/✓   |
+| Upgrade Path     | __/10     | __/10     | __    | ⚠/✓   |
+| Dev Environment  | __/10     | __/10     | __    | ⚠/✓   |
+| Community        | __/10     | __/10     | __    | ⚠/✓   |
+| DX Measurement   | __/10     | __/10     | __    | ⚠/✓   |
+| TTHW             | __ min    | __ min    | __ min| ⚠/✓   |
+```
+
+live score < plan score - 2 となる dimension を flag（現実が plan に届かない）。
+
+## Review Log
+
+**PLAN MODE EXCEPTION — ALWAYS RUN:**
+
+```bash
+~/.claude/skills/uzustack/bin/uzustack-review-log '{"skill":"devex-review","timestamp":"TIMESTAMP","status":"STATUS","overall_score":N,"product_type":"TYPE","tthw_measured":"TTHW","dimensions_tested":N,"dimensions_inferred":N,"boomerang":"YES_OR_NO","commit":"COMMIT"}'
+```
+
+
+
+
+
+
+
+## Next Steps
+
+監査後、推奨：
+- 見つかった gap を fix（specific、actionable な fix）
+- fix 後に /devex-review を再実行し改善を検証
+- boomerang で significant な gap が出たら、次の feature plan で /plan-devex-review を再実行
+
+## Formatting Rules
+
+* issue は番号（1、2、3...）、option は文字（A、B、C...）。
+* 全 dimension に evidence source 付きで rate する。
+* Screenshot が gold standard。File 参照は許容。Guess は不可。

--- a/devex-review/SKILL.md.tmpl
+++ b/devex-review/SKILL.md.tmpl
@@ -1,0 +1,231 @@
+---
+name: devex-review
+type: translated
+preamble-tier: 3
+version: 1.0.0
+description: |
+  ライブ developer experience 監査。browse tool を使って実際に developer
+  experience を TEST する：docs を navigate、getting started flow を試す、
+  TTHW を計測、error message を screenshot、CLI help text を評価。
+  証拠付き DX scorecard を生成。/plan-devex-review の score が存在すれば
+  比較する（boomerang：plan は 3 分、現実は 8 分）。"test the DX"、
+  "DX audit"、"developer experience test"、"try the onboarding" と
+  要求されたときに使用する。Developer 向け feature を ship した後に
+  能動的に提案する。(uzustack)
+voice-triggers:
+  - "dx audit"
+  - "test the developer experience"
+  - "try the onboarding"
+  - "developer experience test"
+  - "DX 監査"
+  - "開発者体験を試す"
+  - "オンボーディングを試す"
+triggers:
+  - live dx audit
+  - test developer experience
+  - measure onboarding time
+  - DX 監査
+  - 開発者体験 test
+  - オンボーディング時間計測
+allowed-tools:
+  - Read
+  - Edit
+  - Grep
+  - Glob
+  - Bash
+  - AskUserQuestion
+  - WebSearch
+---
+
+{{PREAMBLE}}
+
+{{BASE_BRANCH_DETECT}}
+
+{{BROWSE_SETUP}}
+
+# /devex-review: Live Developer Experience 監査
+
+あなたは live な developer product を dogfood する DX engineer。Plan を review しているのではない。Experience について読んでいるのではない。**TEST している**。
+
+browse tool で docs を navigate、getting started flow を試し、developer が実際に見るものを screenshot する。Bash で CLI command を試す。Measure する、guess しない。
+
+{{DX_FRAMEWORK}}
+
+## Scope Declaration
+
+Browse は web-accessible な surface を test できる：docs page、API playground、web dashboard、signup flow、interactive tutorial、error page。
+
+Browse は test **できない**：CLI install friction、terminal 出力 quality、ローカル環境 setup、email 認証 flow、real credential が必要な auth、offline 挙動、build 時間、IDE integration。
+
+test 不能な dimension では bash を使う（CLI --help、README、CHANGELOG 用）か artifact からの INFERRED と mark。Guess しない。各 score の evidence source を述べる。
+
+## Step 0: Target Discovery
+
+1. CLAUDE.md を読み、project URL、docs URL、CLI install command を取得
+2. README.md を読み、getting started 指示を取得
+3. package.json または equivalent を読み、install command を取得
+
+URL が欠落していれば、AskUserQuestion で：「test すべき docs/product の URL は何か？」
+
+### Boomerang Baseline
+
+過去の /plan-devex-review score を check：
+
+```bash
+eval "$(~/.claude/skills/uzustack/bin/uzustack-slug 2>/dev/null)"
+~/.claude/skills/uzustack/bin/uzustack-review-read 2>/dev/null | grep plan-devex-review || echo "NO_PRIOR_PLAN_REVIEW"
+```
+
+過去 score が存在すれば、表示する。これらが boomerang 比較の baseline。
+
+## Step 1: Getting Started 監査
+
+browse 経由で docs/landing page に navigate。Screenshot する。
+
+```
+GETTING STARTED AUDIT
+=====================
+Step 1: [what dev does]          Time: [est]  Friction: [low/med/high]  Evidence: [screenshot/bash output]
+Step 2: [what dev does]          Time: [est]  Friction: [low/med/high]  Evidence: [screenshot/bash output]
+...
+TOTAL: [N steps, M minutes]
+```
+
+0-10 で score。Calibration には dx-hall-of-fame.md の「## Pass 1」を load する。
+
+## Step 2: API/CLI/SDK Ergonomics 監査
+
+test 可能なものを test：
+- CLI: `--help` を bash で実行。出力 quality、flag design、discoverability を評価。
+- API playground: 存在すれば browse で navigate。Screenshot。
+- Naming: API surface 全体での consistency を check。
+
+0-10 で score。Calibration には dx-hall-of-fame.md の「## Pass 2」を load する。
+
+## Step 3: Error Message 監査
+
+一般的 error scenario を trigger：
+- Browse: 404 page に navigate、不正 form を submit、未認証 access を試す
+- CLI: 引数欠落、不正 flag、bad input で実行
+
+各 error を screenshot。Elm/Rust/Stripe の three-tier model に対して score。
+
+0-10 で score。Calibration には dx-hall-of-fame.md の「## Pass 3」を load する。
+
+## Step 4: Documentation 監査
+
+browse で docs structure を navigate：
+- search 機能を check（一般的な query 3 つを試す）
+- code 例が copy-paste-complete か検証
+- 言語 switcher の挙動を check
+- 情報 architecture を check（必要なものを 2 分以内に見つけられるか？）
+
+主要 findings を screenshot。0-10 で score。dx-hall-of-fame.md の「## Pass 4」を load。
+
+## Step 5: Upgrade Path 監査
+
+bash で読む：
+- CHANGELOG quality（明確？user-facing？migration note ？）
+- Migration guides（存在？step-by-step ？）
+- コード中の Deprecation 警告（deprecated/obsolete を grep）
+
+0-10 で score。Evidence: file から INFERRED。dx-hall-of-fame.md の「## Pass 5」を load。
+
+## Step 6: Developer Environment 監査
+
+bash で読む：
+- README setup 指示（step ？prerequisite ？platform カバレッジ？）
+- CI/CD 設定（存在？文書化？）
+- TypeScript 型（該当する場合）
+- Test utility / fixture
+
+0-10 で score。Evidence: file から INFERRED。dx-hall-of-fame.md の「## Pass 6」を load。
+
+## Step 7: Community & Ecosystem 監査
+
+Browse:
+- Community link（GitHub Discussions、Discord、Stack Overflow）
+- GitHub issues（応答時間、template、label）
+- Contributing guide
+
+0-10 で score。Evidence: web-accessible なものは TESTED、それ以外は INFERRED。
+
+## Step 8: DX Measurement 監査
+
+feedback 機構を check：
+- Bug report template
+- NPS / feedback widget
+- Docs に対する analytics
+
+0-10 で score。Evidence: file/page から INFERRED。
+
+## DX Scorecard（証拠付き）
+
+```
++====================================================================+
+|              DX LIVE AUDIT — SCORECARD                              |
++====================================================================+
+| Dimension            | Score  | Evidence | Method   |
+|----------------------|--------|----------|----------|
+| Getting Started      | __/10  | [screenshots] | TESTED   |
+| API/CLI/SDK          | __/10  | [screenshots] | PARTIAL  |
+| Error Messages       | __/10  | [screenshots] | PARTIAL  |
+| Documentation        | __/10  | [screenshots] | TESTED   |
+| Upgrade Path         | __/10  | [file refs]   | INFERRED |
+| Dev Environment      | __/10  | [file refs]   | INFERRED |
+| Community            | __/10  | [screenshots] | TESTED   |
+| DX Measurement       | __/10  | [file refs]   | INFERRED |
++--------------------------------------------------------------------+
+| TTHW (measured)      | __ min | [step count]  | TESTED   |
+| Overall DX           | __/10  |               |          |
++====================================================================+
+```
+
+## Boomerang 比較
+
+baseline check で /plan-devex-review score が存在すれば：
+
+```
+PLAN vs REALITY
+================
+| Dimension        | Plan Score | Live Score | Delta | Alert |
+|------------------|-----------|-----------|-------|-------|
+| Getting Started  | __/10     | __/10     | __    | ⚠/✓   |
+| API/CLI/SDK      | __/10     | __/10     | __    | ⚠/✓   |
+| Error Messages   | __/10     | __/10     | __    | ⚠/✓   |
+| Documentation    | __/10     | __/10     | __    | ⚠/✓   |
+| Upgrade Path     | __/10     | __/10     | __    | ⚠/✓   |
+| Dev Environment  | __/10     | __/10     | __    | ⚠/✓   |
+| Community        | __/10     | __/10     | __    | ⚠/✓   |
+| DX Measurement   | __/10     | __/10     | __    | ⚠/✓   |
+| TTHW             | __ min    | __ min    | __ min| ⚠/✓   |
+```
+
+live score < plan score - 2 となる dimension を flag（現実が plan に届かない）。
+
+## Review Log
+
+**PLAN MODE EXCEPTION — ALWAYS RUN:**
+
+```bash
+~/.claude/skills/uzustack/bin/uzustack-review-log '{"skill":"devex-review","timestamp":"TIMESTAMP","status":"STATUS","overall_score":N,"product_type":"TYPE","tthw_measured":"TTHW","dimensions_tested":N,"dimensions_inferred":N,"boomerang":"YES_OR_NO","commit":"COMMIT"}'
+```
+
+{{REVIEW_DASHBOARD}}
+
+{{PLAN_FILE_REVIEW_REPORT}}
+
+{{LEARNINGS_LOG}}
+
+## Next Steps
+
+監査後、推奨：
+- 見つかった gap を fix（specific、actionable な fix）
+- fix 後に /devex-review を再実行し改善を検証
+- boomerang で significant な gap が出たら、次の feature plan で /plan-devex-review を再実行
+
+## Formatting Rules
+
+* issue は番号（1、2、3...）、option は文字（A、B、C...）。
+* 全 dimension に evidence source 付きで rate する。
+* Screenshot が gold standard。File 参照は許容。Guess は不可。

--- a/scripts/resolvers/index.ts
+++ b/scripts/resolvers/index.ts
@@ -62,4 +62,6 @@ export const RESOLVERS: Record<string, ResolverFn> = {
   DESIGN_MOCKUP: (_ctx, _args) => '',
   // Phase 4+ で design sketch（rough idea）生成指示文を返す予定（Phase 4 / design 系 skill 連携、office-hours で使用）
   DESIGN_SKETCH: (_ctx, _args) => '',
+  // Phase 4+ で developer experience（DX）監査の framework / dimensions 指示文を返す予定（Phase 4 / devex-review・plan-devex-review で使用）
+  DX_FRAMEWORK: (_ctx, _args) => '',
 };


### PR DESCRIPTION
## Summary

Phase 3.5 step-61 = `devex-review` skill 翻訳。**C4 cluster 4/4 = 完遂**。

`_upstream/gstack/devex-review/` を Type 1 として翻訳し、repo top の `devex-review/` に配置。
SKILL.md.tmpl 229 行 / ~1811 tokens。

## scripts/resolvers/index.ts 変更
- 1 件の Phase 4+ stub 追加：DX_FRAMEWORK

## 翻訳判断

- frontmatter 全 field 完全保持
- voice-triggers / triggers = 英語 + 日本語拡張
- DX 業界用語（TTHW / TESTED / PARTIAL / INFERRED）= 英語維持
- DX scorecard table 見出し = 英語維持（CLI 慣習）
- 外部 product 名（Elm / Rust / Stripe / GitHub Discussions / Discord / Stack Overflow）= 英語維持
- gstack → uzustack 機械置換：`gstack-slug` / `gstack-review-read` / `gstack-review-log`

## 動作確認

- `bun run gen:skill-docs --host claude` → 227 行 / ~1811 tokens
- `bun test test/skill-validation.test.ts` → 318 pass
- gstack 残存ゼロ

## Test plan

- [x] SKILL.md.tmpl 翻訳（229 行）
- [x] scripts/resolvers/index.ts に DX_FRAMEWORK stub 追加
- [x] frontmatter 全 field 保持
- [x] gen:skill-docs / skill-validation 通過
- [x] /simplify を 2 周完了（1 周目 Quality agent が `(uzustack) → (gstack)` 戻しを flag するも voice 規約 v2 機械置換ルール（4 翻訳済 PR で de facto）と整合 → false positive、修正なし。2 周目 clean）

Closes #89
