### PR TITLE
feat: freeze + unfreeze pair 翻訳化 — Refs #152

### DIFF
--- a/freeze/SKILL.md
+++ b/freeze/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: freeze
+type: translated
+version: 0.1.0
+description: |
+  ファイル編集を特定の directory に制限する（session スコープ）。許可された
+  path の外への Edit / Write 操作を block する。 デバッグ中に無関係なコードを
+  誤って「修正」してしまうのを防ぐ、 または変更を 1 つの module に限定したい時
+  に使う。「freeze して」「編集を制限」「この folder だけ編集」
+  「編集を lock down」 と要求されたときに使用する。(uzustack)
+triggers:
+  - freezeモード
+  - 編集範囲を固定して
+  - このフォルダ以外触らないで
+  - 作業範囲を制限
+  - 誤爆防止
+allowed-tools:
+  - Bash
+  - Read
+  - AskUserQuestion
+hooks:
+  PreToolUse:
+    - matcher: "Edit"
+      hooks:
+        - type: command
+          command: "bash $CLAUDE_PROJECT_DIR/.claude/skills/freeze/bin/check-freeze.sh"
+          statusMessage: "freeze 境界をチェック中..."
+    - matcher: "Write"
+      hooks:
+        - type: command
+          command: "bash $CLAUDE_PROJECT_DIR/.claude/skills/freeze/bin/check-freeze.sh"
+          statusMessage: "freeze 境界をチェック中..."
+---
+<!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
+<!-- Regenerate: bun run gen:skill-docs -->
+
+# /freeze — directory への編集制限
+
+ファイル編集を特定の directory に lock する。 許可された path の外を targeting する Edit / Write 操作は **block される**（警告だけではない）。
+
+```bash
+mkdir -p ~/.uzustack/analytics
+echo '{"skill":"freeze","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}'  >> ~/.uzustack/analytics/skill-usage.jsonl 2>/dev/null || true
+```
+
+## Setup
+
+ユーザーに編集を制限する directory を尋ねる。 AskUserQuestion を使う：
+
+- Question: 「どの directory に編集を制限しますか？ この path の外のファイルは編集が block されます。」
+- Text input（multiple choice ではない）— ユーザーが path を typed input する。
+
+ユーザーが directory path を提供したら：
+
+1. 絶対 path に解決する：
+```bash
+FREEZE_DIR=$(cd "<user-provided-path>" 2>/dev/null && pwd)
+echo "$FREEZE_DIR"
+```
+
+2. trailing slash を確実にして freeze state file に保存：
+```bash
+FREEZE_DIR="${FREEZE_DIR%/}/"
+STATE_DIR="${CLAUDE_PLUGIN_DATA:-$HOME/.uzustack}"
+mkdir -p "$STATE_DIR"
+echo "$FREEZE_DIR" > "$STATE_DIR/freeze-dir.txt"
+echo "Freeze 境界を設定: $FREEZE_DIR"
+```
+
+ユーザーに伝える：「編集は今 `<path>/` に制限されています。 この directory 外の Edit / Write は block されます。 境界を変更するには `/freeze` をもう一度実行。 削除するには `/unfreeze` を実行するか session を終了。」
+
+## 動作の仕組み
+
+hook は Edit / Write tool input JSON から `file_path` を読み取り、 その path が freeze directory で始まるかを check する。 始まらない場合は `permissionDecision: "deny"` を返して操作を block する。
+
+freeze 境界は state file 経由で session 内で persist される。 hook script は Edit / Write の invocation ごとに state file を読む。
+
+## Notes
+
+- freeze directory の trailing `/` は `/src` が `/src-old` にマッチするのを防ぐ
+- freeze は Edit と Write tool のみに適用 — Read / Bash / Glob / Grep は影響を受けない
+- これは security boundary ではなく **事故防止** のもの — `sed` のような Bash コマンドは依然として境界外のファイルを変更できる
+- 無効化するには `/unfreeze` を実行するか会話を終了する

--- a/freeze/SKILL.md
+++ b/freeze/SKILL.md
@@ -78,6 +78,6 @@ freeze 境界は state file 経由で session 内で persist される。 hook s
 ## Notes
 
 - freeze directory の trailing `/` は `/src` が `/src-old` にマッチするのを防ぐ
-- freeze は Edit と Write tool のみに適用 — Read / Bash / Glob / Grep は影響を受けない
+- freeze は Edit / Write tool のみに適用 — Read / Bash / Glob / Grep は影響を受けない
 - これは security boundary ではなく **事故防止** のもの — `sed` のような Bash コマンドは依然として境界外のファイルを変更できる
 - 無効化するには `/unfreeze` を実行するか会話を終了する

--- a/freeze/SKILL.md.tmpl
+++ b/freeze/SKILL.md.tmpl
@@ -77,6 +77,6 @@ freeze 境界は state file 経由で session 内で persist される。 hook s
 ## Notes
 
 - freeze directory の trailing `/` は `/src` が `/src-old` にマッチするのを防ぐ
-- freeze は Edit と Write tool のみに適用 — Read / Bash / Glob / Grep は影響を受けない
+- freeze は Edit / Write tool のみに適用 — Read / Bash / Glob / Grep は影響を受けない
 - これは security boundary ではなく **事故防止** のもの — `sed` のような Bash コマンドは依然として境界外のファイルを変更できる
 - 無効化するには `/unfreeze` を実行するか会話を終了する

--- a/freeze/SKILL.md.tmpl
+++ b/freeze/SKILL.md.tmpl
@@ -1,0 +1,82 @@
+---
+name: freeze
+type: translated
+version: 0.1.0
+description: |
+  ファイル編集を特定の directory に制限する（session スコープ）。許可された
+  path の外への Edit / Write 操作を block する。 デバッグ中に無関係なコードを
+  誤って「修正」してしまうのを防ぐ、 または変更を 1 つの module に限定したい時
+  に使う。「freeze して」「編集を制限」「この folder だけ編集」
+  「編集を lock down」 と要求されたときに使用する。(uzustack)
+triggers:
+  - freezeモード
+  - 編集範囲を固定して
+  - このフォルダ以外触らないで
+  - 作業範囲を制限
+  - 誤爆防止
+allowed-tools:
+  - Bash
+  - Read
+  - AskUserQuestion
+hooks:
+  PreToolUse:
+    - matcher: "Edit"
+      hooks:
+        - type: command
+          command: "bash $CLAUDE_PROJECT_DIR/.claude/skills/freeze/bin/check-freeze.sh"
+          statusMessage: "freeze 境界をチェック中..."
+    - matcher: "Write"
+      hooks:
+        - type: command
+          command: "bash $CLAUDE_PROJECT_DIR/.claude/skills/freeze/bin/check-freeze.sh"
+          statusMessage: "freeze 境界をチェック中..."
+sensitive: true
+---
+
+# /freeze — directory への編集制限
+
+ファイル編集を特定の directory に lock する。 許可された path の外を targeting する Edit / Write 操作は **block される**（警告だけではない）。
+
+```bash
+mkdir -p ~/.uzustack/analytics
+echo '{"skill":"freeze","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}'  >> ~/.uzustack/analytics/skill-usage.jsonl 2>/dev/null || true
+```
+
+## Setup
+
+ユーザーに編集を制限する directory を尋ねる。 AskUserQuestion を使う：
+
+- Question: 「どの directory に編集を制限しますか？ この path の外のファイルは編集が block されます。」
+- Text input（multiple choice ではない）— ユーザーが path を typed input する。
+
+ユーザーが directory path を提供したら：
+
+1. 絶対 path に解決する：
+```bash
+FREEZE_DIR=$(cd "<user-provided-path>" 2>/dev/null && pwd)
+echo "$FREEZE_DIR"
+```
+
+2. trailing slash を確実にして freeze state file に保存：
+```bash
+FREEZE_DIR="${FREEZE_DIR%/}/"
+STATE_DIR="${CLAUDE_PLUGIN_DATA:-$HOME/.uzustack}"
+mkdir -p "$STATE_DIR"
+echo "$FREEZE_DIR" > "$STATE_DIR/freeze-dir.txt"
+echo "Freeze 境界を設定: $FREEZE_DIR"
+```
+
+ユーザーに伝える：「編集は今 `<path>/` に制限されています。 この directory 外の Edit / Write は block されます。 境界を変更するには `/freeze` をもう一度実行。 削除するには `/unfreeze` を実行するか session を終了。」
+
+## 動作の仕組み
+
+hook は Edit / Write tool input JSON から `file_path` を読み取り、 その path が freeze directory で始まるかを check する。 始まらない場合は `permissionDecision: "deny"` を返して操作を block する。
+
+freeze 境界は state file 経由で session 内で persist される。 hook script は Edit / Write の invocation ごとに state file を読む。
+
+## Notes
+
+- freeze directory の trailing `/` は `/src` が `/src-old` にマッチするのを防ぐ
+- freeze は Edit と Write tool のみに適用 — Read / Bash / Glob / Grep は影響を受けない
+- これは security boundary ではなく **事故防止** のもの — `sed` のような Bash コマンドは依然として境界外のファイルを変更できる
+- 無効化するには `/unfreeze` を実行するか会話を終了する

--- a/freeze/bin/check-freeze.sh
+++ b/freeze/bin/check-freeze.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# check-freeze.sh — /freeze skill の PreToolUse hook
+# stdin から JSON を読み、file_path が freeze 境界内かを check する。
+# block するなら {"permissionDecision":"deny","message":"..."} を、許可なら {} を返す。
+set -euo pipefail
+
+# stdin を読む
+INPUT=$(cat)
+
+# freeze directory の state file 位置を解決
+STATE_DIR="${CLAUDE_PLUGIN_DATA:-$HOME/.uzustack}"
+FREEZE_FILE="$STATE_DIR/freeze-dir.txt"
+
+# freeze file がない場合は全許可（未設定状態）
+if [ ! -f "$FREEZE_FILE" ]; then
+  echo '{}'
+  exit 0
+fi
+
+FREEZE_DIR=$(tr -d '[:space:]' < "$FREEZE_FILE")
+
+# freeze dir が空なら許可
+if [ -z "$FREEZE_DIR" ]; then
+  echo '{}'
+  exit 0
+fi
+
+# tool_input JSON から file_path を抽出
+# まず grep/sed、 escape された quote 用に Python に fallback
+FILE_PATH=$(printf '%s' "$INPUT" | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*:[[:space:]]*"//;s/"$//' || true)
+
+# grep が空を返したら Python fallback
+if [ -z "$FILE_PATH" ]; then
+  FILE_PATH=$(printf '%s' "$INPUT" | python3 -c 'import sys,json; print(json.loads(sys.stdin.read()).get("tool_input",{}).get("file_path",""))' 2>/dev/null || true)
+fi
+
+# file path が取れなければ許可（parse 失敗で block しない）
+if [ -z "$FILE_PATH" ]; then
+  echo '{}'
+  exit 0
+fi
+
+# file_path が絶対 path でなければ絶対化
+case "$FILE_PATH" in
+  /*) ;; # already absolute
+  *)
+    FILE_PATH="$(pwd)/$FILE_PATH"
+    ;;
+esac
+
+# 正規化: double slash 削除 + trailing slash 削除
+FILE_PATH=$(printf '%s' "$FILE_PATH" | sed 's|/\+|/|g;s|/$||')
+
+# symlink と .. 連鎖を resolve（POSIX portable、 macOS 動作）
+_resolve_path() {
+  local _dir _base
+  _dir="$(dirname "$1")"
+  _base="$(basename "$1")"
+  _dir="$(cd "$_dir" 2>/dev/null && pwd -P || printf '%s' "$_dir")"
+  printf '%s/%s' "$_dir" "$_base"
+}
+FILE_PATH=$(_resolve_path "$FILE_PATH")
+FREEZE_DIR=$(_resolve_path "$FREEZE_DIR")
+
+# check: file path が freeze directory で始まるか？
+case "$FILE_PATH" in
+  "${FREEZE_DIR}/"*|"${FREEZE_DIR}")
+    # freeze 境界内 — 許可
+    echo '{}'
+    ;;
+  *)
+    # freeze 境界外 — block
+    # hook 発火 event を log
+    mkdir -p ~/.uzustack/analytics 2>/dev/null || true
+    echo '{"event":"hook_fire","skill":"freeze","pattern":"boundary_deny","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}' >> ~/.uzustack/analytics/skill-usage.jsonl 2>/dev/null || true
+
+    printf '{"permissionDecision":"deny","message":"[freeze] block: %s は freeze 境界 (%s) の外です。freeze された directory 内の編集のみ許可されます。"}\n' "$FILE_PATH" "$FREEZE_DIR"
+    ;;
+esac

--- a/freeze/bin/check-freeze.sh
+++ b/freeze/bin/check-freeze.sh
@@ -74,6 +74,6 @@ case "$FILE_PATH" in
     mkdir -p ~/.uzustack/analytics 2>/dev/null || true
     echo '{"event":"hook_fire","skill":"freeze","pattern":"boundary_deny","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}' >> ~/.uzustack/analytics/skill-usage.jsonl 2>/dev/null || true
 
-    printf '{"permissionDecision":"deny","message":"[freeze] block: %s は freeze 境界 (%s) の外です。freeze された directory 内の編集のみ許可されます。"}\n' "$FILE_PATH" "$FREEZE_DIR"
+    printf '{"permissionDecision":"deny","message":"[freeze] Blocked: %s は freeze 境界 (%s) の外です。freeze された directory 内の編集のみ許可されます。"}\n' "$FILE_PATH" "$FREEZE_DIR"
     ;;
 esac

--- a/unfreeze/SKILL.md
+++ b/unfreeze/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: unfreeze
+type: translated
+version: 0.1.0
+description: |
+  /freeze で設定した freeze 境界を clear し、全 directory への編集を再び許可する。
+  session を終了せずに編集 scope を広げたい時に使う。「unfreeze」「編集を unlock」
+  「freeze を解除」「全編集を許可」 と要求されたときに使用する。(uzustack)
+triggers:
+  - unfreezeモード
+  - 編集制限を解除
+  - 全フォルダ編集可能に
+  - 作業範囲を解除
+  - 誤爆防止を解除
+allowed-tools:
+  - Bash
+  - Read
+---
+<!-- AUTO-GENERATED from SKILL.md.tmpl — do not edit directly -->
+<!-- Regenerate: bun run gen:skill-docs -->
+
+# /unfreeze — freeze 境界を clear
+
+`/freeze` で設定した編集制限を解除し、全 directory への編集を許可する。
+
+```bash
+mkdir -p ~/.uzustack/analytics
+echo '{"skill":"unfreeze","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}'  >> ~/.uzustack/analytics/skill-usage.jsonl 2>/dev/null || true
+```
+
+## 境界を clear
+
+```bash
+STATE_DIR="${CLAUDE_PLUGIN_DATA:-$HOME/.uzustack}"
+if [ -f "$STATE_DIR/freeze-dir.txt" ]; then
+  PREV=$(cat "$STATE_DIR/freeze-dir.txt")
+  rm -f "$STATE_DIR/freeze-dir.txt"
+  echo "Freeze 境界を解除 (旧設定: $PREV)。 編集はどこでも許可されます。"
+else
+  echo "Freeze 境界は設定されていませんでした。"
+fi
+```
+
+ユーザーに結果を伝える。 注：`/freeze` の hook は session に register されたままだが、 state file がないのですべて許可される。 再 freeze するには `/freeze` をもう一度実行する。

--- a/unfreeze/SKILL.md.tmpl
+++ b/unfreeze/SKILL.md.tmpl
@@ -1,0 +1,43 @@
+---
+name: unfreeze
+type: translated
+version: 0.1.0
+description: |
+  /freeze で設定した freeze 境界を clear し、全 directory への編集を再び許可する。
+  session を終了せずに編集 scope を広げたい時に使う。「unfreeze」「編集を unlock」
+  「freeze を解除」「全編集を許可」 と要求されたときに使用する。(uzustack)
+triggers:
+  - unfreezeモード
+  - 編集制限を解除
+  - 全フォルダ編集可能に
+  - 作業範囲を解除
+  - 誤爆防止を解除
+allowed-tools:
+  - Bash
+  - Read
+sensitive: true
+---
+
+# /unfreeze — freeze 境界を clear
+
+`/freeze` で設定した編集制限を解除し、全 directory への編集を許可する。
+
+```bash
+mkdir -p ~/.uzustack/analytics
+echo '{"skill":"unfreeze","ts":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","repo":"'$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "unknown")'"}'  >> ~/.uzustack/analytics/skill-usage.jsonl 2>/dev/null || true
+```
+
+## 境界を clear
+
+```bash
+STATE_DIR="${CLAUDE_PLUGIN_DATA:-$HOME/.uzustack}"
+if [ -f "$STATE_DIR/freeze-dir.txt" ]; then
+  PREV=$(cat "$STATE_DIR/freeze-dir.txt")
+  rm -f "$STATE_DIR/freeze-dir.txt"
+  echo "Freeze 境界を解除 (旧設定: $PREV)。 編集はどこでも許可されます。"
+else
+  echo "Freeze 境界は設定されていませんでした。"
+fi
+```
+
+ユーザーに結果を伝える。 注：`/freeze` の hook は session に register されたままだが、 state file がないのですべて許可される。 再 freeze するには `/freeze` をもう一度実行する。


### PR DESCRIPTION
## Summary

Phase 4「絆を結ぶ」 cluster の epic [#152](https://github.com/uzumaki-inc/uzustack/issues/152) の最初の PR (PR-A)。 step-84-1 サブタスク 1 の前半として freeze + unfreeze pair を翻訳化。

## 変更内容

- `freeze/SKILL.md.tmpl` + `freeze/SKILL.md` (generated) + `freeze/bin/check-freeze.sh` 新規配置
- `unfreeze/SKILL.md.tmpl` + `unfreeze/SKILL.md` (generated) 新規配置
- voice 規約 v1 + 経営者・少人数開発者文脈で日本語化
- `careful/SKILL.md.tmpl` (= step-28 で確立した hook 取り込みパターン) を踏襲

## 機械置換

- `~/.gstack/` → `~/.uzustack/` (analytics path / state dir env var fallback)
- `${CLAUDE_SKILL_DIR}/bin/...` → `$CLAUDE_PROJECT_DIR/.claude/skills/<name>/bin/...`
- `(gstack)` source tag → `(uzustack)`
- hook command + statusMessage 日本語化、 `sensitive: true` 維持

## voice trigger contribute

freeze の triggers 5 件は工藤さんが contribute:

```yaml
triggers:
  - freezeモード
  - 編集範囲を固定して
  - このフォルダ以外触らないで
  - 作業範囲を制限
  - 誤爆防止
```

「誤爆防止」 は body 部の「security boundary ではなく事故防止」 と整合する uzustack 固有の voice 翻案。 unfreeze 側は対称展開 (誤爆防止を解除 等)。

## Test plan

- [x] `bun test` で skill-validate + gen-skill-docs gate-tier test が pass する (exit code 0、 `_upstream/gstack/test/` 配下の failure は upstream tech debt 観測リスト扱い、 本 PR 無関係)
- [x] `bun run gen:skill-docs` で freeze 84 lines / 660 tokens + unfreeze 45 lines / 307 tokens として generate される
- [x] `freeze/bin/check-freeze.sh` が executable (`-rwxr-xr-x`)
- [x] `/simplify` Round 1 完了: actionable 2 件 fix (commit `3ce3e90`)
- [x] `/simplify` Round 2 完了: drift 検出 0 件 (clean)

## /simplify audit trail

### Round 1 (actionable findings 取り扱い)

- **Code Reuse**: actionable 0 / upstream tech debt 観測 4 (analytics emit duplication / git rev-parse inline / STATE_DIR inline / JSON parse pattern — 全て単独修正不可、 観測リスト分離)
- **Code Quality**: actionable 2 / observe-only 7
  - **fix 1 (QUAL-2)**: `freeze/SKILL.md.tmpl:80` `Edit と Write` → `Edit / Write` (同 file 内 voice 一貫性 drift)
  - **fix 2 (QUAL-3)**: `freeze/bin/check-freeze.sh:77` `[freeze] block:` → `[freeze] Blocked:` (label 英語 register 統一、 upstream に揃え)
- **Efficiency**: actionable 0 / observe-only 4 (_resolve_path 2 回 spawn / git rev-parse / mkdir / log rotation 不在 — 全て upstream tech debt)

### Round 2 (cross-validation + drift 検出 — main loop direct grep verification)

small 構成 skill のため sub-agent 並列ではなく main loop で 4 観点確認:

- **R2-1 line count**: bin / unfreeze 完全一致 / freeze/SKILL.md.tmpl の -3 行差は改行 style 違い (specificity drift ではない)
- **R2-2 placeholder marker**: 0 件 ✓
- **R2-3 voice 一貫性**: `(uzustack)` suffix / `type: translated` / hook command path すべて careful 規範と整合
- **R2-4 specificity drift**: trailing slash 例 / `sed` security boundary 例 / Text input 注記 すべて保持

drift 検出 0 件 = clean。 3 周目は回さない ([review.md](https://github.com/uzumaki-inc/uzustack/blob/main/.claude/rules/review.md) 規律「/simplify Round 2 で specificity drift 検出時は即時修正 + audit trail、 3 周目を回さない」)。

### upstream tech debt 観測リスト (Phase 4+ epic で集約)

本 PR で識別、 単独修正は保留 (`.claude/rules/review.md` 規律):

1. analytics emit 2-line inline pattern (freeze / unfreeze / check-freeze.sh + 全 translated skill 共通)
2. `basename "$(git rev-parse --show-toplevel)"` inline (3 箇所、 schema 制約あり)
3. `STATE_DIR="${CLAUDE_PLUGIN_DATA:-$HOME/.uzustack}"` inline (3 箇所)
4. tool_input JSON parse の grep+sed+Python fallback pattern (freeze / careful 共通)
5. `_resolve_path` を hot path で 2 回 spawn (state file 書き込み時 1 度 resolve に圧縮可能)
6. deny 経路の `git rev-parse` 毎回呼び出し (state file cache 可能)
7. deny 経路の `mkdir -p ~/.uzustack/analytics` 毎回 spawn (setup 段階前倒し可能)
8. `~/.uzustack/analytics/skill-usage.jsonl` の log rotation 不在 (uzustack analytics 基盤 epic)
9. (PR scope 外) careful/bin の hook_fire event emission drop (step-28 PR の意図的 drop か翻訳漏れか別途確認推奨)

## 残 sub-task (epic #152 配下)

- guard 翻訳 (step-84-1「やること」 2 件目、 step-116 hook 機構同時設計と pair) → PR-B
- gstack-upgrade / open-gstack-browser symlink 整理 (= 既翻訳済) → PR-C
- 全 35-36 skill validate 横展開 (step-84-2) → 後続 sub-task
- skill-validate.ts 改善 6 項目 (step-84-4) → 後続 sub-task
- voice 規約 v2 拡張対応 (step-84-7) → 後続 sub-task
- hook 機構の発動経路の検証 (step-84-10) → 後続 sub-task

Refs #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)