### PR TITLE
docs: gstack 専用 dir 削除規律を「翻訳済のため不要」 と明確化 — step-84-1 PR-C

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -242,7 +242,7 @@ git subtree pull --prefix _upstream/gstack https://github.com/garrytan/gstack.gi
 `_upstream/gstack/setup` の execution は **invocation method に関わらず禁止**（cd した手動 invocation / `bun test` 経由 / bin script からの spawn / 他いずれの経路でも）。 一度実行されると次の effect が同時発生する：
 
 - `~/.claude/skills/<name>/SKILL.md` の全 symlink が gstack 英語版で上書きされる
-- `~/.claude/skills/gstack-upgrade` / `~/.claude/skills/open-gstack-browser` 等 gstack 専用 dir が追加される
+- `~/.claude/skills/gstack-upgrade` / `~/.claude/skills/open-gstack-browser` 等 gstack 専用 dir が追加される（uzustack には翻訳済 `uzustack-upgrade` / `open-uzustack-browser` があるため dir 自体が不要、 流入したら削除する）
 - `~/.gstack/.last-setup-version` に gstack VERSION が書き込まれる
 - 後続の uzustack 翻訳版 skill 発火が gstack 英語版で発火するようになる (= 修復まで日本語 skill が事実上消滅)
 - host install dir（`.claude/skills/` 等 11 系統）が `_upstream/gstack/` 内に作られ、 Claude Code の skill discovery（CWD 配下の `.claude/skills/` を再帰探索する monorepo 仕様）により subtree 英語版が翻訳版と重複表示される

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,7 +195,7 @@ gh pr create
 **effect**: 一度実行されると次の副作用が同時発生する：
 
 - `~/.claude/skills/<name>/SKILL.md` の全 symlink が gstack 英語版 (`_upstream/gstack/<name>/SKILL.md`) で上書きされる
-- `~/.claude/skills/gstack-upgrade` / `~/.claude/skills/open-gstack-browser` 等 gstack 専用 directory が新規追加される
+- `~/.claude/skills/gstack-upgrade` / `~/.claude/skills/open-gstack-browser` 等 gstack 専用 directory が新規追加される（uzustack には翻訳済 `uzustack-upgrade` / `open-uzustack-browser` があるため dir 自体が不要、 流入したら削除する）
 - `~/.gstack/.last-setup-version` に gstack VERSION が書き込まれる
 - 後続の uzustack 翻訳版 skill 発火が gstack 英語版で発火するようになる (= 修復まで日本語 skill が事実上消滅)
 - host install 結果（`.claude/skills/` 等 11 dir）が `_upstream/gstack/` 内にも作られ、 Claude Code の skill discovery（CWD 配下の `.claude/skills/` を再帰探索する monorepo 仕様）により **uzustack 翻訳版と subtree 英語版が同じ skill name で重複表示**される

--- a/docs/uzustack/translation-rebase-fixes.md
+++ b/docs/uzustack/translation-rebase-fixes.md
@@ -49,7 +49,7 @@ uzustack は `~/.uzustack/` で完結する世界線を持つ設計だが、 上
 **effect** (= 一度実行されると同時発生する副作用)：
 
 - `~/.claude/skills/<name>/SKILL.md` の全 symlink が gstack 英語版で上書きされる
-- `~/.claude/skills/gstack-upgrade` / `~/.claude/skills/open-gstack-browser` 等 gstack 専用 directory が新規追加される
+- `~/.claude/skills/gstack-upgrade` / `~/.claude/skills/open-gstack-browser` 等 gstack 専用 directory が新規追加される（uzustack には翻訳済 `uzustack-upgrade` / `open-uzustack-browser` があるため dir 自体が不要、 流入したら削除する）
 - `~/.gstack/.last-setup-version` に gstack VERSION が書き込まれる
 - 後続の uzustack 翻訳版 skill 発火が gstack 英語版で発火するようになる (= 修復まで日本語 skill が事実上消滅)
 - gstack 本家 setup は host 別の install 結果（`.claude/skills/`、 `.codex/skills/`、 `.factory/skills/` 等 11 host dir）を CWD 配下にも作成する
@@ -89,7 +89,7 @@ rm -rf \
 # symlink を uzustack 翻訳版に復元
 ./bin/dev-setup ~
 
-# 残存する gstack 専用 dir (gstack-upgrade / open-gstack-browser) も削除
+# 残存する gstack 専用 dir も削除（uzustack には翻訳済 uzustack-upgrade / open-uzustack-browser があるため dir 自体が不要、 流入したら削除する）
 rm -rf ~/.claude/skills/gstack-upgrade ~/.claude/skills/open-gstack-browser ~/.claude/skills/gstack
 ```
 


### PR DESCRIPTION
## Summary

- `ARCHITECTURE.md` / `CONTRIBUTING.md` / `docs/uzustack/translation-rebase-fixes.md` の「gstack 専用 dir (`gstack-upgrade` / `open-gstack-browser`) を `rm -rf` で削除する」 規律記述に「**翻訳済 `uzustack-upgrade` / `open-uzustack-browser` があるため dir 自体が不要、 流入したら削除する**」 と設計意図 1 文を追記
- gstack-* 命名での redirect stub 作成は Phase 6（Type 1 維持 / Type 3 化準備 / scope exclude の 3 選択肢判定後）に温存する判断を反映

## Closes

Closes #157

## Test plan

- [x] `ARCHITECTURE.md` の該当箇所が明確化された
- [x] `CONTRIBUTING.md` の該当箇所が明確化された
- [x] `docs/uzustack/translation-rebase-fixes.md` の該当箇所 2 箇所（effect list + cleanup rm コメント）が明確化された
- [x] `/simplify` を 2 周完了（Round 1 + Round 2 ともに actionable 0 件、 main loop direct grep verification で sub-agent 並列の代替）
- [x] merge 前に PR body checkbox tick 確認

## /simplify audit trail

- **Round 1**: actionable 0 件（追記文言 drift / future-prediction 注記 / sanitize check 等 5 check すべて clean）
- **Round 2**: actionable 0 件（cross-validation + drift detection 5 check すべて clean、 「流入」 vs「混入」 用語選択は別文脈で文脈適合のため false positive 判定）
- **learning curve 観測**: PR-A (R1=2 / R2=0) → PR-B (R1=0 / R2=0) → PR-C (R1=0 / R2=0) = cluster 内連続 PR で初動品質向上 pattern が 3 PR で実証

## Parent

step-84-1 サブタスク 1 — Phase 4 cluster 翻訳化（PR-C）

## Related PR / issue

- 先行 PR: #153 (PR-A freeze + unfreeze 翻訳)、 #154 (PR-B guard 翻訳)
- Phase 4 cluster epic: #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)