### PR TITLE
feat: bin/dev-setup に slug-cache redirect 追加 — step-84 サブタスク 8 (4 GAP bin pilot)

### DIFF
--- a/bin/dev-setup
+++ b/bin/dev-setup
@@ -83,3 +83,19 @@ if [[ "$TARGET_DIR" == "$REPO_ROOT" ]]; then
 else
   echo "To tear down (manual for now): rm -rf \"$TARGET_DIR/.claude/skills/<skill>\""
 fi
+
+# 上流 gstack-slug は CACHE_DIR を hardcode するため、symlink で物理書込先を
+# uzustack 側に redirect する。既存 dir 内容は cp -n で保全 merge。
+GSTACK_CACHE="$HOME/.gstack/slug-cache"
+UZUSTACK_CACHE="$HOME/.uzustack/slug-cache"
+mkdir -p "$UZUSTACK_CACHE"
+if [[ ! -L "$GSTACK_CACHE" ]]; then
+  if [[ -d "$GSTACK_CACHE" ]]; then
+    cp -n "$GSTACK_CACHE"/* "$UZUSTACK_CACHE/" 2>/dev/null || true
+    rm -rf "$GSTACK_CACHE"
+  elif [[ -e "$GSTACK_CACHE" ]]; then
+    rm -f "$GSTACK_CACHE"
+  fi
+  mkdir -p "$(dirname "$GSTACK_CACHE")" 2>/dev/null || true
+  ln -snf "$UZUSTACK_CACHE" "$GSTACK_CACHE"
+fi

--- a/bin/dev-teardown
+++ b/bin/dev-teardown
@@ -42,6 +42,10 @@ done
 rmdir "$CLAUDE_SKILLS" 2>/dev/null || true
 rmdir "$TARGET_DIR/.claude" 2>/dev/null || true
 
+# dev-setup で作成した slug-cache redirect symlink を解除（symlink 時のみ、内容は uzustack 側に温存）
+GSTACK_CACHE="$HOME/.gstack/slug-cache"
+[[ -L "$GSTACK_CACHE" ]] && rm -f "$GSTACK_CACHE"
+
 if (( ${#removed[@]} > 0 )); then
   echo "Removed from $CLAUDE_SKILLS:"
   echo "  ${removed[*]}"


### PR DESCRIPTION
## Summary
- 上流 gstack-slug の `~/.gstack/slug-cache/` 書込を `~/.uzustack/slug-cache/` に **symlink redirect**
- bin/dev-setup に redirect step + bin/dev-teardown に逆操作 (対称性) 追加
- step-82 plan-ceo-review で identified した **GSTACK_HOME 非対応 4 GAP bin** の 1 つ目を解消、step-84 サブタスク 8 として追跡

## Background
step-82 で `/learn` skill 翻訳化で core path 解消したが、上流 skill (未翻訳 freeze / unfreeze / guard 等) や上流 bin が `~/.claude/skills/gstack/bin/gstack-slug` を呼ぶたびに **`~/.gstack/slug-cache/` に書込** が発生。原因は上流 gstack-slug の `CACHE_DIR="$HOME/.gstack/slug-cache"` hardcode (env 非対応)。本 PR は **slug-cache だけ shadow symlink で redirect** する短期 fix。

## 変更内容
- `bin/dev-setup` (+12 lines)：末尾に slug-cache redirect step 追加
  - 4 path 分岐 (symlink / dir / regular file or broken symlink / 不在) で edge case 全 cover
  - 既存 dir 内容は `cp -n` で `~/.uzustack/slug-cache/` に merge (上書き避け)
  - `ln -snf` で setup pattern と整合 + idempotent 強化
- `bin/dev-teardown` (+4 lines)：対称性で逆操作 (symlink 解除) を追加
  - symlink 時のみ `rm -f`、内容は uzustack 側に温存

## Verification
- **手動 1 回実行**：dir → symlink 化、`~/.gstack/slug-cache → ~/.uzustack/slug-cache`
- **dogfood**：上流 gstack-slug 直叩きで `~/.uzustack/slug-cache/` に redirect 書込確認
- **dev-setup 再実行**：idempotent (no error、symlink 維持)
- **dev-teardown → dev-setup re-run**：symlink 解除 → 復元 cycle、対称性確認

## /simplify Round 1 fix 履歴
- F1.1: dev-teardown に逆操作追加 (対称性確保)
- F1.2: `ln -s` → `ln -snf` に統一 (setup pattern 整合 + idempotent 強化)
- F2.1: Edge case (regular file / broken symlink) 対応、4 path 分岐で全 cover
- F2.4: Comment 簡潔化 (context trace は commit message に移譲、code は WHY のみ)
- skip 8 件：F1.3 helper 化 (premature) / F1.4 find -exec (minor) / F2.2 cp -n empty (実装 OK) / F2.3 rm -rf error (`set -euo pipefail` で auto-catch) / F2.5 echo style (許容) / F3.1-5 efficiency (minor / false positive)
- Round 2 skip：scope 小 + memory `simplify_specificity_drift.md` Round 2 drift risk

## Step tracking
- step-84 サブタスク 8 として追跡 (他 3 GAP bin = update-check / telemetry-log / repo-mode は Phase 4 cluster pair で順次)

## Test plan
- [x] 手動 1 回実行で dir → symlink 化
- [x] 上流 gstack-slug 直叩きで ~/.uzustack/ 側 redirect
- [x] bin/dev-setup 再実行で idempotent
- [x] bin/dev-teardown で symlink 解除 + dev-setup 再実行で復元 (対称性)
- [x] /simplify Round 1 (4 件 fix + 8 件 skip)、Round 2 skip 判断 (scope 小)

🤖 Generated with [Claude Code](https://claude.com/claude-code)