### PR TITLE
docs: _upstream/gstack/ 内 setup 実行禁止規律を 3 docs に明記

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -197,6 +197,10 @@ git subtree pull --prefix _upstream/gstack https://github.com/garrytan/gstack.gi
 
 `feature/sync-gstack-<日付>-<skill>` ブランチで再翻訳。詳細手順は [CONTRIBUTING.md](CONTRIBUTING.md#gstack-更新追従) を参照。
 
+### `_upstream/gstack/` 内で setup を走らせない
+
+`cd _upstream/gstack && ./setup` 等、 `_upstream/` 配下を CWD として gstack 本家 setup を実行してはならない。 Claude Code の skill discovery（CWD 配下の `.claude/skills/` を再帰探索する monorepo 仕様）により subtree 英語版が翻訳版と重複表示される。 host install dir（`.claude/skills/` 等 11 系統）は `_upstream/gstack/.gitignore` で git track 外、 subtree pull の上書き対象でもないため、 一度作られると物理 rm 必要。 詳細は [docs/uzustack/translation-rebase-fixes.md](docs/uzustack/translation-rebase-fixes.md) 参照（issue #132 / step-86）。
+
 `_upstream/gstack/` 配下の編集は禁止（subtree pull の上書き対象）。uzustack 独自編集は repo top の `<skill>/` 配下または root level で行う。
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,6 +183,12 @@ gh pr create
 
 自動 PR の中に翻訳済み skill（`type: translated`）の上流変更が含まれていたら、[翻訳ガイド](#翻訳ガイドgstack-の英語スキルを翻訳する場合) の「rebase の手順」を参照して再翻訳します。uzustack 独自部分（`type: native`）は gstack 更新と無関係。
 
+### `_upstream/gstack/` 内で setup を走らせない
+
+**禁止**：`cd _upstream/gstack && ./setup` 等、 `_upstream/` 配下を CWD として gstack 本家 setup を実行してはならない。 host install 結果（`.claude/skills/` 等 11 dir）が `_upstream/gstack/` 内に作られると、 Claude Code の skill discovery（CWD 配下の `.claude/skills/` を再帰探索する monorepo 仕様）により **uzustack 翻訳版と subtree 英語版が同じ skill name で重複表示**される。
+
+詳細と再発時の手動 cleanup 手順は [docs/uzustack/translation-rebase-fixes.md](docs/uzustack/translation-rebase-fixes.md#_upstreamgstack-内で-setup-を走らせないpr-131-step-86--issue-132) を参照（issue #132 / step-86）。
+
 ---
 
 ## Type 2 → Type 3 への昇華プロセス

--- a/docs/uzustack/translation-rebase-fixes.md
+++ b/docs/uzustack/translation-rebase-fixes.md
@@ -39,3 +39,43 @@ uzustack は `~/.uzustack/` で完結する世界線を持つ設計だが、 上
 | `setup` line 403 loop に `_upstream` EXCLUDE 追加 | gstack subtree pull の上書き対象を skill loop から除外。 line 404 の SKILL.md 存在 check で実質 skip されるが、 `_upstream/` 配下に SKILL.md が混入する将来の subtree 形態変化に対する safeguard | `setup` の `link_claude_skill_dirs()` |
 
 **rebase 時の保持**：上流 gstack の `setup` を翻訳取り込む時、 line 403 loop に `_upstream` EXCLUDE が抜けると同じ bug を再発する。 `bin/dev-setup` の `redirect_gstack_path()` 関数も上流に存在しないため、 上流差分を翻訳に取り込む時に該当しない。
+
+---
+
+## `_upstream/gstack/` 内で setup を走らせない（PR #131 step-86 / issue #132）
+
+**禁止事項**：`cd _upstream/gstack && ./setup` 等、 `_upstream/` 配下を CWD として gstack 本家 setup を実行してはならない。
+
+**理由**：
+
+- gstack 本家 setup は host 別の install 結果（`.claude/skills/`、 `.codex/skills/`、 `.factory/skills/` 等 11 host dir）を CWD 配下に作成する
+- これらは `_upstream/gstack/.gitignore` で全部 ignored = git track 外、 subtree pull の上書き対象でもない
+- しかし Claude Code の skill discovery 仕様（[Automatic discovery from nested directories](https://code.claude.com/docs/en/skills)）= **CWD 配下の `.claude/skills/` を再帰探索**するため、 `<repo>/_upstream/gstack/.claude/skills/` も discoverable
+- 結果：uzustack 翻訳済 skill（root level）と subtree 英語版（_upstream 配下）が **同じ skill name で重複表示**される（`/cont` 補完で `/context-save` が日本語 + 英語の 2 件 等）
+
+**運用ルール**：
+
+- gstack 本家 setup を試したい場合は **uzustack repo の外**で実行する（例：別 clone `~/src/gstack-test/` 等）
+- agentic session が誤って `_upstream/gstack/` 内で setup を起動した場合は、 即時に手動 cleanup（下記）を実行する
+
+**再発時の手動 cleanup**：
+
+```bash
+cd /path/to/uzustack
+rm -rf \
+  _upstream/gstack/.claude \
+  _upstream/gstack/.codex \
+  _upstream/gstack/.factory \
+  _upstream/gstack/.hermes \
+  _upstream/gstack/.gbrain \
+  _upstream/gstack/.kiro \
+  _upstream/gstack/.opencode \
+  _upstream/gstack/.openclaw \
+  _upstream/gstack/.slate \
+  _upstream/gstack/.cursor \
+  _upstream/gstack/.agents
+```
+
+これらは git track 外なので削除しても repo 状態は変わらず、 commit も発生しない（手動 1 度の cleanup として完結）。
+
+**memory 規律との整合**：`setup_no_artifact_cleanup.md`「環境固有の遺物処理は setup 自動化より手動 1 回」 に従い、 `bin/dev-setup` には組み込まず手動対処とする。


### PR DESCRIPTION
Closes #132

## Summary

`_upstream/gstack/.{claude,codex,factory,hermes,gbrain,kiro,opencode,openclaw,slate,cursor,agents}/` 11 host install dir が紛れ込んだ結果、 Claude Code skill discovery の monorepo 仕様で翻訳版と subtree 英語版が重複表示される問題（issue #132）に対する **規律明記による再発防止 fix**。

## 物理 rm は実施済（git track 外）

調査の結果、 これら 11 dir は `_upstream/gstack/.gitignore` で **全部 ignored** = git track 外、 subtree pull の上書き対象でもない。 過去どこかで `cd _upstream/gstack && ./setup` 相当を走らせた **ローカル install 結果**。

ローカル環境では本 session 内で物理 rm 1 度実施済（commit には残らない）：

```bash
rm -rf \
  _upstream/gstack/.claude \
  _upstream/gstack/.codex \
  _upstream/gstack/.factory \
  _upstream/gstack/.hermes \
  _upstream/gstack/.gbrain \
  _upstream/gstack/.kiro \
  _upstream/gstack/.opencode \
  _upstream/gstack/.openclaw \
  _upstream/gstack/.slate \
  _upstream/gstack/.cursor \
  _upstream/gstack/.agents
```

verify 結果：`_upstream/` 配下 SKILL.md 477 → 47 件、 `find . -path "*.claude/skills/context-save/SKILL.md"` で uzustack root level の 1 件のみ残存。

## 変更内容（docs 3 file +50 lines）

### `ARCHITECTURE.md`
- `gstack subtree integration` section に「`_upstream/gstack/` 内で setup を走らせない」 sub-section 追加（簡潔記述 + cross-reference）

### `CONTRIBUTING.md`
- `gstack 更新追従` section に運用ルール追加（禁止 + cross-reference）

### `docs/uzustack/translation-rebase-fixes.md`
- 「`_upstream/gstack/` 内で setup を走らせない」 section 新設（禁止理由 + Claude Code skill discovery 仕様 link + 再発時手動 cleanup 手順）

## 設計判断：bin/dev-setup には組み込まない

- memory `setup_no_artifact_cleanup` 規律：「環境固有の遺物処理は setup 自動化より手動 1 回」
- これら 11 dir は uzustack repo 内に紛れ込んだ host install 結果 = 構造的整合の崩れだが、 dev-setup を走らせる毎に消す形 にすると subtree 配下を毎回 modify する印象、 dev mode の透明性 に反する
- 規律を docs で明記し、 再発時は手動対処（運用コスト最小、 透明性最大）

## 設計判断：subtree-pull workflow には hook 追加せず

- subtree pull で `.claude/skills/` 等は入らない（gstack 本家側でも `.gitignore` 済 = subtree pull の対象外）
- = workflow に cleanup hook を追加しても予防効果なし
- 真の再発 path は「`_upstream/` 内での setup 実行」 = docs 規律明記が直接の予防策

## /simplify

- [x] **Round 1 完遂、 fix 0 件 / skip 0 件 / praise 1 件**（docs only PR、 main loop direct review）
  - praise: 3 docs 全部に cross-reference を張る形で「主たる記述は translation-rebase-fixes.md 1 か所、 ARCHITECTURE / CONTRIBUTING は要約 + link」 = DRY 維持
- [x] **Round 2 skip**（docs only、 logic 変更なし、 specificity drift なし）

## Test plan

- [x] 物理 rm で 11 dir 削除済
- [x] verify：`_upstream/` 配下 SKILL.md 477 → 47 件
- [x] verify：`find . -path "*.claude/skills/context-save/SKILL.md"` で 1 件のみ
- [x] Claude Code 再起動後、 `/cont` 補完で `/context-save` が **日本語版 1 件のみ**表示（手動 verify、 merge 前確認推奨）

## Background

- Issue #132（症状 / Claude Code 公式 skill discovery 仕様 / 修正方針議論の経緯）
- 関連 PR #131 step-85（隣接 root cause = `~/.claude/skills/gstack -> _upstream/gstack` symlink、 本 PR は更にその下層 = Claude Code skill discovery monorepo 仕様での `_upstream/.../.claude/skills/` 再帰発見）
- 関連 step：step-86（新規、 本 PR の milestone）

🤖 Generated with [Claude Code](https://claude.com/claude-code)