### PR TITLE
docs: OSS 公開時の sanitize 規律を CLAUDE.md に追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,10 @@ skill 実行の中間成果物（checkpoint / timeline / 学習履歴）は `~/.
 
 詳細は [ARCHITECTURE.md](ARCHITECTURE.md) の State preservation layer section を参照。
 
+## OSS 公開時の sanitize
+
+`~/.claude/` (user home) 内容を OSS 公開 surface に貼らない。絶対 path (`/Users/<name>/...`) / ls 出力 / file 内容 / 個人固有名 / OS user 名 / vault 名 を PR / issue / commit message / branch 名 / file 名 に書かない。OK: placeholder (`~/.claude/projects/{slug}/`) と抽象要約。push 前に `/Users/` `/home/` 等の残存を grep。
+
 ## 守破離 / Phase 進捗
 
 現在は **Phase 3.6（進行中）**。型の取り込みは Phase 3.5 で完了（2026-05-02）、守の完成は Phase 6 で達成予定。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ skill 実行の中間成果物（checkpoint / timeline / 学習履歴）は `~/.
 
 ## OSS 公開時の sanitize
 
-`~/.claude/` (user home) 内容を OSS 公開 surface に貼らない。絶対 path (`/Users/<name>/...`) / ls 出力 / file 内容 / 個人固有名 / OS user 名 / vault 名 を PR / issue / commit message / branch 名 / file 名 に書かない。OK: placeholder (`~/.claude/projects/{slug}/`) と抽象要約。push 前に `/Users/` `/home/` 等の残存を grep。
+`~/.claude/` (user home) 内容を OSS 公開 surface に貼らない。絶対 path (`/Users/<name>/...`) / ls 出力 / file 内容 / 個人固有名 / OS user 名 / vault 名 を PR (title / body / コメント) / issue (title / body / コメント) / commit message / branch 名 / file 名 に書かない。OK: placeholder (`~/.claude/projects/{slug}/`) と抽象要約。push 前に `/Users/` `/home/` 等の残存を grep。
 
 ## 守破離 / Phase 進捗
 


### PR DESCRIPTION
## Summary

- `CLAUDE.md` の `## State preservation` 直後に `## OSS 公開時の sanitize` section (4 lines / 1 paragraph) を追加
- `~/.claude/` (user home) 内容 / 絶対 path / 個人固有名 / OS user 名 / vault 名 を OSS 公開 surface (PR title・body・コメント / issue title・body・コメント / commit message / branch 名 / file 名) に貼らない規律 + push 前 grep 命令を明文化
- 前 session で text 圧縮済 (= 700 → 276 → 308 文字、 user-level CLAUDE.md → project root CLAUDE.md 配置修正による scope 自明化で caveat 削除)

Closes #145
Refs #136

## self-consistency check

新 section text 自身が新規律を遵守しているか:

| 規律項目 | 違反候補 | 判定 |
|---|---|---|
| 絶対 path `/Users/<name>/...` 禁止 | `/Users/<name>/...` (placeholder 例示) | ✅ OK (`<name>` placeholder で実 username 不在) |
| 個人固有名 / OS user 名 禁止 | なし | ✅ OK |
| vault 名 禁止 | なし | ✅ OK |
| placeholder OK | `~/.claude/projects/{slug}/` | ✅ OK (`{slug}` で抽象化) |

commit message / branch 名 (`docs/oss-sanitize-rule`) / PR title / PR body もすべて同規律遵守 (個人固有名 / 絶対 path 不在)。

## /simplify Round 1 audit trail

`.claude/rules/workflow.md` 規律「極小 diff (1〜2 file、 trivial fix) は 1 周のみ」 適用、 3 agent 並列で Round 1 実行:

### Round 1 で fix した findings (commit 4a4e55c)

- **surface list 拡張** (med、 Agent quality + coverage 双方が独立指摘 = cross-validation): `PR / issue` を `PR (title / body / コメント) / issue (title / body / コメント)` に拡張。 squash merge 後 commit message も `commit message` に含まれる前提で別途列挙不要

### Deferred to follow-up (audit trail として記録、 個別 action 時に都度判断)

| # | 重要度 | 内容 | 判定理由 |
|---|---|---|---|
| 1 | Med | `.claude/rules/review.md` の sanitize 規律 (`sanitize 作業自体の self-referential leak 防止`) との cross-reference 双方向 link | scope 拡大 — cross-reference 整備は別 task として扱う方が caveat creep を避けられる |
| 2 | Med | push 前 grep の CI 自動化 (`sanitize-guard.yml` 等) + pre-commit hook | 規律本文ではなく自動化 layer の責務、 CI / hook 化 commit 時点で別 issue 起票 |
| 3 | Low | `bin/uzustack-slug` で branch 名 sanitize 済の言及 | 既存 tool 言及は CLAUDE.md ではなく `bin/uzustack-slug` の comment / docs 側に持たせる方が自然 |
| 4 | Low | Claude 出力 / error log 貼付け時の sanitize 規律明示 | 規律対象拡張は別 PR で workshopping |
| 5 | Low | `docs/uzustack/placeholder-convention.md` への link | 1 link 追加が caveat creep の入り口、 必要時 (= placeholder 仕様 query があった時) 都度追加 |

### 仕分け方針

trivial 1 周の運用として「規律 literal coverage に直結する findings のみ即時 fix、 cross-reference / automation / 派生規律拡張は follow-up」 を原則化。 前 session の compression effort (700 → 276 文字) を /simplify findings で無効化しない。

## Test plan

- [x] `git diff CLAUDE.md` で +4 lines / -0 lines / single section 追加を確認 (commit 49fc0f9)
- [x] /simplify Round 1 fix 適用 (commit 4a4e55c、 surface list 拡張 +1 line)
- [x] 新 section text の self-consistency check 4 項目すべて ✅
- [x] pre-commit sanitize grep: diff / commit message / branch 名 / PR title / PR body に `/Users/<name>/` `/home/<name>/` 個人固有名 残存ゼロ
- [x] commit message / branch 名 (`docs/oss-sanitize-rule`) / PR title / PR body に個人固有名 / 絶対 path 不在 (= 新規律の最初の application target を本 PR で達成)
- [x] /simplify Round 1 (trivial 1 周 exception 適用) 完了、 audit trail を本 PR body に記録

## Out of scope

- user-level `~/.claude/CLAUDE.md` の変更 (前 session で edit-then-revert 済、 本 PR 対象外)
- `~/.claude/plans/` 配下の旧 plan file の整理 (別 step で判断)
- /simplify deferred findings (上記 5 件、 個別 action 時に都度判断)
