### PR TITLE
feat: skill voice 規約 v1 機械チェック — Phase 4 step-83 (Tier 1+2 達成)

### DIFF
--- a/.github/workflows/skill-docs.yml
+++ b/.github/workflows/skill-docs.yml
@@ -41,3 +41,5 @@ jobs:
             echo "::error::Generated files are stale or gen:skill-docs wrote outside skills/. Run: bun run gen:skill-docs"
             exit 1
           }
+      - name: Voice validation (voice 規約 v1, step-83 サブタスク 3)
+        run: bun run skill:validate

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "build": "bun run build:design",
     "build:design": "bun build --compile design/src/cli.ts --outfile design/dist/design && (rm -f .*.bun-build || true)",
-    "gen:skill-docs": "bun run scripts/gen-skill-docs.ts"
+    "gen:skill-docs": "bun run scripts/gen-skill-docs.ts",
+    "skill:validate": "bun run scripts/skill-validate.ts"
   },
   "engines": {
     "bun": ">=1.0.0"

--- a/scripts/skill-validate.ts
+++ b/scripts/skill-validate.ts
@@ -1,0 +1,108 @@
+#!/usr/bin/env bun
+/**
+ * Skill voice validation — voice 規約 v1 の機械チェック可能 subset。
+ * Phase 3.6 step-83 サブタスク 3 で配置、`.github/workflows/skill-docs.yml` の Voice validation step で実行。
+ *
+ * Subtree path 許可：行内に `_upstream/gstack/` を含む場合は skip
+ *   (uzustack 内の subtree path 言及として許可、voice 規約 v2 拡張 PR #116)。
+ *
+ * placeholder resolve verify は gen-skill-docs.ts L208/L213-216 で実装済
+ *   (Unknown placeholder throw + defense-in-depth)、本 script は voice 規約のみ扱う。
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { discoverTemplates, discoverSkillFiles } from './discover-skills';
+
+const ROOT = path.resolve(import.meta.dir, '..');
+
+interface Violation {
+  file: string;
+  line: number;
+  pattern: string;
+  excerpt: string;
+}
+
+function isTranslated(content: string): boolean {
+  const fmStart = content.indexOf('---\n');
+  if (fmStart !== 0) return false;
+  const fmEnd = content.indexOf('\n---', fmStart + 4);
+  if (fmEnd === -1) return false;
+  const fm = content.slice(fmStart + 4, fmEnd);
+  return /^type:\s*translated\s*$/m.test(fm);
+}
+
+const PATTERNS: Array<{ name: string; regex: RegExp }> = [
+  { name: '~/.gstack/ (path)', regex: /~\/\.gstack\// },
+  { name: '$GSTACK_HOME (env var)', regex: /\$GSTACK_HOME|\$\{GSTACK_HOME/ },
+  { name: 'gstack-XXX (bin 名)', regex: /\bgstack-[a-zA-Z0-9_-]+/ },
+  { name: '~/.claude/skills/gstack/ (skill path)', regex: /~\/\.claude\/skills\/gstack\// },
+];
+
+function checkFile(rel: string, content: string): { violations: Violation[]; translated: boolean } {
+  const translated = isTranslated(content);
+  if (!translated) return { violations: [], translated };
+
+  const violations: Violation[] = [];
+  const lines = content.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    // Subtree path 許可: `_upstream/gstack/` を含む行は skip
+    // (subtree directory 名は voice 規約 v2 拡張で外部 identifier 維持、PR #116)
+    if (line.includes('_upstream/gstack/')) continue;
+    for (const { name, regex } of PATTERNS) {
+      if (regex.test(line)) {
+        violations.push({
+          file: rel,
+          line: i + 1,
+          pattern: name,
+          excerpt: line.trim().slice(0, 120),
+        });
+      }
+    }
+  }
+  return { violations, translated };
+}
+
+function main() {
+  const tmpls = discoverTemplates(ROOT);
+  const mds = discoverSkillFiles(ROOT);
+
+  // .tmpl は generator source、.md は generated。両方 check することで
+  // .md だけ手動編集された drift も catch (defense-in-depth、skill-docs.yml と同 pattern)
+  const targets: Array<{ rel: string; abs: string }> = [];
+  for (const t of tmpls) targets.push({ rel: t.tmpl, abs: path.join(ROOT, t.tmpl) });
+  for (const m of mds) targets.push({ rel: m, abs: path.join(ROOT, m) });
+
+  const allViolations: Violation[] = [];
+  let translatedCount = 0;
+  for (const { rel, abs } of targets) {
+    const content = fs.readFileSync(abs, 'utf-8');
+    const { violations, translated } = checkFile(rel, content);
+    if (translated) translatedCount++;
+    allViolations.push(...violations);
+  }
+
+  console.log('Skill voice validation');
+  console.log('═'.repeat(60));
+  console.log(`  Scanned: ${targets.length} files (${translatedCount} type: translated)`);
+  console.log(`  Violations: ${allViolations.length}`);
+
+  if (allViolations.length === 0) {
+    console.log('  ✅ All clean.');
+    process.exit(0);
+  }
+
+  console.log('');
+  console.log('Violations detected:');
+  console.log('─'.repeat(60));
+  for (const v of allViolations) {
+    console.log(`  ${v.file}:${v.line}  [${v.pattern}]`);
+    console.log(`    ${v.excerpt}`);
+  }
+  console.log('─'.repeat(60));
+  console.error('::error::Voice 規約 v1 違反が検出されました。`docs/uzustack/translation-voice-guide.md` を参照して修正してください。');
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## Summary
- 翻訳済 31 skill に対する **voice 規約 v1 機械チェック** を新規実装 (`scripts/skill-validate.ts` 100 行)
- CI gate 化 (`.github/workflows/skill-docs.yml` に Voice validation step 追加)
- Phase 4 step-83 (翻訳 skill 自動 e2e test infrastructure) の Tier 1+2 達成

## Background
Phase 3.6 step-82 の `/plan-eng-review` Section 3 Issue T1 で「翻訳 skill 自動 e2e test なし」 が TODO 化、step-83 として独立。本 PR は step-83 サブタスク 1-4 完遂分。

## 変更内容
- `scripts/skill-validate.ts` 新規：4 patterns 機械 grep (`~/.gstack/` / `$GSTACK_HOME` / `gstack-XXX` (bin 名) / `~/.claude/skills/gstack/`)、frontmatter `type: translated` のみ対象、`_upstream/gstack/` 含む行は subtree path として許可
- `package.json`：`skill:validate` script 追加
- `.github/workflows/skill-docs.yml`：Voice validation step 追加 (gen-skill-docs idempotency check の後)

## Verification
- 初回 run：82 files scanned (62 type: translated = 31 翻訳 skill × 2 (.tmpl + .md))、**Violations 0** = 既存 31 翻訳 skill すべて voice 規約 v1 準拠
- dogfood：4 patterns 全て catch + exit 1、revert 後再 run で Violations 0 確認

## Tier 採否 (step-83 サブタスク 2)
- ✅ **Tier 1** (gen-docs idempotency)：既存 CI gate 維持
- ✅ **Tier 2** (skill validation static)：本 PR で実装
  - voice 規約 v1 機械チェック (新規)
  - placeholder resolve verify は既存 (gen-skill-docs.ts:208/213-216 = `Unknown placeholder` throw + defense-in-depth) で達成済 → サブタスク 4 新規実装不要
- ⏸ **Tier 3** (LLM judge eval, $0.15/run)：Phase 4 cluster 完了後判断
- ⏸ **Tier 4** (E2E claude -p, $6-15/run)：Phase 4 cluster 完了後判断 (touchfiles 独自 fork + fixture 段階的独自化要)

## Test plan
- [x] `bun run skill:validate` 単体実行 (Violations 0 + idempotent)
- [x] dogfood 4 patterns catch (~/.gstack/ / $GSTACK_HOME / gstack-XXX / ~/.claude/skills/gstack/) + exit 1
- [x] revert 後再 run で Violations 0
- [x] `/simplify` を 2 周 — Round 1: 2 件 fix (`fs.readFileSync` 二重 read 解消 + JSDoc 冗長削減)、Round 2: 1 件 fix (`isTranslated()` 二重呼び出し解消、checkFile signature を `{ violations, translated }` に変更)、3 周目は回さず方針 (memory `simplify_specificity_drift.md`)

## /simplify findings 詳細
**Round 1 fix (commit ac97398)**:
- F2.4/F3.1 (cross-confirm): `fs.readFileSync` 二重 read → `checkFile(rel, content)` に signature 変更で解消
- F2.5: JSDoc の WHAT 列挙 (PATTERNS と重複) を削除、WHY のみ残す

**Round 2 fix (commit 4fb700d)**:
- F3.2 (Agent 2/3 cross-confirm): `isTranslated()` 二重呼び出し → `checkFile()` の戻り値を `{ violations, translated }` に変更、main で unpack で解消

**Round 1+2 で skip した finding**: 13 件 (frontmatter 抽出共通化 / Stringly-typed PATTERNS / parameter sprawl / 2 loop 統合 / error handling missing / hard-coded paths config 化 / Promise.all / regex merge / diff-based selection 等) — scope creep / premature optimization / cosmetic / false positive と判定

🤖 Generated with [Claude Code](https://claude.com/claude-code)