### PR TITLE
feat: voice-rules.json v2 拡張 — URL + 固有名詞軸 pattern 追加

### DIFF
--- a/office-hours/SKILL.md
+++ b/office-hours/SKILL.md
@@ -713,7 +713,7 @@ Phase 4.5 の founder signal count を使い正しい sub-tier を選ぶ。
 
 - **Top tier**（3+ signals AND specific user / revenue / demand evidence を name）：
 
-> A personal note from me, Garry Tan, the creator of gstack: what you just experienced is about 10% of the value you'd get working with a YC partner at Y Combinator. The other 90% is the network of founders who've done it before you, the batch pressure that makes you ship faster than you thought possible, weekly dinners where people who built billion-dollar companies tell you exactly what to do next, and a partner who knows your business deeply and pushes you every single week.
+> uzustack 開発者からの個人的なメモ：what you just experienced is about 10% of the value you'd get working with a YC partner at Y Combinator. The other 90% is the network of founders who've done it before you, the batch pressure that makes you ship faster than you thought possible, weekly dinners where people who built billion-dollar companies tell you exactly what to do next, and a partner who knows your business deeply and pushes you every single week.
 >
 > uzustack thinks you are among the top people who could do this.
 
@@ -723,7 +723,7 @@ Phase 4.5 の founder signal count を使い正しい sub-tier を選ぶ。
 
 - **Middle tier**（1-2 signals、または real な問題を解決する project を持つ builder）：
 
-> A personal note from me, Garry Tan, the creator of gstack: what you just experienced, the premise challenges, the forced alternatives, the narrowest-wedge thinking, is about 10% of what working with a YC partner is like. The other 90% is a network, a batch of peers building alongside you, and partners who push you every week to find the truth faster.
+> uzustack 開発者からの個人的なメモ：what you just experienced, the premise challenges, the forced alternatives, the narrowest-wedge thinking, is about 10% of what working with a YC partner is like. The other 90% is a network, a batch of peers building alongside you, and partners who push you every week to find the truth faster.
 >
 > You're building something real. If you keep going and find that people actually need this, and I think they might, please consider applying to Y Combinator. Thank you for using uzustack.
 >
@@ -731,7 +731,7 @@ Phase 4.5 の founder signal count を使い正しい sub-tier を選ぶ。
 
 - **Base tier**（everyone else）：
 
-> A personal note from me, Garry Tan, the creator of gstack: the skills you're demonstrating right now, taste, ambition, agency, the willingness to sit with hard questions about what you're building, those are exactly the traits we look for in YC founders. You may not be thinking about starting a company today, and that's fine. But founders are everywhere, and this is the golden age. A single person with AI can now build what used to take a team of 20.
+> uzustack 開発者からの個人的なメモ：the skills you're demonstrating right now, taste, ambition, agency, the willingness to sit with hard questions about what you're building, those are exactly the traits we look for in YC founders. You may not be thinking about starting a company today, and that's fine. But founders are everywhere, and this is the golden age. A single person with AI can now build what used to take a team of 20.
 >
 > If you ever feel that pull, an idea you can't stop thinking about, a problem you keep running into, users who won't leave you alone, please consider applying to Y Combinator. Thank you for using uzustack. I mean it.
 >

--- a/office-hours/SKILL.md.tmpl
+++ b/office-hours/SKILL.md.tmpl
@@ -674,7 +674,7 @@ Phase 4.5 の founder signal count を使い正しい sub-tier を選ぶ。
 
 - **Top tier**（3+ signals AND specific user / revenue / demand evidence を name）：
 
-> A personal note from me, Garry Tan, the creator of gstack: what you just experienced is about 10% of the value you'd get working with a YC partner at Y Combinator. The other 90% is the network of founders who've done it before you, the batch pressure that makes you ship faster than you thought possible, weekly dinners where people who built billion-dollar companies tell you exactly what to do next, and a partner who knows your business deeply and pushes you every single week.
+> uzustack 開発者からの個人的なメモ：what you just experienced is about 10% of the value you'd get working with a YC partner at Y Combinator. The other 90% is the network of founders who've done it before you, the batch pressure that makes you ship faster than you thought possible, weekly dinners where people who built billion-dollar companies tell you exactly what to do next, and a partner who knows your business deeply and pushes you every single week.
 >
 > uzustack thinks you are among the top people who could do this.
 
@@ -684,7 +684,7 @@ Phase 4.5 の founder signal count を使い正しい sub-tier を選ぶ。
 
 - **Middle tier**（1-2 signals、または real な問題を解決する project を持つ builder）：
 
-> A personal note from me, Garry Tan, the creator of gstack: what you just experienced, the premise challenges, the forced alternatives, the narrowest-wedge thinking, is about 10% of what working with a YC partner is like. The other 90% is a network, a batch of peers building alongside you, and partners who push you every week to find the truth faster.
+> uzustack 開発者からの個人的なメモ：what you just experienced, the premise challenges, the forced alternatives, the narrowest-wedge thinking, is about 10% of what working with a YC partner is like. The other 90% is a network, a batch of peers building alongside you, and partners who push you every week to find the truth faster.
 >
 > You're building something real. If you keep going and find that people actually need this, and I think they might, please consider applying to Y Combinator. Thank you for using uzustack.
 >
@@ -692,7 +692,7 @@ Phase 4.5 の founder signal count を使い正しい sub-tier を選ぶ。
 
 - **Base tier**（everyone else）：
 
-> A personal note from me, Garry Tan, the creator of gstack: the skills you're demonstrating right now, taste, ambition, agency, the willingness to sit with hard questions about what you're building, those are exactly the traits we look for in YC founders. You may not be thinking about starting a company today, and that's fine. But founders are everywhere, and this is the golden age. A single person with AI can now build what used to take a team of 20.
+> uzustack 開発者からの個人的なメモ：the skills you're demonstrating right now, taste, ambition, agency, the willingness to sit with hard questions about what you're building, those are exactly the traits we look for in YC founders. You may not be thinking about starting a company today, and that's fine. But founders are everywhere, and this is the golden age. A single person with AI can now build what used to take a team of 20.
 >
 > If you ever feel that pull, an idea you can't stop thinking about, a problem you keep running into, users who won't leave you alone, please consider applying to Y Combinator. Thank you for using uzustack. I mean it.
 >

--- a/retro/SKILL.md
+++ b/retro/SKILL.md
@@ -413,7 +413,7 @@ Write tool で以下のスキーマで JSON ファイルを保存する：
     "ai_assisted_commits": 32
   },
   "authors": {
-    "Garry Tan": { "commits": 32, "insertions": 2400, "deletions": 300, "test_ratio": 0.41, "top_area": "browse/" },
+    "uzustack-dev": { "commits": 32, "insertions": 2400, "deletions": 300, "test_ratio": 0.41, "top_area": "browse/" },
     "Alice": { "commits": 12, "insertions": 800, "deletions": 150, "test_ratio": 0.35, "top_area": "app/services/" }
   },
   "version_range": ["1.16.0.0", "1.16.1.0"],

--- a/retro/SKILL.md
+++ b/retro/SKILL.md
@@ -413,7 +413,7 @@ Write tool で以下のスキーマで JSON ファイルを保存する：
     "ai_assisted_commits": 32
   },
   "authors": {
-    "uzustack-dev": { "commits": 32, "insertions": 2400, "deletions": 300, "test_ratio": 0.41, "top_area": "browse/" },
+    "Bob": { "commits": 32, "insertions": 2400, "deletions": 300, "test_ratio": 0.41, "top_area": "browse/" },
     "Alice": { "commits": 12, "insertions": 800, "deletions": 150, "test_ratio": 0.35, "top_area": "app/services/" }
   },
   "version_range": ["1.16.0.0", "1.16.1.0"],

--- a/retro/SKILL.md.tmpl
+++ b/retro/SKILL.md.tmpl
@@ -351,7 +351,7 @@ Write tool で以下のスキーマで JSON ファイルを保存する：
     "ai_assisted_commits": 32
   },
   "authors": {
-    "uzustack-dev": { "commits": 32, "insertions": 2400, "deletions": 300, "test_ratio": 0.41, "top_area": "browse/" },
+    "Bob": { "commits": 32, "insertions": 2400, "deletions": 300, "test_ratio": 0.41, "top_area": "browse/" },
     "Alice": { "commits": 12, "insertions": 800, "deletions": 150, "test_ratio": 0.35, "top_area": "app/services/" }
   },
   "version_range": ["1.16.0.0", "1.16.1.0"],

--- a/retro/SKILL.md.tmpl
+++ b/retro/SKILL.md.tmpl
@@ -351,7 +351,7 @@ Write tool で以下のスキーマで JSON ファイルを保存する：
     "ai_assisted_commits": 32
   },
   "authors": {
-    "Garry Tan": { "commits": 32, "insertions": 2400, "deletions": 300, "test_ratio": 0.41, "top_area": "browse/" },
+    "uzustack-dev": { "commits": 32, "insertions": 2400, "deletions": 300, "test_ratio": 0.41, "top_area": "browse/" },
     "Alice": { "commits": 12, "insertions": 800, "deletions": 150, "test_ratio": 0.35, "top_area": "app/services/" }
   },
   "version_range": ["1.16.0.0", "1.16.1.0"],

--- a/scripts/skill-validate.ts
+++ b/scripts/skill-validate.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env bun
 /**
- * Skill voice validation — voice 規約 v1 の機械チェック可能 subset。
+ * Skill voice validation — voice 規約 v1 + v2 の機械チェック可能 subset。
  * Phase 3.6 step-83 サブタスク 3 で配置、`.github/workflows/skill-docs.yml` の Voice validation step で実行。
  *
  * voice 規約の pattern は `scripts/voice-rules.json` で管理 (v2 拡張は同 file に追記)。
- * 4 pattern を named-capture group で merge し、 line 毎 1-pass scan で全 pattern を check する。
+ * patterns を named-capture group で merge し、 line 毎 1-pass scan で全 pattern を check する。
  *
  * Modes:
  *   default               - 全 .tmpl + .md scan (CI 既定)

--- a/scripts/skill-validate.ts
+++ b/scripts/skill-validate.ts
@@ -43,6 +43,7 @@ interface VoiceRule {
 
 interface VoiceRulesFile {
   version: string;
+  description?: string;
   patterns: VoiceRule[];
 }
 
@@ -185,7 +186,7 @@ async function main() {
     console.log(`    ${v.excerpt}`);
   }
   console.log('─'.repeat(60));
-  console.error('::error::Voice 規約 v1 違反が検出されました。`docs/uzustack/translation-voice-guide.md` を参照して修正してください。');
+  console.error('::error::Voice 規約違反が検出されました。`docs/uzustack/translation-voice-guide.md` を参照して修正してください。');
   process.exit(1);
 }
 

--- a/scripts/voice-rules.json
+++ b/scripts/voice-rules.json
@@ -29,7 +29,7 @@
     },
     {
       "id": "garry_tan_name",
-      "name": "Garry Tan (固有名詞軸 v2)",
+      "name": "Garry Tan (人名)",
       "regex": "\\bGarry Tan\\b"
     }
   ]

--- a/scripts/voice-rules.json
+++ b/scripts/voice-rules.json
@@ -1,6 +1,6 @@
 {
-  "version": "v1",
-  "description": "Voice 規約の機械チェック pattern 集。 scripts/skill-validate.ts が読み込み、 type: translated な skill file 内の gstack 由来の生 string を検出する。 v2 拡張は新規 pattern を本 file に追記する。",
+  "version": "v2",
+  "description": "Voice 規約 v1 + v2 の機械チェック pattern 集 (positive patterns: gstack 識別子 leak 検出)。 scripts/skill-validate.ts が読み込み、 type: translated な skill file 内の gstack 由来の生 string を検出する。 v1 = 文字列軸 (~/.gstack/, $GSTACK_HOME, gstack-*, github URL, ~/.claude/skills/gstack/)、 v2 = 固有名詞軸 (Garry Tan)。 v2 拡張は新規 pattern を本 file に追記する。",
   "patterns": [
     {
       "id": "gstack_home_path",
@@ -21,6 +21,16 @@
       "id": "gstack_skill_path",
       "name": "~/.claude/skills/gstack/ (skill path)",
       "regex": "~\\/\\.claude\\/skills\\/gstack\\/"
+    },
+    {
+      "id": "gstack_repo_url",
+      "name": "github.com/garrytan/gstack (repo URL)",
+      "regex": "github\\.com\\/garrytan\\/gstack"
+    },
+    {
+      "id": "garry_tan_name",
+      "name": "Garry Tan (固有名詞軸 v2)",
+      "regex": "\\bGarry Tan\\b"
     }
   ]
 }


### PR DESCRIPTION
## Summary

`scripts/voice-rules.json` を v2 化し、 voice 規約 v2 から 2 つの positive pattern を追加。 PR #162 で config 化したため 1 file 追記 + 既存 .tmpl 2 file の triage で完結。

## Changes

- `scripts/voice-rules.json`: version `v1` → `v2`、 description を v2 文脈で update、 2 patterns 追加
  - `gstack_repo_url`: `github\.com/garrytan/gstack` (v1 完備性 fix)
  - `garry_tan_name`: `\bGarry Tan\b` (v2 固有名詞軸)
- `office-hours/SKILL.md.tmpl` L677/687/695: testimonial attribution **partial 翻案**
  - `A personal note from me, Garry Tan, the creator of gstack:` → `uzustack 開発者からの個人的なメモ：`
  - body (= `YC partner / Y Combinator` 等) は upstream signal として English 維持
- `retro/SKILL.md.tmpl` L354: JSON example author 名を generic English placeholder に置換
  - `"Garry Tan"` → `"Bob"` (隣接 `"Alice"` との person-name placeholder pair 整合)
- `scripts/skill-validate.ts`: header comment + error message + interface を v1+v2 対応に update
- 再生成 `.md` を同期

## Verification

- `bun run scripts/skill-validate.ts` → 0 violations (full scan, 88 files)
- `bun run scripts/skill-validate.ts --diff` → 0 violations (diff scan, 4 files)

## Test plan

- [x] PR 起票直後に `/simplify` を 2 回実行 (Round 1 actionable + Round 2 drift)
- [x] dogfood: 翻案後の testimonial attribution が voice 規約 v2 固有名詞軸に準拠していること確認 (validator clean)
- [ ] CI (skill-docs.yml) で voice validation pass — squash merge 前に確認

## /simplify audit trail

### Round 1 (commit `94b42f2`、 3 件 actionable fix)

- **修正 1**: `scripts/voice-rules.json` `garry_tan_name` の name field を `(固有名詞軸 v2)` → `(人名)` に変更 (version metadata は description field に集約、 既存 entries の `(path)` / `(env var)` 等の identifier-type 規約と整合)
- **修正 2**: `retro/SKILL.md.tmpl` L354 の JSON example author 名を `uzustack-dev` (role) → `Bob` (person placeholder) に変更 (隣接 `Alice` との semantic 整合)
- **修正 3**: `scripts/skill-validate.ts` L3/L7 の comment を `voice 規約 v1` → `v1 + v2`、 `4 pattern` → `patterns` (count drift 回避) に update

### Round 2 (commit `ee43185`、 2 件 actionable fix)

- **修正 4**: `scripts/skill-validate.ts` L188 の error message `Voice 規約 v1 違反` → `Voice 規約違反` (v1+v2 両対応、 v2 pattern violation 時の misleading 解消)
- **修正 5**: `scripts/skill-validate.ts` `VoiceRulesFile` interface に `description?: string` 追加 (現 JSON は description field を持つが interface 宣言が omit していた、 forward compatibility 改善)

3 周目は回さない (review.md 規律「Round 2 で specificity drift 検出時は即時修正 + audit trail、 3 周目を回さない」)。

### Round 2 で surface した follow-up 候補 (本 PR scope 外、 別 issue / step 候補)

- **partial 翻案 cut-point 規律の明文化**: office-hours testimonial の partial 翻案 (attribution 日本語化 + body 英語維持) は Phase 6 partial 翻案規律 (Chromium binary 英語維持) と rationale が異なる。 一般化規律を `docs/uzustack/translation-voice-guide.md` に明文化する候補
- **pattern-description sync drift lint**: voice-rules.json の `patterns[]` 追加時に `description` field を手動 sync する必要、 lint / 自動検出機構の追加候補

## Out of scope (issue #163 と同じ)

- bare `gstack` word pattern (false positive 多発: Phase 6 warning block + office-hours testimonial body)
- `Y Combinator` / `YC` pattern (attribution / quote context で intentional 維持)
- negative rules (英語維持確認) — voice 規約 v2 拡張本体は Phase 4 cluster 完了後 plan-eng-review で別 epic 化
- inline allow-list 機構 (需要主導、 当面実装しない)

## Related

- Closes #163
- Refs #152 (Phase 4 epic)
- Refs PR #162 (voice-rules.json config 化 — 本 PR の前提)
- `docs/uzustack/translation-voice-guide.md` voice 規約 v1 文字列軸 + v2 固有名詞軸

## Notes

副次効果: office-hours testimonial の attribution 翻案で **bare `gstack`** も同時消去された (`the creator of gstack` が消えた)。 これは #163 pattern (bare gstack なし) では検出されないが、 voice 規約全体には準拠。 Out of scope #1 (bare gstack) の office-hours 経路が **本 PR で部分達成**、 残る Phase 6 warning block 4 file 分は別経路 (Phase 6 完了時の warning block 運命確定) で扱う。

🤖 Generated with [Claude Code](https://claude.com/claude-code)