### PR TITLE
fix: bun test が gstack setup を spawn する経路を bunfig.toml で block + 禁止規律を effect 軸に書き換え — Closes #155

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -244,6 +244,7 @@ git subtree pull --prefix _upstream/gstack https://github.com/garrytan/gstack.gi
 - `~/.claude/skills/<name>/SKILL.md` の全 symlink が gstack 英語版で上書きされる
 - `~/.claude/skills/gstack-upgrade` / `~/.claude/skills/open-gstack-browser` 等 gstack 専用 dir が追加される
 - `~/.gstack/.last-setup-version` に gstack VERSION が書き込まれる
+- 後続の uzustack 翻訳版 skill 発火が gstack 英語版で発火するようになる (= 修復まで日本語 skill が事実上消滅)
 - host install dir（`.claude/skills/` 等 11 系統）が `_upstream/gstack/` 内に作られ、 Claude Code の skill discovery（CWD 配下の `.claude/skills/` を再帰探索する monorepo 仕様）により subtree 英語版が翻訳版と重複表示される
 - host install dir は `_upstream/gstack/.gitignore` で git track 外、 subtree pull の上書き対象でもないため、 一度作られると物理 rm 必要
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -237,9 +237,23 @@ git subtree pull --prefix _upstream/gstack https://github.com/garrytan/gstack.gi
 
 `feature/sync-gstack-<日付>-<skill>` ブランチで再翻訳。詳細手順は [CONTRIBUTING.md](CONTRIBUTING.md#gstack-更新追従) を参照。
 
-### `_upstream/gstack/` 内で setup を走らせない
+### `_upstream/gstack/setup` を実行しない（effect 軸）
 
-`cd _upstream/gstack && ./setup` 等、 `_upstream/` 配下を CWD として gstack 本家 setup を実行してはならない。 Claude Code の skill discovery（CWD 配下の `.claude/skills/` を再帰探索する monorepo 仕様）により subtree 英語版が翻訳版と重複表示される。 host install dir（`.claude/skills/` 等 11 系統）は `_upstream/gstack/.gitignore` で git track 外、 subtree pull の上書き対象でもないため、 一度作られると物理 rm 必要。 詳細は [docs/uzustack/translation-rebase-fixes.md](docs/uzustack/translation-rebase-fixes.md) 参照（issue #132 / step-86）。
+`_upstream/gstack/setup` の execution は **invocation method に関わらず禁止**（cd した手動 invocation / `bun test` 経由 / bin script からの spawn / 他いずれの経路でも）。 一度実行されると次の effect が同時発生する：
+
+- `~/.claude/skills/<name>/SKILL.md` の全 symlink が gstack 英語版で上書きされる
+- `~/.claude/skills/gstack-upgrade` / `~/.claude/skills/open-gstack-browser` 等 gstack 専用 dir が追加される
+- `~/.gstack/.last-setup-version` に gstack VERSION が書き込まれる
+- host install dir（`.claude/skills/` 等 11 系統）が `_upstream/gstack/` 内に作られ、 Claude Code の skill discovery（CWD 配下の `.claude/skills/` を再帰探索する monorepo 仕様）により subtree 英語版が翻訳版と重複表示される
+- host install dir は `_upstream/gstack/.gitignore` で git track 外、 subtree pull の上書き対象でもないため、 一度作られると物理 rm 必要
+
+主要な発火経路 (= 防御対象):
+
+1. **`bun test` 経由** (issue #155): uzustack root の `bunfig.toml` に `[test] pathIgnorePatterns = ["**/_upstream/**"]` を配置して default discovery から除外
+2. **手動 `cd _upstream/gstack && ./setup`** (issue #132 / step-86): 規律として禁止
+3. **bin script からの spawn**: 現状 guard で block 済（将来注意）
+
+詳細は [docs/uzustack/translation-rebase-fixes.md](docs/uzustack/translation-rebase-fixes.md) 参照（issue #132 / step-86 / #155）。
 
 `_upstream/gstack/` 配下の編集は禁止（subtree pull の上書き対象）。uzustack 独自編集は repo top の `<skill>/` 配下または root level で行う。
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,6 +199,7 @@ gh pr create
 - `~/.gstack/.last-setup-version` に gstack VERSION が書き込まれる
 - 後続の uzustack 翻訳版 skill 発火が gstack 英語版で発火するようになる (= 修復まで日本語 skill が事実上消滅)
 - host install 結果（`.claude/skills/` 等 11 dir）が `_upstream/gstack/` 内にも作られ、 Claude Code の skill discovery（CWD 配下の `.claude/skills/` を再帰探索する monorepo 仕様）により **uzustack 翻訳版と subtree 英語版が同じ skill name で重複表示**される
+- host install dir は `_upstream/gstack/.gitignore` で git track 外、 subtree pull の上書き対象でもないため、 一度作られると物理 rm 必要
 
 **主要な発火経路 (= 防御対象)**:
 
@@ -206,7 +207,7 @@ gh pr create
 2. **手動 `cd _upstream/gstack && ./setup`** (= issue #132 / step-86): メンテナーが誤って実行する経路。 規律として禁止
 3. **bin script からの spawn** (= `_upstream/gstack/bin/gstack-session-update` 等): SessionStart hook 経由で発火する可能性。 現状は `.git` 不在 guard + team mode guard で block されているが、 将来 guard が外れる場合は注意
 
-詳細と再発時の手動 cleanup 手順は [docs/uzustack/translation-rebase-fixes.md](docs/uzustack/translation-rebase-fixes.md#_upstreamgstacksetup-の実行禁止effect-軸pr-131-step-86--issue-132--155) を参照（issue #132 / step-86 / #155）。
+詳細と再発時の手動 cleanup 手順は [docs/uzustack/translation-rebase-fixes.md](docs/uzustack/translation-rebase-fixes.md#_upstreamgstacksetup-の実行禁止effect-軸-pr-131-step-86--issue-132--155) を参照（issue #132 / step-86 / #155）。
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,11 +188,25 @@ gh pr create
 
 自動 PR の中に翻訳済み skill（`type: translated`）の上流変更が含まれていたら、[翻訳ガイド](#翻訳ガイドgstack-の英語スキルを翻訳する場合) の「rebase の手順」を参照して再翻訳します。uzustack 独自部分（`type: native`）は gstack 更新と無関係。
 
-### `_upstream/gstack/` 内で setup を走らせない
+### `_upstream/gstack/setup` を実行しない（effect 軸）
 
-**禁止**：`cd _upstream/gstack && ./setup` 等、 `_upstream/` 配下を CWD として gstack 本家 setup を実行してはならない。 host install 結果（`.claude/skills/` 等 11 dir）が `_upstream/gstack/` 内に作られると、 Claude Code の skill discovery（CWD 配下の `.claude/skills/` を再帰探索する monorepo 仕様）により **uzustack 翻訳版と subtree 英語版が同じ skill name で重複表示**される。
+**禁止**：`_upstream/gstack/setup` の execution。 invocation method (= cd した手動 invocation / `bun test` 経由 / bin script からの spawn / 他いずれの経路でも) に関わらず、 **gstack setup script の execution 自体が禁止**。
 
-詳細と再発時の手動 cleanup 手順は [docs/uzustack/translation-rebase-fixes.md](docs/uzustack/translation-rebase-fixes.md#_upstreamgstack-内で-setup-を走らせないpr-131-step-86--issue-132) を参照（issue #132 / step-86）。
+**effect**: 一度実行されると次の副作用が同時発生する：
+
+- `~/.claude/skills/<name>/SKILL.md` の全 symlink が gstack 英語版 (`_upstream/gstack/<name>/SKILL.md`) で上書きされる
+- `~/.claude/skills/gstack-upgrade` / `~/.claude/skills/open-gstack-browser` 等 gstack 専用 directory が新規追加される
+- `~/.gstack/.last-setup-version` に gstack VERSION が書き込まれる
+- 後続の uzustack 翻訳版 skill 発火が gstack 英語版で発火するようになる (= 修復まで日本語 skill が事実上消滅)
+- host install 結果（`.claude/skills/` 等 11 dir）が `_upstream/gstack/` 内にも作られ、 Claude Code の skill discovery（CWD 配下の `.claude/skills/` を再帰探索する monorepo 仕様）により **uzustack 翻訳版と subtree 英語版が同じ skill name で重複表示**される
+
+**主要な発火経路 (= 防御対象)**:
+
+1. **`bun test` 経由** (= 2026-05-15 12:50 実害発生、 issue #155): `_upstream/gstack/test/team-mode.test.ts` が `execSync` で `_upstream/gstack/setup -q` を直接 spawn する。 uzustack root の `bunfig.toml` に `[test] pathIgnorePatterns = ["**/_upstream/**"]` を配置して `bun test` の default discovery から除外
+2. **手動 `cd _upstream/gstack && ./setup`** (= issue #132 / step-86): メンテナーが誤って実行する経路。 規律として禁止
+3. **bin script からの spawn** (= `_upstream/gstack/bin/gstack-session-update` 等): SessionStart hook 経由で発火する可能性。 現状は `.git` 不在 guard + team mode guard で block されているが、 将来 guard が外れる場合は注意
+
+詳細と再発時の手動 cleanup 手順は [docs/uzustack/translation-rebase-fixes.md](docs/uzustack/translation-rebase-fixes.md#_upstreamgstacksetup-の実行禁止effect-軸pr-131-step-86--issue-132--155) を参照（issue #132 / step-86 / #155）。
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,7 +205,7 @@ gh pr create
 
 1. **`bun test` 経由** (= 2026-05-15 12:50 実害発生、 issue #155): `_upstream/gstack/test/team-mode.test.ts` が `execSync` で `_upstream/gstack/setup -q` を直接 spawn する。 uzustack root の `bunfig.toml` に `[test] pathIgnorePatterns = ["**/_upstream/**"]` を配置して `bun test` の default discovery から除外
 2. **手動 `cd _upstream/gstack && ./setup`** (= issue #132 / step-86): メンテナーが誤って実行する経路。 規律として禁止
-3. **bin script からの spawn** (= `_upstream/gstack/bin/gstack-session-update` 等): SessionStart hook 経由で発火する可能性。 現状は `.git` 不在 guard + team mode guard で block されているが、 将来 guard が外れる場合は注意
+3. **bin script からの spawn** (= `_upstream/gstack/bin/gstack-session-update` 等): SessionStart hook 経由で発火する可能性。 現状は `.git` 不在 guard + team mode guard + `~/.claude/settings.json` 未登録 で block されているが、 将来 guard が外れる場合は注意
 
 詳細と再発時の手動 cleanup 手順は [docs/uzustack/translation-rebase-fixes.md](docs/uzustack/translation-rebase-fixes.md#_upstreamgstacksetup-の実行禁止effect-軸-pr-131-step-86--issue-132--155) を参照（issue #132 / step-86 / #155）。
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,11 @@
+# uzustack bun config — bun 全体の設定 home (test / install / loader 等を集約予定)
+#
+# 現状は test scope の guard のみ。Phase 4+ で bun 関連設定が増えたら集約する。
+
+[test]
+# _upstream/gstack/ は subtree として保持し、 uzustack の `bun test` では実行しない。
+# 理由: _upstream/gstack/test/team-mode.test.ts が execSync で _upstream/gstack/setup -q
+# を spawn し、 ~/.claude/skills/ の全 symlink を gstack 英語版で上書きする副作用がある
+# (= 2026-05-15 12:50 実害発生、 issue #155)。 上流 test 自体は upstream PR で対処すべき
+# 領域だが、 守期間中の「上流 PR 出さない」 規律により uzustack 側 guard で防ぐ。
+pathIgnorePatterns = ["**/_upstream/**"]

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,6 +1,4 @@
-# uzustack bun config — bun 全体の設定 home (test / install / loader 等を集約予定)
-#
-# 現状は test scope の guard のみ。Phase 4+ で bun 関連設定が増えたら集約する。
+# uzustack bun config
 
 [test]
 # _upstream/gstack/ は subtree として保持し、 uzustack の `bun test` では実行しない。

--- a/docs/uzustack/translation-rebase-fixes.md
+++ b/docs/uzustack/translation-rebase-fixes.md
@@ -42,21 +42,32 @@ uzustack は `~/.uzustack/` で完結する世界線を持つ設計だが、 上
 
 ---
 
-## `_upstream/gstack/` 内で setup を走らせない（PR #131 step-86 / issue #132）
+## `_upstream/gstack/setup` の実行禁止（effect 軸、 PR #131 step-86 / issue #132 / #155）
 
-**禁止事項**：`cd _upstream/gstack && ./setup` 等、 `_upstream/` 配下を CWD として gstack 本家 setup を実行してはならない。
+**禁止事項**：`_upstream/gstack/setup` の execution は **invocation method に関わらず禁止**。 cd した手動 invocation / `bun test` 経由 / bin script からの spawn / 他いずれの経路でも、 gstack setup script の execution 自体が禁止対象。
 
-**理由**：
+**effect** (= 一度実行されると同時発生する副作用)：
 
-- gstack 本家 setup は host 別の install 結果（`.claude/skills/`、 `.codex/skills/`、 `.factory/skills/` 等 11 host dir）を CWD 配下に作成する
+- `~/.claude/skills/<name>/SKILL.md` の全 symlink が gstack 英語版で上書きされる
+- `~/.claude/skills/gstack-upgrade` / `~/.claude/skills/open-gstack-browser` 等 gstack 専用 directory が新規追加される
+- `~/.gstack/.last-setup-version` に gstack VERSION が書き込まれる
+- 後続の uzustack 翻訳版 skill 発火が gstack 英語版で発火するようになる (= 修復まで日本語 skill が事実上消滅)
+- gstack 本家 setup は host 別の install 結果（`.claude/skills/`、 `.codex/skills/`、 `.factory/skills/` 等 11 host dir）を CWD 配下にも作成する
 - これらは `_upstream/gstack/.gitignore` で全部 ignored = git track 外、 subtree pull の上書き対象でもない
 - しかし Claude Code の skill discovery 仕様（[Automatic discovery from nested directories](https://code.claude.com/docs/en/skills)）= **CWD 配下の `.claude/skills/` を再帰探索**するため、 `<repo>/_upstream/gstack/.claude/skills/` も discoverable
 - 結果：uzustack 翻訳済 skill（root level）と subtree 英語版（_upstream 配下）が **同じ skill name で重複表示**される（`/cont` 補完で `/context-save` が日本語 + 英語の 2 件 等）
 
+**主要な発火経路 (= 防御対象)**：
+
+1. **`bun test` 経由** (issue #155、 2026-05-15 12:50 実害発生): `_upstream/gstack/test/team-mode.test.ts:332,345` が `execSync` で `_upstream/gstack/setup -q` を直接 spawn する。 uzustack root の `bunfig.toml` に `[test] pathIgnorePatterns = ["**/_upstream/**"]` を配置することで `bun test` の default discovery から `_upstream/` 配下を除外し block する
+2. **手動 `cd _upstream/gstack && ./setup`** (issue #132 / step-86): メンテナーが誤って実行する経路。 規律として禁止
+3. **bin script からの spawn** (`_upstream/gstack/bin/gstack-session-update` 等): SessionStart hook 経由で発火する可能性。 現状 `.git` 不在 guard + team mode guard + `~/.claude/settings.json` 未登録 で block 済 (将来 guard が外れる場合は注意)
+
 **運用ルール**：
 
 - gstack 本家 setup を試したい場合は **uzustack repo の外**で実行する（例：別 clone `~/src/gstack-test/` 等）
-- agentic session が誤って `_upstream/gstack/` 内で setup を起動した場合は、 即時に手動 cleanup（下記）を実行する
+- `bun test` を uzustack root から実行する場合は `bunfig.toml` の guard が効いていることを前提とする（消去・上書きしない）
+- agentic session が誤って `_upstream/gstack/setup` を起動した場合は、 即時に手動 cleanup（下記）+ `./bin/dev-setup ~` で symlink を uzustack 翻訳版に復元
 
 **再発時の手動 cleanup**：
 
@@ -74,6 +85,12 @@ rm -rf \
   _upstream/gstack/.slate \
   _upstream/gstack/.cursor \
   _upstream/gstack/.agents
+
+# symlink を uzustack 翻訳版に復元
+./bin/dev-setup ~
+
+# 残存する gstack 専用 dir (gstack-upgrade / open-gstack-browser) も削除
+rm -rf ~/.claude/skills/gstack-upgrade ~/.claude/skills/open-gstack-browser ~/.claude/skills/gstack
 ```
 
 これらは git track 外なので削除しても repo 状態は変わらず、 commit も発生しない（手動 1 度の cleanup として完結）。


### PR DESCRIPTION
## Summary

- uzustack root に `bunfig.toml` 追加 (= `[test] pathIgnorePatterns = ["**/_upstream/**"]`) で `bun test` の default discovery から `_upstream/` 配下を除外、 `_upstream/gstack/test/team-mode.test.ts` 経由の gstack setup spawn を block
- 既存禁止規律 3 file (CONTRIBUTING.md:191 / ARCHITECTURE.md:240 / docs/uzustack/translation-rebase-fixes.md:45) を **invocation method 軸 → effect 軸** に書き換え、 test 経由 / bin spawn 経由 / 将来の未知経路を一括 cover
- bunfig.toml は今後 uzustack の bun 設定 home として育てる前提 (test / install / loader / preload 等の集約先)
- 関連: issue #155 (Closes)、 issue #132 / step-86 (= 既存規律の前身、 手動 invocation のみ cover していた)

## Test plan

- [x] uzustack root に `bunfig.toml` 追加 + `pathIgnorePatterns = ["**/_upstream/**"]` 配置
- [x] CONTRIBUTING.md:191 / ARCHITECTURE.md:240 / docs/uzustack/translation-rebase-fixes.md:45 を effect 軸に書き換え
- [x] `bun test` の default discovery が `_upstream/` を除外することを実機確認 (160 file → 2 file に縮小、 残りは uzustack 独自 `design/test/*.test.ts` のみ)
- [x] discovery 結果が `~/.claude/skills/` / `~/.gstack/` に副作用を与えないことを確認 (= `setup -q` 経路が完全に block)
- [x] PR 起票直後の `/simplify` を 2 周実施 (= workflow.md 規律)
- [x] issue #155 + PR body の checkbox を merge 前に tick (= 本 update で完了)

## /simplify audit trail

**Round 1** (= actionable findings 取扱い): 3 件修正 (commit `d9f0d75`)
- (P0 Quality) CONTRIBUTING.md L209 anchor link 修正 (`effect-軸pr` → `effect-軸-pr`)
- (Reuse #1) CONTRIBUTING.md effect list に `.gitignore + 物理 rm` bullet 追加 (3 file 同期)
- (Reuse #2) ARCHITECTURE.md effect list に「日本語 skill 事実上消滅」 致命性 bullet 追加 (3 file 同期)

Skip (= 設計判断): Efficiency agent の「detail 集約案」 は「3 file standalone 読み」 設計と衝突、 Reuse 軸を採用して keep。

**Round 2** (= cross-validation + specificity drift 検出): 2 件修正 (commit `061d523`)
- (P1 Reuse) CONTRIBUTING.md:210 bin spawn guard list を 3 guard に揃える (`.git` 不在 + team mode + `~/.claude/settings.json` 未登録 = translation-rebase-fixes.md と同期)
- (P1 Efficiency) bunfig.toml preamble の future-prediction 言い切り注記を削除 (user CLAUDE.md 規律「現状使う予定なし / 将来 X の場合 等」 違反、 事実と規範のみに圧縮)

Skip (= Round 1 設計判断踏襲): Efficiency #1 (ARCHITECTURE 縮退) / Efficiency #2 (CONTRIBUTING 縮退) は standalone 読み設計と衝突、 keep。

**3 周目は回さない** (= workflow.md 規律「/simplify Round 2 で specificity drift 検出時は即時修正 + audit trail、 3 周目を回さない」)。

## Out of scope (= follow-up)

- 残存する `~/.claude/skills/gstack-upgrade` / `~/.claude/skills/open-gstack-browser` symlink の削除 → PR-C (= step-84-1 サブタスク 1 内の予定作業)
- 上流 gstack の `_upstream/gstack/test/team-mode.test.ts` への skip-when-not-gstack-root gate 追加 → 守期間中の「上流 PR 出さない」 規律により skip (= 上流 tech debt 観測リストに追加、 計 11 件目)

🤖 Generated with [Claude Code](https://claude.com/claude-code)