### PR TITLE
feat: setup-deploy 翻訳 — Phase 3.5 step-64 (C5 cluster 2/5)

### DIFF
--- a/setup-deploy/SKILL.md
+++ b/setup-deploy/SKILL.md
@@ -143,14 +143,14 @@ deploy workflow は検出したが platform 設定がない場合：
 
 AskUserQuestion で情報を集める：
 
-1. **How are deploys triggered?**
+1. **deploy はどう trigger するか？**
    - A) Automatically on push to main (Fly, Render, Vercel, Netlify, etc.)
    - B) Via GitHub Actions workflow
    - C) Via a deploy script or CLI command (describe it)
    - D) Manually (SSH, dashboard, etc.)
    - E) This project doesn't deploy (library, CLI, tool)
 
-2. **What's the production URL?**（自由記述 — アプリが動いている URL）
+2. **production URL は何か？**（自由記述 — アプリが動いている URL）
 
 3. **uzustack はどうやって deploy 成否を確認できるか？**
    - A) HTTP health check at a specific URL (e.g., /health, /api/status)

--- a/setup-deploy/SKILL.md
+++ b/setup-deploy/SKILL.md
@@ -1,0 +1,227 @@
+---
+name: setup-deploy
+type: translated
+preamble-tier: 2
+version: 1.0.0
+description: |
+  /land-and-deploy 用の deploy 設定を構成する skill。deploy platform
+  （Fly.io / Render / Vercel / Netlify / Heroku / GitHub Actions / custom）を
+  検出し、production URL / health check endpoint / deploy status command を
+  CLAUDE.md に書き込む。以降の deploy が automatic に動作する。
+  「setup deploy」「deploy 設定」「set up land-and-deploy」「uzustack で deploy する方法」
+  「deploy 設定を追加」と要求されたときに使用する。(uzustack)
+triggers:
+  - configure deploy
+  - setup deployment
+  - set deploy platform
+  - deploy 設定する
+  - deploy 構成する
+  - setup deploy する
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - AskUserQuestion
+---
+<!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
+<!-- Regenerate: bun run gen:skill-docs -->
+
+
+
+# /setup-deploy — uzustack の deploy 設定を構成する
+
+`/land-and-deploy` が automatic に動作するよう、deploy 設定を構成する skill。
+deploy platform / production URL / health check / deploy status command を検出し、
+すべて CLAUDE.md に永続化する。
+
+一度この skill を実行すれば、以降の `/land-and-deploy` は CLAUDE.md を読むだけで platform 検出を skip する。
+
+## User-invocable
+ユーザーが `/setup-deploy` と入力したとき、本 skill を起動する。
+
+## Instructions
+
+### Step 1: 既存設定の確認
+
+```bash
+grep -A 20 "## Deploy Configuration" CLAUDE.md 2>/dev/null || echo "NO_CONFIG"
+```
+
+既存設定があれば表示し、ユーザーに確認する：
+
+- **Context:** Deploy 設定は既に CLAUDE.md に存在する。
+- **RECOMMENDATION:** setup が変わっているなら A を選ぶ。
+- A) Reconfigure from scratch (overwrite existing)
+- B) Edit specific fields (show current config, let me change one thing)
+- C) Done — configuration looks correct
+
+ユーザーが C を選んだら停止する。
+
+### Step 2: Platform 検出
+
+deploy bootstrap の platform 検出を実行：
+
+```bash
+# Platform 設定ファイル
+[ -f fly.toml ] && echo "PLATFORM:fly" && cat fly.toml
+[ -f render.yaml ] && echo "PLATFORM:render" && cat render.yaml
+[ -f vercel.json ] || [ -d .vercel ] && echo "PLATFORM:vercel"
+[ -f netlify.toml ] && echo "PLATFORM:netlify" && cat netlify.toml
+[ -f Procfile ] && echo "PLATFORM:heroku"
+[ -f railway.json ] || [ -f railway.toml ] && echo "PLATFORM:railway"
+
+# GitHub Actions の deploy workflow
+for f in $(find .github/workflows -maxdepth 1 \( -name '*.yml' -o -name '*.yaml' \) 2>/dev/null); do
+  [ -f "$f" ] && grep -qiE "deploy|release|production|staging|cd" "$f" 2>/dev/null && echo "DEPLOY_WORKFLOW:$f"
+done
+
+# プロジェクト種別
+[ -f package.json ] && grep -q '"bin"' package.json 2>/dev/null && echo "PROJECT_TYPE:cli"
+find . -maxdepth 1 -name '*.gemspec' 2>/dev/null | grep -q . && echo "PROJECT_TYPE:library"
+```
+
+### Step 3: Platform 別の構成
+
+検出結果に基づき、platform 別の構成手順をユーザーに案内する。
+
+#### Fly.io
+
+`fly.toml` を検出した場合：
+
+1. アプリ名抽出：`grep -m1 "^app" fly.toml | sed 's/app = "\(.*\)"/\1/'`
+2. `fly` CLI が install されているか確認：`which fly 2>/dev/null`
+3. install 済なら検証：`fly status --app {app} 2>/dev/null`
+4. URL 推論：`https://{app}.fly.dev`
+5. deploy status コマンド：`fly status --app {app}`
+6. health check：`https://{app}.fly.dev`（アプリが `/health` を持つならそれを使う）
+
+production URL の確認をユーザーに依頼する。Fly のアプリは custom domain を使う場合がある。
+
+#### Render
+
+`render.yaml` を検出した場合：
+
+1. service 名と type を render.yaml から抽出
+2. Render API key の確認：`echo $RENDER_API_KEY | head -c 4`（full key を露出させない）
+3. URL 推論：`https://{service-name}.onrender.com`
+4. Render は接続済 branch への push で auto-deploy するため、deploy workflow は不要
+5. health check：推論した URL
+
+ユーザーに確認を依頼する。Render は接続済 git branch から auto-deploy する — main へ merge すると Render が自動で取り込む。`/land-and-deploy` の「deploy 待機」は新版が応答するまで Render URL を poll する設計。
+
+#### Vercel
+
+vercel.json または .vercel を検出した場合：
+
+1. `vercel` CLI 確認：`which vercel 2>/dev/null`
+2. install 済なら：`vercel ls --prod 2>/dev/null | head -3`
+3. Vercel は push で auto-deploy する（PR で preview、main merge で production）
+4. health check：vercel project 設定の production URL
+
+#### Netlify
+
+netlify.toml を検出した場合：
+
+1. site 情報を netlify.toml から抽出
+2. Netlify は push で auto-deploy する
+3. health check：production URL
+
+#### GitHub Actions のみ
+
+deploy workflow は検出したが platform 設定がない場合：
+
+1. workflow ファイルを読み挙動を理解する
+2. deploy 先を抽出（記載があれば）
+3. production URL をユーザーに確認
+
+#### Custom / 手動
+
+何も検出できない場合：
+
+AskUserQuestion で情報を集める：
+
+1. **How are deploys triggered?**
+   - A) Automatically on push to main (Fly, Render, Vercel, Netlify, etc.)
+   - B) Via GitHub Actions workflow
+   - C) Via a deploy script or CLI command (describe it)
+   - D) Manually (SSH, dashboard, etc.)
+   - E) This project doesn't deploy (library, CLI, tool)
+
+2. **What's the production URL?**（自由記述 — アプリが動いている URL）
+
+3. **uzustack はどうやって deploy 成否を確認できるか？**
+   - A) HTTP health check at a specific URL (e.g., /health, /api/status)
+   - B) CLI command (e.g., `fly status`, `kubectl rollout status`)
+   - C) Check the GitHub Actions workflow status
+   - D) No automated way — just check the URL loads
+
+4. **Pre-merge / post-merge hook はあるか？**
+   - merge 前に実行するコマンド（例：`bun run build`）
+   - merge 後 deploy 検証前に実行するコマンド
+
+### Step 4: 設定の書き込み
+
+CLAUDE.md を読む（無ければ作成）。`## Deploy Configuration` section があれば置換、なければ末尾に追加する。
+
+```markdown
+## Deploy Configuration (configured by /setup-deploy)
+- Platform: {platform}
+- Production URL: {url}
+- Deploy workflow: {workflow file or "auto-deploy on push"}
+- Deploy status command: {command or "HTTP health check"}
+- Merge method: {squash/merge/rebase}
+- Project type: {web app / API / CLI / library}
+- Post-deploy health check: {health check URL or command}
+
+### Custom deploy hooks
+- Pre-merge: {command or "none"}
+- Deploy trigger: {command or "automatic on push to main"}
+- Deploy status: {command or "poll production URL"}
+- Health check: {URL or command}
+```
+
+### Step 5: 検証
+
+書き込み後、設定が動くか検証する：
+
+1. health check URL を構成したら試す：
+```bash
+curl -sf "{health-check-url}" -o /dev/null -w "%{http_code}" 2>/dev/null || echo "UNREACHABLE"
+```
+
+2. deploy status コマンドを構成したら試す：
+```bash
+{deploy-status-command} 2>/dev/null | head -5 || echo "COMMAND_FAILED"
+```
+
+結果を報告する。失敗してもブロックしない — health check が一時的に不通でも設定そのものは有用。
+
+### Step 6: Summary
+
+```
+DEPLOY CONFIGURATION — COMPLETE
+════════════════════════════════
+Platform:      {platform}
+URL:           {url}
+Health check:  {health check}
+Status cmd:    {status command}
+Merge method:  {merge method}
+
+CLAUDE.md に保存。/land-and-deploy は以降この設定を automatic に使う。
+
+次のアクション：
+- /land-and-deploy で現在の PR を merge + deploy する
+- CLAUDE.md の "## Deploy Configuration" section を編集して設定を変更する
+- /setup-deploy を再実行して再構成する
+```
+
+## Important Rules
+
+- **secret を露出させない。** API key / token / password の full string を print しない。
+- **ユーザー確認を取る。** 検出した設定を表示し、書き込み前に必ず確認を取る。
+- **CLAUDE.md が source of truth。** 設定はすべて CLAUDE.md に置く — 別の config ファイルを作らない。
+- **Idempotent。** `/setup-deploy` を複数回実行しても、直前の設定をきれいに上書きする。
+- **Platform CLI は optional。** `fly` や `vercel` CLI が install されていなければ URL ベースの health check に fallback する。

--- a/setup-deploy/SKILL.md.tmpl
+++ b/setup-deploy/SKILL.md.tmpl
@@ -141,14 +141,14 @@ deploy workflow は検出したが platform 設定がない場合：
 
 AskUserQuestion で情報を集める：
 
-1. **How are deploys triggered?**
+1. **deploy はどう trigger するか？**
    - A) Automatically on push to main (Fly, Render, Vercel, Netlify, etc.)
    - B) Via GitHub Actions workflow
    - C) Via a deploy script or CLI command (describe it)
    - D) Manually (SSH, dashboard, etc.)
    - E) This project doesn't deploy (library, CLI, tool)
 
-2. **What's the production URL?**（自由記述 — アプリが動いている URL）
+2. **production URL は何か？**（自由記述 — アプリが動いている URL）
 
 3. **uzustack はどうやって deploy 成否を確認できるか？**
    - A) HTTP health check at a specific URL (e.g., /health, /api/status)

--- a/setup-deploy/SKILL.md.tmpl
+++ b/setup-deploy/SKILL.md.tmpl
@@ -1,0 +1,225 @@
+---
+name: setup-deploy
+type: translated
+preamble-tier: 2
+version: 1.0.0
+description: |
+  /land-and-deploy 用の deploy 設定を構成する skill。deploy platform
+  （Fly.io / Render / Vercel / Netlify / Heroku / GitHub Actions / custom）を
+  検出し、production URL / health check endpoint / deploy status command を
+  CLAUDE.md に書き込む。以降の deploy が automatic に動作する。
+  「setup deploy」「deploy 設定」「set up land-and-deploy」「uzustack で deploy する方法」
+  「deploy 設定を追加」と要求されたときに使用する。(uzustack)
+triggers:
+  - configure deploy
+  - setup deployment
+  - set deploy platform
+  - deploy 設定する
+  - deploy 構成する
+  - setup deploy する
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - AskUserQuestion
+---
+
+{{PREAMBLE}}
+
+# /setup-deploy — uzustack の deploy 設定を構成する
+
+`/land-and-deploy` が automatic に動作するよう、deploy 設定を構成する skill。
+deploy platform / production URL / health check / deploy status command を検出し、
+すべて CLAUDE.md に永続化する。
+
+一度この skill を実行すれば、以降の `/land-and-deploy` は CLAUDE.md を読むだけで platform 検出を skip する。
+
+## User-invocable
+ユーザーが `/setup-deploy` と入力したとき、本 skill を起動する。
+
+## Instructions
+
+### Step 1: 既存設定の確認
+
+```bash
+grep -A 20 "## Deploy Configuration" CLAUDE.md 2>/dev/null || echo "NO_CONFIG"
+```
+
+既存設定があれば表示し、ユーザーに確認する：
+
+- **Context:** Deploy 設定は既に CLAUDE.md に存在する。
+- **RECOMMENDATION:** setup が変わっているなら A を選ぶ。
+- A) Reconfigure from scratch (overwrite existing)
+- B) Edit specific fields (show current config, let me change one thing)
+- C) Done — configuration looks correct
+
+ユーザーが C を選んだら停止する。
+
+### Step 2: Platform 検出
+
+deploy bootstrap の platform 検出を実行：
+
+```bash
+# Platform 設定ファイル
+[ -f fly.toml ] && echo "PLATFORM:fly" && cat fly.toml
+[ -f render.yaml ] && echo "PLATFORM:render" && cat render.yaml
+[ -f vercel.json ] || [ -d .vercel ] && echo "PLATFORM:vercel"
+[ -f netlify.toml ] && echo "PLATFORM:netlify" && cat netlify.toml
+[ -f Procfile ] && echo "PLATFORM:heroku"
+[ -f railway.json ] || [ -f railway.toml ] && echo "PLATFORM:railway"
+
+# GitHub Actions の deploy workflow
+for f in $(find .github/workflows -maxdepth 1 \( -name '*.yml' -o -name '*.yaml' \) 2>/dev/null); do
+  [ -f "$f" ] && grep -qiE "deploy|release|production|staging|cd" "$f" 2>/dev/null && echo "DEPLOY_WORKFLOW:$f"
+done
+
+# プロジェクト種別
+[ -f package.json ] && grep -q '"bin"' package.json 2>/dev/null && echo "PROJECT_TYPE:cli"
+find . -maxdepth 1 -name '*.gemspec' 2>/dev/null | grep -q . && echo "PROJECT_TYPE:library"
+```
+
+### Step 3: Platform 別の構成
+
+検出結果に基づき、platform 別の構成手順をユーザーに案内する。
+
+#### Fly.io
+
+`fly.toml` を検出した場合：
+
+1. アプリ名抽出：`grep -m1 "^app" fly.toml | sed 's/app = "\(.*\)"/\1/'`
+2. `fly` CLI が install されているか確認：`which fly 2>/dev/null`
+3. install 済なら検証：`fly status --app {app} 2>/dev/null`
+4. URL 推論：`https://{app}.fly.dev`
+5. deploy status コマンド：`fly status --app {app}`
+6. health check：`https://{app}.fly.dev`（アプリが `/health` を持つならそれを使う）
+
+production URL の確認をユーザーに依頼する。Fly のアプリは custom domain を使う場合がある。
+
+#### Render
+
+`render.yaml` を検出した場合：
+
+1. service 名と type を render.yaml から抽出
+2. Render API key の確認：`echo $RENDER_API_KEY | head -c 4`（full key を露出させない）
+3. URL 推論：`https://{service-name}.onrender.com`
+4. Render は接続済 branch への push で auto-deploy するため、deploy workflow は不要
+5. health check：推論した URL
+
+ユーザーに確認を依頼する。Render は接続済 git branch から auto-deploy する — main へ merge すると Render が自動で取り込む。`/land-and-deploy` の「deploy 待機」は新版が応答するまで Render URL を poll する設計。
+
+#### Vercel
+
+vercel.json または .vercel を検出した場合：
+
+1. `vercel` CLI 確認：`which vercel 2>/dev/null`
+2. install 済なら：`vercel ls --prod 2>/dev/null | head -3`
+3. Vercel は push で auto-deploy する（PR で preview、main merge で production）
+4. health check：vercel project 設定の production URL
+
+#### Netlify
+
+netlify.toml を検出した場合：
+
+1. site 情報を netlify.toml から抽出
+2. Netlify は push で auto-deploy する
+3. health check：production URL
+
+#### GitHub Actions のみ
+
+deploy workflow は検出したが platform 設定がない場合：
+
+1. workflow ファイルを読み挙動を理解する
+2. deploy 先を抽出（記載があれば）
+3. production URL をユーザーに確認
+
+#### Custom / 手動
+
+何も検出できない場合：
+
+AskUserQuestion で情報を集める：
+
+1. **How are deploys triggered?**
+   - A) Automatically on push to main (Fly, Render, Vercel, Netlify, etc.)
+   - B) Via GitHub Actions workflow
+   - C) Via a deploy script or CLI command (describe it)
+   - D) Manually (SSH, dashboard, etc.)
+   - E) This project doesn't deploy (library, CLI, tool)
+
+2. **What's the production URL?**（自由記述 — アプリが動いている URL）
+
+3. **uzustack はどうやって deploy 成否を確認できるか？**
+   - A) HTTP health check at a specific URL (e.g., /health, /api/status)
+   - B) CLI command (e.g., `fly status`, `kubectl rollout status`)
+   - C) Check the GitHub Actions workflow status
+   - D) No automated way — just check the URL loads
+
+4. **Pre-merge / post-merge hook はあるか？**
+   - merge 前に実行するコマンド（例：`bun run build`）
+   - merge 後 deploy 検証前に実行するコマンド
+
+### Step 4: 設定の書き込み
+
+CLAUDE.md を読む（無ければ作成）。`## Deploy Configuration` section があれば置換、なければ末尾に追加する。
+
+```markdown
+## Deploy Configuration (configured by /setup-deploy)
+- Platform: {platform}
+- Production URL: {url}
+- Deploy workflow: {workflow file or "auto-deploy on push"}
+- Deploy status command: {command or "HTTP health check"}
+- Merge method: {squash/merge/rebase}
+- Project type: {web app / API / CLI / library}
+- Post-deploy health check: {health check URL or command}
+
+### Custom deploy hooks
+- Pre-merge: {command or "none"}
+- Deploy trigger: {command or "automatic on push to main"}
+- Deploy status: {command or "poll production URL"}
+- Health check: {URL or command}
+```
+
+### Step 5: 検証
+
+書き込み後、設定が動くか検証する：
+
+1. health check URL を構成したら試す：
+```bash
+curl -sf "{health-check-url}" -o /dev/null -w "%{http_code}" 2>/dev/null || echo "UNREACHABLE"
+```
+
+2. deploy status コマンドを構成したら試す：
+```bash
+{deploy-status-command} 2>/dev/null | head -5 || echo "COMMAND_FAILED"
+```
+
+結果を報告する。失敗してもブロックしない — health check が一時的に不通でも設定そのものは有用。
+
+### Step 6: Summary
+
+```
+DEPLOY CONFIGURATION — COMPLETE
+════════════════════════════════
+Platform:      {platform}
+URL:           {url}
+Health check:  {health check}
+Status cmd:    {status command}
+Merge method:  {merge method}
+
+CLAUDE.md に保存。/land-and-deploy は以降この設定を automatic に使う。
+
+次のアクション：
+- /land-and-deploy で現在の PR を merge + deploy する
+- CLAUDE.md の "## Deploy Configuration" section を編集して設定を変更する
+- /setup-deploy を再実行して再構成する
+```
+
+## Important Rules
+
+- **secret を露出させない。** API key / token / password の full string を print しない。
+- **ユーザー確認を取る。** 検出した設定を表示し、書き込み前に必ず確認を取る。
+- **CLAUDE.md が source of truth。** 設定はすべて CLAUDE.md に置く — 別の config ファイルを作らない。
+- **Idempotent。** `/setup-deploy` を複数回実行しても、直前の設定をきれいに上書きする。
+- **Platform CLI は optional。** `fly` や `vercel` CLI が install されていなければ URL ベースの health check に fallback する。


### PR DESCRIPTION
## Summary

- `_upstream/gstack/setup-deploy/SKILL.md.tmpl` を Type 1 翻訳、`setup-deploy/` に新規配置（225 行 / ~1656 tokens）
- frontmatter 全 field 完全保持 + `type: translated` 追加 + triggers 日本語 3 件追加
- voice 規約 v2 機械置換徹底：description suffix `(uzustack)`、本文 `gstack` 文字列なし
- AskUserQuestion option (A〜E / A〜D) は英語維持（CLI 慣習、voice 規約 v2 fixed identifier）
- ASCII output box（Step 6 完了表示）は構造維持で内容のみ日本語化

## Phase 3.5 進行

- 64/76 step = **84%**（C5 cluster 2/5）
- 残り：step-65〜67 (C5 残り 3) + step-68〜71 (C6 design 4) + step-72〜75 (C7 plan 4) + step-76 (step-42 retry)

## 分類

(a) 既存翻訳パターン踏襲（依存ファイル = `SKILL.md.tmpl` のみ、hook なし、placeholder = `{{PREAMBLE}}` のみ、付属 binary 0 件）

## Test plan

- [x] `bun run gen:skill-docs --host all`（claude 生成成功、他 9 host は Phase 4+ deferred）
- [x] `bun test test/skill-validation.test.ts test/gen-skill-docs.test.ts` = 689 pass / 0 fail
- [x] `/simplify` を 2 周完了（actionable finding 1 件 = Round 1 で AskUserQuestion 質問 stem の英日混在を検出 → Q1/Q2 を日本語化に統一 / Round 2 で 3 agent 全 clean cross-validation）

## /simplify findings 要約

- **Round 1**：Reuse 0 / Quality 1 actionable / Efficiency 0
  - 修正：AskUserQuestion 質問 stem 4 件のうち Q1 "How are deploys triggered?" / Q2 "What's the production URL?" が英語のまま、Q3/Q4 は日本語化済で混在
  - 直し方：Q1 → 「deploy はどう trigger するか？」、Q2 → 「production URL は何か？」（option (A〜E) は英語維持で land-and-deploy パターンに整合）
- **Round 2**（cross-validation）：Reuse 0 / Quality 0 / Efficiency 0、3 agent 全 clean

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)