### PR TITLE
fix: plan-* skill の broken bin 参照を uzustack-slug 直呼びに切替 — issue #137 / step-97

### DIFF
--- a/plan-ceo-review/SKILL.md
+++ b/plan-ceo-review/SKILL.md
@@ -117,8 +117,9 @@ git log --since=30.days --name-only --format="" | sort | uniq -c | sort -rn | he
 **設計ドキュメント check：**
 ```bash
 setopt +o nomatch 2>/dev/null || true  # zsh compat
-SLUG=$(~/.claude/skills/uzustack/browse/bin/remote-slug 2>/dev/null || basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")
-BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/' '-' || echo 'no-branch')
+eval "$(~/.claude/skills/uzustack/bin/uzustack-slug 2>/dev/null)"
+SLUG="${SLUG:-$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")}"
+BRANCH="${BRANCH:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/' '-' || echo 'no-branch')}"
 DESIGN=$(ls -t ~/.uzustack/projects/$SLUG/*-$BRANCH-design-*.md 2>/dev/null | head -1)
 [ -z "$DESIGN" ] && DESIGN=$(ls -t ~/.uzustack/projects/$SLUG/*-design-*.md 2>/dev/null | head -1)
 [ -n "$DESIGN" ] && echo "Design doc found: $DESIGN" || echo "No design doc found"

--- a/plan-ceo-review/SKILL.md.tmpl
+++ b/plan-ceo-review/SKILL.md.tmpl
@@ -115,8 +115,9 @@ git log --since=30.days --name-only --format="" | sort | uniq -c | sort -rn | he
 **設計ドキュメント check：**
 ```bash
 setopt +o nomatch 2>/dev/null || true  # zsh compat
-SLUG=$(~/.claude/skills/uzustack/browse/bin/remote-slug 2>/dev/null || basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")
-BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/' '-' || echo 'no-branch')
+eval "$(~/.claude/skills/uzustack/bin/uzustack-slug 2>/dev/null)"
+SLUG="${SLUG:-$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")}"
+BRANCH="${BRANCH:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/' '-' || echo 'no-branch')}"
 DESIGN=$(ls -t ~/.uzustack/projects/$SLUG/*-$BRANCH-design-*.md 2>/dev/null | head -1)
 [ -z "$DESIGN" ] && DESIGN=$(ls -t ~/.uzustack/projects/$SLUG/*-design-*.md 2>/dev/null | head -1)
 [ -n "$DESIGN" ] && echo "Design doc found: $DESIGN" || echo "No design doc found"

--- a/plan-devex-review/SKILL.md
+++ b/plan-devex-review/SKILL.md
@@ -87,8 +87,9 @@ git diff $(git merge-base HEAD main 2>/dev/null || echo HEAD~10) --stat 2>/dev/n
 **Design doc check：**
 ```bash
 setopt +o nomatch 2>/dev/null || true
-SLUG=$(~/.claude/skills/uzustack/browse/bin/remote-slug 2>/dev/null || basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")
-BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/' '-' || echo 'no-branch')
+eval "$(~/.claude/skills/uzustack/bin/uzustack-slug 2>/dev/null)"
+SLUG="${SLUG:-$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")}"
+BRANCH="${BRANCH:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/' '-' || echo 'no-branch')}"
 DESIGN=$(ls -t ~/.uzustack/projects/$SLUG/*-$BRANCH-design-*.md 2>/dev/null | head -1)
 [ -z "$DESIGN" ] && DESIGN=$(ls -t ~/.uzustack/projects/$SLUG/*-design-*.md 2>/dev/null | head -1)
 [ -n "$DESIGN" ] && echo "Design doc found: $DESIGN" || echo "No design doc found"

--- a/plan-devex-review/SKILL.md.tmpl
+++ b/plan-devex-review/SKILL.md.tmpl
@@ -91,8 +91,9 @@ git diff $(git merge-base HEAD main 2>/dev/null || echo HEAD~10) --stat 2>/dev/n
 **Design doc check：**
 ```bash
 setopt +o nomatch 2>/dev/null || true
-SLUG=$(~/.claude/skills/uzustack/browse/bin/remote-slug 2>/dev/null || basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")
-BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/' '-' || echo 'no-branch')
+eval "$(~/.claude/skills/uzustack/bin/uzustack-slug 2>/dev/null)"
+SLUG="${SLUG:-$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")}"
+BRANCH="${BRANCH:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/' '-' || echo 'no-branch')}"
 DESIGN=$(ls -t ~/.uzustack/projects/$SLUG/*-$BRANCH-design-*.md 2>/dev/null | head -1)
 [ -z "$DESIGN" ] && DESIGN=$(ls -t ~/.uzustack/projects/$SLUG/*-design-*.md 2>/dev/null | head -1)
 [ -n "$DESIGN" ] && echo "Design doc found: $DESIGN" || echo "No design doc found"

--- a/plan-eng-review/SKILL.md
+++ b/plan-eng-review/SKILL.md
@@ -83,8 +83,9 @@ architecture を評価するときは「退屈さを default に」を考えよ�
 ### Design Doc Check
 ```bash
 setopt +o nomatch 2>/dev/null || true  # zsh compat
-SLUG=$(~/.claude/skills/uzustack/browse/bin/remote-slug 2>/dev/null || basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")
-BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/' '-' || echo 'no-branch')
+eval "$(~/.claude/skills/uzustack/bin/uzustack-slug 2>/dev/null)"
+SLUG="${SLUG:-$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")}"
+BRANCH="${BRANCH:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/' '-' || echo 'no-branch')}"
 DESIGN=$(ls -t ~/.uzustack/projects/$SLUG/*-$BRANCH-design-*.md 2>/dev/null | head -1)
 [ -z "$DESIGN" ] && DESIGN=$(ls -t ~/.uzustack/projects/$SLUG/*-design-*.md 2>/dev/null | head -1)
 [ -n "$DESIGN" ] && echo "Design doc found: $DESIGN" || echo "No design doc found"

--- a/plan-eng-review/SKILL.md.tmpl
+++ b/plan-eng-review/SKILL.md.tmpl
@@ -82,8 +82,9 @@ architecture を評価するときは「退屈さを default に」を考えよ�
 ### Design Doc Check
 ```bash
 setopt +o nomatch 2>/dev/null || true  # zsh compat
-SLUG=$(~/.claude/skills/uzustack/browse/bin/remote-slug 2>/dev/null || basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")
-BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/' '-' || echo 'no-branch')
+eval "$(~/.claude/skills/uzustack/bin/uzustack-slug 2>/dev/null)"
+SLUG="${SLUG:-$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")}"
+BRANCH="${BRANCH:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/' '-' || echo 'no-branch')}"
 DESIGN=$(ls -t ~/.uzustack/projects/$SLUG/*-$BRANCH-design-*.md 2>/dev/null | head -1)
 [ -z "$DESIGN" ] && DESIGN=$(ls -t ~/.uzustack/projects/$SLUG/*-design-*.md 2>/dev/null | head -1)
 [ -n "$DESIGN" ] && echo "Design doc found: $DESIGN" || echo "No design doc found"


### PR DESCRIPTION
## Summary

`plan-ceo-review` / `plan-devex-review` / `plan-eng-review` の 3 SKILL.md.tmpl で参照していた broken bin `~/.claude/skills/uzustack/browse/bin/remote-slug` (browse skill 未実装で存在しない) を canonical pattern `~/.claude/skills/uzustack/bin/uzustack-slug` に切替。 fallback 経路を defensive な `${VAR:-default}` 形式で articulate し、 「browse 機構なくても動く保証」 を維持。

Closes #137

## 変更 detail

3 file × 同一 bash block を以下に変換:

**Before**:
```bash
SLUG=$(~/.claude/skills/uzustack/browse/bin/remote-slug 2>/dev/null || basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")
BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/' '-' || echo 'no-branch')
```

**After**:
```bash
eval "$(~/.claude/skills/uzustack/bin/uzustack-slug 2>/dev/null)"
SLUG="${SLUG:-$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")}"
BRANCH="${BRANCH:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/' '-' || echo 'no-branch')}"
```

合計 +18 / -12 (3 file × .tmpl + 生成 .md の 6 file)、 `bun run gen:skill-docs` で生成済。

## 設計判断

| 項目 | 採用 | 理由 |
|---|---|---|
| canonical pattern | `eval "$(uzustack-slug)"` | 既存翻訳済 skill (`design-html`、 `plan-tune`、 `design-shotgun`) と一貫 |
| uzustack-bin 直呼び | `~/.claude/skills/uzustack/bin/uzustack-slug` | voice 規約 v1 / `.claude/rules/workflow.md` の plan-ceo-review 規律遵守 |
| fallback articulate | `${SLUG:-...}` / `${BRANCH:-...}` | issue Acceptance criteria 「browse 機構なくても動く保証」 を defensive に表現 |
| `setopt +o nomatch` | 保持 | zsh compat 用、 各 file の既存 wording (コメントあり / なし) を尊重 |

## 検証 (smoke test 実施済)

### canonical path (uzustack-slug 利用可)

```
$ eval "$(~/.claude/skills/uzustack/bin/uzustack-slug 2>/dev/null)"
SLUG=uzumaki-inc-uzustack
BRANCH=fixplan-skill-broken-bin-reference
```

### fallback path (uzustack-slug bin missing 想定)

```
$ eval "$(/non-existent-bin 2>/dev/null)"
$ SLUG="${SLUG:-$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")}"
$ BRANCH="${BRANCH:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null | tr '/' '-' || echo 'no-branch')}"
SLUG=uzustack
BRANCH=fix-plan-skill-broken-bin-reference
```

両 path で空文字 / undefined にならず、 design doc lookup の subsequent line (`ls -t ~/.uzustack/projects/$SLUG/*-$BRANCH-design-*.md`) が安全に動作する保証。

## /simplify audit trail (2 周実施、 標準 protocol)

### Round 1 (actionable findings、 3 agent 並列)

| Agent | finding | 重要度 | 仕分け |
|---|---|---|---|
| reuse | 既存 5 canonical site (`design-html`、 `plan-tune`、 `design-shotgun` 等) は `eval "$(uzustack-slug)"` 単独で `${VAR:-...}` fallback 無し → 新 3 site は divergent pattern | low | **skip** — issue #137 Acceptance criteria 「fallback を articulate」 と整合、 「behaviorally equivalent」 評価、 5 既存 site 伝播は scope 拡大 |
| quality | bash quality 全 check 通過 (eval safety / `${:-}` semantics / echo chain / copy-paste / comment) | — | No actionable findings |
| edge case | 全 edge case 妥当 (non-git / external env / glob 暴走不可 / setopt) | — | No actionable findings |

### Round 2 (cross-validation + drift 検出、 `/simplify` skill 再 invocation で 3 agent 並列)

| Agent | Round 1 confirmation | 新規 finding (cross-validation で surface) | 重要度 |
|---|---|---|---|
| reuse | confirmed (defensive fallback 意図的 skip) | helper bin 抽出却下 (scope)、 broken bin 0 残存、 upstream divergence は守期間規律と整合 | none |
| quality | confirmed | 1) eval 失敗時 silent swallow は graceful degradation 意図通り / 2) **旧 `\|\| echo 'no-branch'` も dead code (tr exit status のみ反応) = 新 pattern は旧 dead code を継承、 semantics drift なし** / 3) fallback sanitize 非対称 (basename 側 unsanitized、 git toplevel basename で特殊文字稀、 許容範囲) | low × 2、 none × 1 |
| efficiency | confirmed | 1) `git rev-parse` worst case 3 回呼出だが bash `${VAR:-default}` short-circuit で正常 path で fallback 評価されない (実 invoke 増えず) / 2) cache bypass 整合 OK / 3) canonical divergence は防御層として正当 | low × 2、 none × 1 |

**Round 2 verdict (3 agent 独立)**: 全 agent が「3 周目不要、 即時修正候補なし、 merge ready」 に独立到達。

### Round 2 で得た深掘り insight

- **BRANCH semantics の旧 dead code 継承**: 旧 `BRANCH=$(... | tr '/' '-' || echo 'no-branch')` の `|| echo 'no-branch'` は **元から dead code** (tr が空入力でも success exit するため発火しない)。 新 pattern の `${BRANCH:-... || echo 'no-branch'}` 内も同様 dead code を継承。 「articulate」 した fallback の中身が旧 dead code であった事実は specificity drift ではなく **semantics 等価性の証明** (= 旧挙動を完全保持)
- **BRANCH sanitization の cross-path divergence**: uzustack-slug 内 `tr -cd 'a-zA-Z0-9._-'` (strip `/`) vs fallback `tr '/' '-'` (convert)。 同 branch でも path で BRANCH 値が異なるが、 SLUG が dominant key で実害なし。 uzustack-slug 側の sanitize 統一は将来 task として deferred

### 仕分け原則

`.claude/rules/review.md` 「Round 2 specificity drift 検出時は即時修正 + audit trail、 3 周目を回さない」 の解釈:
- drift が **spec 違反 (= 原文逸脱)** → 即時修正
- drift が **acceptable divergence (= 両 path で生きる中の差)** → audit trail のみ

本件 Round 1 + Round 2 findings は全 後者に該当、 即時修正対象なし。 3 周目不要。

## sanitize self-check

- commit message / branch 名 (`fix/plan-skill-broken-bin-reference`) / PR title / PR body に個人固有名 / 絶対 path 不在 (新規律 PR #146 application target 2 件目)
- 変更内容に `~/.claude/skills/uzustack/...` (placeholder 形式) のみ含み、 実 username / vault 名なし

## Test plan

- [x] 3 SKILL.md.tmpl 編集 + `bun run gen:skill-docs` で 3 SKILL.md 自動再生成 (合計 6 file の整合 commit)
- [x] uzustack proper の broken pattern `browse/bin/remote-slug` 残存 grep — 0 件確認 (CHANGELOG.md の履歴記述と greptile-triage.md は scope 外)
- [x] canonical path smoke test (= uzustack-slug 利用可) → 正常 output
- [x] fallback path smoke test (= uzustack-slug missing 想定) → 期待 default 値
- [x] pre-publish sanitize grep on diff / commit message / branch 名 / PR title / PR body — 全 NO LEAKS
- [x] /simplify Round 1 (actionable findings、 3 agent 並列) — 1 low finding intentional skip
- [x] /simplify Round 2 (cross-validation + drift、 skill 再 invocation で 3 agent 並列) — 4 low findings + 2 none、 全 acceptable divergence で skip、 3 周目不要 verdict
- [x] CI: Skill Docs Freshness check PASSED (= .tmpl ↔ .md 整合確認済)

## Out of scope

- **`review/greptile-triage.md:37,186`**: 同種 broken pattern (`~/.claude/skills/uzustack/browse/bin/remote-slug`) 残存だが、 変数名 `REMOTE_SLUG`、 3-tier fallback、 greptile 統合 context と異なる concerns。 別 issue で扱う
- **`_upstream/gstack/` 配下の同 pattern**: upstream tech debt 観測リスト行き (uzustack 単独修正保留、 守期間規律)
- **CHANGELOG.md:35 の記述更新**: ship タイミングで bump 時に処理 (本 PR は fix のみ、 CHANGELOG entry 化は別判断)
- **BRANCH sanitization の cross-path 統一**: uzustack-slug 側の `tr -cd` と fallback `tr '/' '-'` の divergence、 acceptable な実害なし divergence として skip。 統一する場合は別 task で uzustack-slug の sanitize 仕様変更を含む scope
- **canonical 5 site への fallback 伝播**: design-html / plan-tune / design-shotgun 等の既存 `eval` 単独 site に `${VAR:-...}` defensive 層を伝播するか否か。 acceptable divergence と評価され本 PR scope 外、 将来必要時に判断
