### PR TITLE
refactor: skill-validate.ts 改善 6 項目 (frontmatter utility / config 化 / Promise.all / regex merge / diff-based / error handling) — Closes #161

### DIFF
--- a/scripts/frontmatter.ts
+++ b/scripts/frontmatter.ts
@@ -7,20 +7,16 @@
  * (field 解析の semantics が呼び出し側で異なるため、ここで吸収しない)。
  */
 
-export interface Frontmatter {
-  /** `---` で挟まれた本体（前後の `---` line は含まない、 改行も trim しない）。 */
-  raw: string;
-}
-
 /**
- * 先頭 `---\n` で始まる YAML frontmatter を抽出する。
+ * 先頭 `---\n` で始まる YAML frontmatter の本体を抽出する。
  *
- * @returns frontmatter が見つかれば `{ raw }`、 先頭が `---\n` でない / 閉じ `\n---` が無い場合は `null`。
+ * @returns frontmatter の本体 (`---` で挟まれた中身、 前後の `---` line は含まない、 改行も trim しない)。
+ *   先頭が `---\n` でない / 閉じ `\n---` が無い場合は `null`。
  */
-export function parseFrontmatter(content: string): Frontmatter | null {
+export function parseFrontmatter(content: string): string | null {
   const fmStart = content.indexOf('---\n');
   if (fmStart !== 0) return null;
   const fmEnd = content.indexOf('\n---', fmStart + 4);
   if (fmEnd === -1) return null;
-  return { raw: content.slice(fmStart + 4, fmEnd) };
+  return content.slice(fmStart + 4, fmEnd);
 }

--- a/scripts/frontmatter.ts
+++ b/scripts/frontmatter.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared YAML frontmatter parser for skill content.
+ *
+ * 3 箇所 (skill-validate.ts:isTranslated / gen-skill-docs.ts:extractNameAndDescription /
+ * gen-skill-docs.ts:extractVoiceTriggers) が同じ `content.indexOf('---\n')` pattern を
+ * duplicate していた重複を統合。本体抽出のみを担当し、field 解析は呼び出し側で行う
+ * (field 解析の semantics が呼び出し側で異なるため、ここで吸収しない)。
+ */
+
+export interface Frontmatter {
+  /** `---` で挟まれた本体（前後の `---` line は含まない、 改行も trim しない）。 */
+  raw: string;
+}
+
+/**
+ * 先頭 `---\n` で始まる YAML frontmatter を抽出する。
+ *
+ * @returns frontmatter が見つかれば `{ raw }`、 先頭が `---\n` でない / 閉じ `\n---` が無い場合は `null`。
+ */
+export function parseFrontmatter(content: string): Frontmatter | null {
+  const fmStart = content.indexOf('---\n');
+  if (fmStart !== 0) return null;
+  const fmEnd = content.indexOf('\n---', fmStart + 4);
+  if (fmEnd === -1) return null;
+  return { raw: content.slice(fmStart + 4, fmEnd) };
+}

--- a/scripts/gen-skill-docs.ts
+++ b/scripts/gen-skill-docs.ts
@@ -47,10 +47,9 @@ const HOST_ARG_VAL: HostArg = (() => {
 // ─── Frontmatter Helpers ────────────────────────────────────
 
 function extractNameAndDescription(content: string): { name: string; description: string } {
-  const fm = parseFrontmatter(content);
-  if (!fm) return { name: '', description: '' };
+  const frontmatter = parseFrontmatter(content);
+  if (frontmatter === null) return { name: '', description: '' };
 
-  const frontmatter = fm.raw;
   const nameMatch = frontmatter.match(/^name:\s*(.+)$/m);
   const name = nameMatch ? nameMatch[1].trim() : '';
 
@@ -85,9 +84,8 @@ function extractNameAndDescription(content: string): { name: string; description
 // ─── Voice Trigger Processing ───────────────────────────────
 
 function extractVoiceTriggers(content: string): string[] {
-  const fm = parseFrontmatter(content);
-  if (!fm) return [];
-  const frontmatter = fm.raw;
+  const frontmatter = parseFrontmatter(content);
+  if (frontmatter === null) return [];
 
   const triggers: string[] = [];
   let inVoice = false;

--- a/scripts/gen-skill-docs.ts
+++ b/scripts/gen-skill-docs.ts
@@ -20,6 +20,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { discoverTemplates } from './discover-skills';
+import { parseFrontmatter } from './frontmatter';
 import { RESOLVERS } from './resolvers/index';
 import type { Host, TemplateContext } from './resolvers/types';
 import { HOST_PATHS } from './resolvers/types';
@@ -46,12 +47,10 @@ const HOST_ARG_VAL: HostArg = (() => {
 // ─── Frontmatter Helpers ────────────────────────────────────
 
 function extractNameAndDescription(content: string): { name: string; description: string } {
-  const fmStart = content.indexOf('---\n');
-  if (fmStart !== 0) return { name: '', description: '' };
-  const fmEnd = content.indexOf('\n---', fmStart + 4);
-  if (fmEnd === -1) return { name: '', description: '' };
+  const fm = parseFrontmatter(content);
+  if (!fm) return { name: '', description: '' };
 
-  const frontmatter = content.slice(fmStart + 4, fmEnd);
+  const frontmatter = fm.raw;
   const nameMatch = frontmatter.match(/^name:\s*(.+)$/m);
   const name = nameMatch ? nameMatch[1].trim() : '';
 
@@ -86,11 +85,9 @@ function extractNameAndDescription(content: string): { name: string; description
 // ─── Voice Trigger Processing ───────────────────────────────
 
 function extractVoiceTriggers(content: string): string[] {
-  const fmStart = content.indexOf('---\n');
-  if (fmStart !== 0) return [];
-  const fmEnd = content.indexOf('\n---', fmStart + 4);
-  if (fmEnd === -1) return [];
-  const frontmatter = content.slice(fmStart + 4, fmEnd);
+  const fm = parseFrontmatter(content);
+  if (!fm) return [];
+  const frontmatter = fm.raw;
 
   const triggers: string[] = [];
   let inVoice = false;

--- a/scripts/skill-validate.ts
+++ b/scripts/skill-validate.ts
@@ -52,7 +52,7 @@ const rulesPath = path.join(ROOT, 'scripts/voice-rules.json');
 const rules: VoiceRulesFile = JSON.parse(fs.readFileSync(rulesPath, 'utf-8'));
 const ID_TO_NAME = new Map(rules.patterns.map(p => [p.id, p.name]));
 // 各 pattern を named-capture group で wrap し alternation で merge。
-// 1-pass scan で全 pattern を check (元: 4-pass)。 group 名 = pattern id で復元する。
+// 1-pass scan で全 pattern を check、 group 名 = pattern id で hit pattern を復元する。
 const MERGED_REGEX = new RegExp(
   rules.patterns.map(p => `(?<${p.id}>${p.regex})`).join('|'),
   'g'
@@ -60,8 +60,8 @@ const MERGED_REGEX = new RegExp(
 
 function isTranslated(content: string): boolean {
   const fm = parseFrontmatter(content);
-  if (!fm) return false;
-  return /^type:\s*translated\s*$/m.test(fm.raw);
+  if (fm === null) return false;
+  return /^type:\s*translated\s*$/m.test(fm);
 }
 
 function checkFile(rel: string, content: string): { violations: Violation[]; translated: boolean } {
@@ -76,22 +76,20 @@ function checkFile(rel: string, content: string): { violations: Violation[]; tra
     // (subtree directory 名は voice 規約 v2 拡張で外部 identifier 維持、PR #116)
     if (line.includes('_upstream/gstack/')) continue;
 
-    // 同 line 内で同 pattern が複数回 hit しても violation は 1 件にまとめる
-    // (元の `regex.test(line)` の挙動を保持)。 異なる pattern が同 line に hit する場合は別 violation。
+    // alternation の 1 match には named-capture group が 1 つだけ hit する性質を使う。
+    // 同 line 内で同 pattern が複数回 hit しても violation は 1 件にまとめる (異なる pattern が
+    // 同 line に hit する場合は別 violation、 これは pattern x line で 1 件の元の挙動を保つ意図)。
     const matchedIds = new Set<string>();
     for (const m of line.matchAll(MERGED_REGEX)) {
-      if (!m.groups) continue;
-      for (const id of Object.keys(m.groups)) {
-        if (m.groups[id] !== undefined && !matchedIds.has(id)) {
-          matchedIds.add(id);
-          violations.push({
-            file: rel,
-            line: i + 1,
-            pattern: ID_TO_NAME.get(id)!,
-            excerpt: line.trim().slice(0, 120),
-          });
-        }
-      }
+      const id = Object.keys(m.groups!).find(k => m.groups![k] !== undefined);
+      if (!id || matchedIds.has(id)) continue;
+      matchedIds.add(id);
+      violations.push({
+        file: rel,
+        line: i + 1,
+        pattern: ID_TO_NAME.get(id)!,
+        excerpt: line.trim().slice(0, 120),
+      });
     }
   }
   return { violations, translated };

--- a/scripts/skill-validate.ts
+++ b/scripts/skill-validate.ts
@@ -3,6 +3,14 @@
  * Skill voice validation — voice 規約 v1 の機械チェック可能 subset。
  * Phase 3.6 step-83 サブタスク 3 で配置、`.github/workflows/skill-docs.yml` の Voice validation step で実行。
  *
+ * voice 規約の pattern は `scripts/voice-rules.json` で管理 (v2 拡張は同 file に追記)。
+ * 4 pattern を named-capture group で merge し、 line 毎 1-pass scan で全 pattern を check する。
+ *
+ * Modes:
+ *   default               - 全 .tmpl + .md scan (CI 既定)
+ *   --diff                - git merge-base HEAD origin/main からの変更 file のみ scan (local 高速 feedback)
+ *   SKILL_VALIDATE_DIFF=1 - 同上 (env var 経由)
+ *
  * Subtree path 許可：行内に `_upstream/gstack/` を含む場合は skip
  *   (uzustack 内の subtree path 言及として許可、voice 規約 v2 拡張 PR #116)。
  *
@@ -11,10 +19,14 @@
  */
 
 import * as fs from 'fs';
+import * as fsp from 'fs/promises';
 import * as path from 'path';
+import { execSync } from 'child_process';
 import { discoverTemplates, discoverSkillFiles } from './discover-skills';
+import { parseFrontmatter } from './frontmatter';
 
 const ROOT = path.resolve(import.meta.dir, '..');
+const DIFF_MODE = process.argv.includes('--diff') || process.env.SKILL_VALIDATE_DIFF === '1';
 
 interface Violation {
   file: string;
@@ -23,21 +35,34 @@ interface Violation {
   excerpt: string;
 }
 
-function isTranslated(content: string): boolean {
-  const fmStart = content.indexOf('---\n');
-  if (fmStart !== 0) return false;
-  const fmEnd = content.indexOf('\n---', fmStart + 4);
-  if (fmEnd === -1) return false;
-  const fm = content.slice(fmStart + 4, fmEnd);
-  return /^type:\s*translated\s*$/m.test(fm);
+interface VoiceRule {
+  id: string;
+  name: string;
+  regex: string;
 }
 
-const PATTERNS: Array<{ name: string; regex: RegExp }> = [
-  { name: '~/.gstack/ (path)', regex: /~\/\.gstack\// },
-  { name: '$GSTACK_HOME (env var)', regex: /\$GSTACK_HOME|\$\{GSTACK_HOME/ },
-  { name: 'gstack-XXX (bin 名)', regex: /\bgstack-[a-zA-Z0-9_-]+/ },
-  { name: '~/.claude/skills/gstack/ (skill path)', regex: /~\/\.claude\/skills\/gstack\// },
-];
+interface VoiceRulesFile {
+  version: string;
+  patterns: VoiceRule[];
+}
+
+// ─── voice-rules.json load + merged regex 構築 ──────────────
+
+const rulesPath = path.join(ROOT, 'scripts/voice-rules.json');
+const rules: VoiceRulesFile = JSON.parse(fs.readFileSync(rulesPath, 'utf-8'));
+const ID_TO_NAME = new Map(rules.patterns.map(p => [p.id, p.name]));
+// 各 pattern を named-capture group で wrap し alternation で merge。
+// 1-pass scan で全 pattern を check (元: 4-pass)。 group 名 = pattern id で復元する。
+const MERGED_REGEX = new RegExp(
+  rules.patterns.map(p => `(?<${p.id}>${p.regex})`).join('|'),
+  'g'
+);
+
+function isTranslated(content: string): boolean {
+  const fm = parseFrontmatter(content);
+  if (!fm) return false;
+  return /^type:\s*translated\s*$/m.test(fm.raw);
+}
 
 function checkFile(rel: string, content: string): { violations: Violation[]; translated: boolean } {
   const translated = isTranslated(content);
@@ -50,47 +75,108 @@ function checkFile(rel: string, content: string): { violations: Violation[]; tra
     // Subtree path 許可: `_upstream/gstack/` を含む行は skip
     // (subtree directory 名は voice 規約 v2 拡張で外部 identifier 維持、PR #116)
     if (line.includes('_upstream/gstack/')) continue;
-    for (const { name, regex } of PATTERNS) {
-      if (regex.test(line)) {
-        violations.push({
-          file: rel,
-          line: i + 1,
-          pattern: name,
-          excerpt: line.trim().slice(0, 120),
-        });
+
+    // 同 line 内で同 pattern が複数回 hit しても violation は 1 件にまとめる
+    // (元の `regex.test(line)` の挙動を保持)。 異なる pattern が同 line に hit する場合は別 violation。
+    const matchedIds = new Set<string>();
+    for (const m of line.matchAll(MERGED_REGEX)) {
+      if (!m.groups) continue;
+      for (const id of Object.keys(m.groups)) {
+        if (m.groups[id] !== undefined && !matchedIds.has(id)) {
+          matchedIds.add(id);
+          violations.push({
+            file: rel,
+            line: i + 1,
+            pattern: ID_TO_NAME.get(id)!,
+            excerpt: line.trim().slice(0, 120),
+          });
+        }
       }
     }
   }
   return { violations, translated };
 }
 
-function main() {
+// ─── diff-based target 絞り込み ─────────────────────────────
+
+function diffFiles(): Set<string> | null {
+  try {
+    const base = execSync('git merge-base HEAD origin/main', { encoding: 'utf-8' }).trim();
+    const committed = execSync(`git diff --name-only ${base}...HEAD`, { encoding: 'utf-8' });
+    // uncommitted な working tree 変更も含める (local 開発中の changeset prepare に有用)
+    const uncommitted = execSync('git diff --name-only HEAD', { encoding: 'utf-8' });
+    return new Set(
+      [...committed.split('\n'), ...uncommitted.split('\n')].filter(Boolean)
+    );
+  } catch (e) {
+    console.error(`WARNING: --diff mode で git diff の取得に失敗: ${(e as Error).message}`);
+    console.error('  full scan に fallback します');
+    return null;
+  }
+}
+
+// ─── Main ──────────────────────────────────────────────────
+
+async function main() {
   const tmpls = discoverTemplates(ROOT);
   const mds = discoverSkillFiles(ROOT);
 
   // .tmpl は generator source、.md は generated。両方 check することで
   // .md だけ手動編集された drift も catch (defense-in-depth、skill-docs.yml と同 pattern)
-  const targets: Array<{ rel: string; abs: string }> = [];
+  let targets: Array<{ rel: string; abs: string }> = [];
   for (const t of tmpls) targets.push({ rel: t.tmpl, abs: path.join(ROOT, t.tmpl) });
   for (const m of mds) targets.push({ rel: m, abs: path.join(ROOT, m) });
 
+  let mode = 'full';
+  if (DIFF_MODE) {
+    const changed = diffFiles();
+    if (changed) {
+      const before = targets.length;
+      targets = targets.filter(t => changed.has(t.rel));
+      mode = `diff (${before} → ${targets.length})`;
+    }
+  }
+
+  // Promise.all 並列化 + file 単位 try/catch (1 file の read fail で全体を止めない)
+  const skipped: Array<{ rel: string; error: string }> = [];
+  const results = await Promise.all(
+    targets.map(async ({ rel, abs }) => {
+      try {
+        const content = await fsp.readFile(abs, 'utf-8');
+        return checkFile(rel, content);
+      } catch (e) {
+        skipped.push({ rel, error: (e as Error).message });
+        return { violations: [] as Violation[], translated: false };
+      }
+    })
+  );
+
   const allViolations: Violation[] = [];
   let translatedCount = 0;
-  for (const { rel, abs } of targets) {
-    const content = fs.readFileSync(abs, 'utf-8');
-    const { violations, translated } = checkFile(rel, content);
-    if (translated) translatedCount++;
-    allViolations.push(...violations);
+  for (const r of results) {
+    if (r.translated) translatedCount++;
+    allViolations.push(...r.violations);
   }
 
   console.log('Skill voice validation');
   console.log('═'.repeat(60));
+  console.log(`  Mode: ${mode}`);
   console.log(`  Scanned: ${targets.length} files (${translatedCount} type: translated)`);
   console.log(`  Violations: ${allViolations.length}`);
+  console.log(`  Skipped (read error): ${skipped.length}`);
+
+  if (skipped.length > 0) {
+    console.error('');
+    console.error('Skipped files:');
+    for (const s of skipped) {
+      console.error(`  ${s.rel}: ${s.error}`);
+    }
+  }
 
   if (allViolations.length === 0) {
     console.log('  ✅ All clean.');
-    process.exit(0);
+    // skip があれば exit 1 で gating を保つ (silent skip 防止)
+    process.exit(skipped.length > 0 ? 1 : 0);
   }
 
   console.log('');

--- a/scripts/voice-rules.json
+++ b/scripts/voice-rules.json
@@ -1,0 +1,25 @@
+{
+  "version": "v1",
+  "patterns": [
+    {
+      "id": "gstack_home_path",
+      "name": "~/.gstack/ (path)",
+      "regex": "~\\/\\.gstack\\/"
+    },
+    {
+      "id": "gstack_home_env",
+      "name": "$GSTACK_HOME (env var)",
+      "regex": "\\$GSTACK_HOME|\\$\\{GSTACK_HOME"
+    },
+    {
+      "id": "gstack_bin_prefix",
+      "name": "gstack-XXX (bin 名)",
+      "regex": "\\bgstack-[a-zA-Z0-9_-]+"
+    },
+    {
+      "id": "gstack_skill_path",
+      "name": "~/.claude/skills/gstack/ (skill path)",
+      "regex": "~\\/\\.claude\\/skills\\/gstack\\/"
+    }
+  ]
+}

--- a/scripts/voice-rules.json
+++ b/scripts/voice-rules.json
@@ -1,5 +1,6 @@
 {
   "version": "v1",
+  "description": "Voice 規約の機械チェック pattern 集。 scripts/skill-validate.ts が読み込み、 type: translated な skill file 内の gstack 由来の生 string を検出する。 v2 拡張は新規 pattern を本 file に追記する。",
   "patterns": [
     {
       "id": "gstack_home_path",


### PR DESCRIPTION
## Summary

Phase 4 cluster sub-step 84-4。 `scripts/skill-validate.ts` (voice 規約 v1 機械チェック、 step-83 で配置) の 6 項目 refactor。 step-84-2 で確認した自動 cover logic + regression dogfood pattern を維持しつつ validator 自体を改善。

Closes #161 / Refs #152

## 変更内容

- **frontmatter 共通 utility**: `scripts/frontmatter.ts` に `parseFrontmatter()` 抽出。 `skill-validate.ts:isTranslated` + `gen-skill-docs.ts` L49/L89 の 3 箇所 duplicate を統合
- **config 化**: `PATTERNS` array を `scripts/voice-rules.json` に分離。 voice 規約 v1 + v2 拡張 (sub-step 84-7) を 1 file で管理可能
- **Promise.all 並列化**: sync `fs.readFileSync` を `fsp.readFile` + `Promise.all` で並列化 (88 file の throughput 改善)
- **regex merge**: 4 個の regex を alternation + named-capture group で 1-pass scan 化。 pattern 名 reporting は group 名 → `ID_TO_NAME` map で復元
- **diff-based mode**: `--diff` flag + `SKILL_VALIDATE_DIFF=1` env var で「変更 file のみ check」 mode 追加。 CI (`skill-docs.yml`) は full scan 維持、 local 高速 feedback 用
- **error handling**: file 単位 try/catch + skipped audit trail (skip 0 件確認も含む)、 skip があれば exit 1 で gating を保つ (silent skip 防止)

## Test plan

- [x] `bun run skill:validate` clean run 確認 (88 files / 68 type: translated / Violations 0 / Skipped 0)
- [x] regression dogfood 実機実証: `careful/SKILL.md.tmpl` に意図的違反 inject → catch (line 62 / pattern 名「~/.gstack/ (path)」 復元、 named-capture group 復元 working) → revert で clean run 再確認
- [x] diff mode smoke test: `--diff` + `SKILL_VALIDATE_DIFF=1` 両 mode で `diff (88 → 0)` 動作 (working tree changes は scripts/*.ts と JSON のみ、 SKILL.md 対象外で 0 件、 期待動作)
- [x] `bun run gen:skill-docs --dry-run` で全 FRESH (frontmatter.ts 統合した extractNameAndDescription / extractVoiceTriggers が正常動作)
- [x] `/simplify` を 2 周 (Round 1 actionable 4 件修正 + Round 2 drift 0 件 確認、 詳細は下記 audit trail)

## /simplify audit trail

### Round 1 (actionable 4 件修正、 commit `eda8999`)

- **voice-rules.json**: `description` field を top-level に追加 (`scripts/jargon-list.json` convention 揃え、 future contributor 向け clarity)
- **skill-validate.ts**: `matchAll` nested loop を named-capture alternation の「1 match = 1 group hit」 性質を使って simplify (2 段 nest → 1 段、 `Object.keys(m.groups!).find(...)` で intent 明瞭化)
- **skill-validate.ts**: `// 1-pass scan で全 pattern を check (元: 4-pass)` の `(元: 4-pass)` 変更 narration 削除 (元実装は git log で十分)
- **frontmatter.ts**: `parseFrontmatter` shape を `{ raw: string } | null` → `string | null` に simplify (YAGNI、 wrapper の indirection 廃止)。 callers 3 箇所 (skill-validate.ts:isTranslated / gen-skill-docs.ts:extractNameAndDescription / gen-skill-docs.ts:extractVoiceTriggers) も `.raw` access を除去して直接 access に

### Round 2 (drift / regression 検出: 0 件、 3 周目 skip)

- 数値整合性 clean: 88 files / 68 type:translated / Violations 0 / 4 pattern / 3 callers の全 surface で PR body と一致
- `MERGED_REGEX` named-capture id 4 件 と `ID_TO_NAME` map source の `id` field は 1:1 整合 (grep 確認)
- alternation 内 `|` (例: `\$GSTACK_HOME|\$\{GSTACK_HOME`) は named-capture group `()` で scope 局所化、 実機 dogfood で 4 pattern すべて期待通り hit
- `.raw` access 残存 0 件 (`grep -rn "\.raw" scripts/{skill-validate,gen-skill-docs,frontmatter}.ts`)、 callers 3 箇所すべて新 shape `string | null` に追従
- minor line shift: 上記「変更内容」 冒頭の「gen-skill-docs.ts L49 / L89」 のうち L89 は Round 1 simplify の自然 shift で現状 L86 だが本質的 drift ではない (= 自然 shift と Round 2 agent 判定)
- cosmetic (skip): inner named-capture group 将来追加時のリスク / `id` charset (dash / 数字始まり) runtime validation / `VoiceRulesFile` interface に `description?` field 追加 — いずれも runtime 影響なし

### upstream tech debt 観測リスト (uzustack 単独 fix なし)

- `_upstream/gstack/scripts/gen-skill-docs.ts` L80-85 / L124-128 / L220-224 + `_upstream/gstack/test/skill-validation.test.ts` L1436 / L1454 に同様の `indexOf('---\n')` frontmatter parse pattern が 3 + 2 箇所存在
- review.md 規律「upstream perfect-clone と /simplify findings の仕分け」 に従い、 守期間中は uzustack 単独 fix せず subtree pull で吸収。 「破」 移行時に独自 fix / upstream PR を再判断

### false positive 判定

- `id` 廃止 → `p${i}` (anti-pattern、 self-documenting 性能優先で保持)
- execSync 3 回 sequential (merge-base 依存で完全並列化不可、 gain marginal)
- `ID_TO_NAME.get(id)!` WHY comment (Round 1 matchAll simplify で構造変わり、 簡潔さ優先)
- 各種 micro-opt (line 毎 Set new / 配列 spread / sync JSON load) — clarity 優先

## Out of scope

- voice 規約 v2 自体の追加 pattern (sub-step 84-7 で別 turn)
- hook 機構の発動経路の検証 (sub-step 84-10 で別 turn)

## Notes

- config file format: JSON 採用 (TS object literal だと runtime parse 必要 / YAML 依存追加回避)
- diff base 解決: `git merge-base HEAD origin/main` (PR diff scope と一致) + working tree 変更も include (local 開発中の changeset prepare に有用)
- regex merge での pattern 名復元: `(?<gstack_home_path>~\/\.gstack\/)|...` 形式の named-capture group + `ID_TO_NAME` map
- `Mode:` 表示行と `Skipped (read error):` 表示行を新規追加 (= validator UX の透明性向上、 silent skip 防止)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
