### PR TITLE
refactor: translation-voice-guide.md 構造再編 — 読者目的別 3 章構成 + Appendix audit trail 化

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -116,13 +116,13 @@ uzustack の runtime は **約 50 個の bin script** + テンプレート機構
 
 ### voice 翻案ガイドライン
 
-[docs/uzustack/translation-voice-guide.md](docs/uzustack/translation-voice-guide.md) に集約。3 軸構成：
+[docs/uzustack/translation-voice-guide.md](docs/uzustack/translation-voice-guide.md) に集約。読者目的別の 3 章構成（第 1 章 translator 用 / 第 2 章 メンテナー用 / 第 3 章 validator 用）+ Appendix A（成立履歴）。第 1 章 1.1 の機械置換ルールは 3 軸：
 
 - **文字列軸**：パス / bin 名 / URL の機械置換ルール
 - **固有名詞軸**：プロジェクト名 / 用語の維持 / 翻訳ルール
 - **voice 軸**：思想 / 規律の翻案ルール
 
-voice 規約 v1（bin 翻訳時に確立、PR #40〜#48）+ v2 拡張（plan / strategy / design / orchestration 系、PR #66〜#118、PR #120 で集約）の 2 層がある。
+voice 規約 v1（Phase 3 bin 翻訳）+ v2（Phase 3.5 plan / strategy / design 系）+ v2 拡張（Phase 4 機械化）の 3 層、詳細は Appendix A 参照。
 
 ### freshness CI
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -122,7 +122,7 @@ uzustack の runtime は **約 50 個の bin script** + テンプレート機構
 - **固有名詞軸**：プロジェクト名 / 用語の維持 / 翻訳ルール
 - **voice 軸**：思想 / 規律の翻案ルール
 
-voice 規約 v1（Phase 3 bin 翻訳）+ v2（Phase 3.5 plan / strategy / design 系）+ v2 拡張（Phase 4 機械化）の 3 層、詳細は Appendix A 参照。
+voice 規約 v1（Phase 3 bin 翻訳）+ v2（Phase 3.5 plan / strategy / design 系）+ v2 拡張（Phase 4 機械化）の 3 段階、詳細は Appendix A 参照。
 
 ### freshness CI
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,10 +44,7 @@ uzustack の翻訳作業（gstack の英語 skill → 日本語 + 経営者文�
 - [docs/uzustack/translation-voice-guide.md](docs/uzustack/translation-voice-guide.md) — voice 規約と訳語表（読者目的別 3 章構成：translator / メンテナー / validator + Appendix 成立履歴）
 - [docs/uzustack/translation-rebase-fixes.md](docs/uzustack/translation-rebase-fixes.md) — rebase 時に保持すべき uzustack 独自 fix
 
-voice 規約は 2 層で蓄積：
-
-- **v1**：bin 翻訳時に確立（PR #40〜#48）
-- **v2 拡張**：plan / strategy / design / orchestration 系で確立（PR #66〜#118、PR #120 で集約）
+voice 規約の成立履歴（v1 / v2 / v2 拡張 の 3 段階）は本ガイド Appendix A を参照。
 
 翻訳作業中に追加ルール候補が出た場合、同 PR 内で `docs/uzustack/translation-voice-guide.md` も更新する（cluster-end の事後集約より気付き〜規約化の lag を最小化）。
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ SKILL.md は **`.tmpl` から生成される**。直接編集してはならな�
 
 uzustack の翻訳作業（gstack の英語 skill → 日本語 + 経営者文脈）には voice 規約がある。**新規翻訳 / rebase 着手前は必読**：
 
-- [docs/uzustack/translation-voice-guide.md](docs/uzustack/translation-voice-guide.md) — voice 規約と訳語表（文字列軸 / 固有名詞軸 / voice 軸の 3 軸構成）
+- [docs/uzustack/translation-voice-guide.md](docs/uzustack/translation-voice-guide.md) — voice 規約と訳語表（読者目的別 3 章構成：translator / メンテナー / validator + Appendix 成立履歴）
 - [docs/uzustack/translation-rebase-fixes.md](docs/uzustack/translation-rebase-fixes.md) — rebase 時に保持すべき uzustack 独自 fix
 
 voice 規約は 2 層で蓄積：

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -282,7 +282,7 @@ push / PR ごとに以下を実行：
 
 ### voice 規約 + 訳語表
 
-uzustack の翻訳作業で使う **voice 規約と訳語表（置換ルール表 v1 + voice 規約 v1/v2）** は [docs/uzustack/translation-voice-guide.md](docs/uzustack/translation-voice-guide.md) に集約しています。文字列軸・固有名詞軸・voice 軸の 3 軸構成で訳語の機械置換ルールを定義しているため、新規翻訳着手前に必読です。
+uzustack の翻訳作業で使う **voice 規約と訳語表** は [docs/uzustack/translation-voice-guide.md](docs/uzustack/translation-voice-guide.md) に集約しています。読者目的別の 3 章構成（第 1 章 translator 用 / 第 2 章 メンテナー用 / 第 3 章 validator 用）+ Appendix A（成立履歴）を持ち、第 1 章 1.1 で訳語の機械置換ルールを 3 軸（文字列 / 固有名詞 / voice）で定義しています。新規翻訳着手前に必読です。
 
 ### 新規翻訳の手順（1 個ずつ、緊急時 / 単発の場合）
 

--- a/docs/uzustack/phase6-warning-block.md
+++ b/docs/uzustack/phase6-warning-block.md
@@ -43,7 +43,7 @@ connect-chrome / canary / setup-browser-cookies に既存する `# <skill> — P
 
 ### voice 翻案の射程
 
-warning block 自体は uzustack voice (= 経営者文脈 + 日本語) で書く。 ただし browse 機構の英語 error / output / Chromium binary 出力 自体は Phase 6 まで翻案保留 (= 英語のまま動作させる) と明示する (詳細は `docs/uzustack/translation-voice-guide.md` の「Phase 6 待ち skill の voice 翻案射程」 section)。
+warning block 自体は uzustack voice (= 経営者文脈 + 日本語) で書く。 ただし browse 機構の英語 error / output / Chromium binary 出力 自体は Phase 6 まで翻案保留 (= 英語のまま動作させる) と明示する (詳細は `docs/uzustack/translation-voice-guide.md` の「1.4 射程外」 section)。
 
 ### subtree pull 上書き耐性
 

--- a/docs/uzustack/translation-voice-guide.md
+++ b/docs/uzustack/translation-voice-guide.md
@@ -161,7 +161,7 @@ bash + 副言語 embedded（Python heredoc / bun -e の JS 等）の翻訳に適
 | premise | 前提（premise） |
 | Outside Voice | 外部視点（Outside Voice） |
 | founder mode | 創業者モード（founder-mode） |
-| wartime / peacetime | 戦時 / 平時 |
+| wartime / peacetime | 火消し対応 / 平常運転（wartime / peacetime） |
 
 #### Mode / 状態名 layer
 

--- a/docs/uzustack/translation-voice-guide.md
+++ b/docs/uzustack/translation-voice-guide.md
@@ -255,26 +255,24 @@ voice 規約は **ファイル名そのもの** も射程に含める。`bin/<na
 
 **運用方針の補足**：
 
-- **bash + 副言語 embedded** は副言語コメントも日本語化
-- **TypeScript / 主言語そのもの** は英語維持（reader 想定の言語と一致させる）
 - **CONFIG_HEADER の日本語化方針**：英語コメントを bin 配置初期段階で保留する場合は、本ルール表整備後に brain 系翻訳と整合させて日本語化する
 - **DEFAULTS の意味論判断は brain 系翻訳に集中**：gstack 文字を含まない key（例：`gbrain_sync_mode`）は機械置換せず、brain 系翻訳時に集中判断
 
 ### 2.4 翻案の指針（meta-rule）
 
+具体ルールは 1.2 / 1.3 に列挙、本 section は判断の meta-rule のみ。
+
 - **persona 表現は意味で訳す**：直訳より「日本語で持つべき重み」を優先。例：`Boil the Lake` の「徹底的にやり切る」感を「一晩でやり切る」で表現
 - **Mode 名は初出併記、以降短縮**：`スコープ拡張モード（SCOPE EXPANSION）` 初出 → 「拡張モード」短縮
 - **思考特性は意味訳 + 出典維持**：個人名（Bezos / Munger 等）は attribution として保持、訳語は意味重視
-- **STOP / OK / CRITICAL GAP 等の inline marker**：英語維持（CLI 慣習との整合）
-- **AskUserQuestion / RECOMMENDATION 等の tool / framework 名**：英語維持（fixed identifier）
 
 ### 2.5 蓄積観測
 
 bin 翻訳バッチ完了時の追加観測 3 点：
 
-- **機械置換は dangling reference まで忠実に伝播する**：comment 内の他 binary 参照も置換対象。実体未持ち込みの binary 参照を削除した事例あり。`/simplify` の quality + reuse agent が独立に同じ findings を発見、cross-validation で confidence 高い
+- **機械置換は dangling reference まで忠実に伝播する**：comment 内の他 binary 参照も置換対象。具体例：`uzustack-question-log:27` の `uzustack-question-sensitivity`（実体未持ち込み）参照を削除した事例。`/simplify` の quality + reuse agent が独立に同じ findings を発見、cross-validation で confidence 高い
 - **output 表示英語維持の境界線**：sentinel token + 周辺 context は parser 互換重視で英語維持。`uzustack-specialist-stats` output / dashboard 系で適用。コメント / status メッセージは日本語化、機械処理される token は英語維持
-- **judgment 軸数の動的性**：外部 CLI 連携の有無で軸数が変動する。事前合意で軸数を確定すれば翻訳バッチ進行が機械化される
+- **judgment 軸数の動的性**：外部 CLI 連携の有無で軸数が変動する。例：`gbrain` 連携あり → 3 軸 / なし → 2 軸 / なし + CONTRIBUTING 統合あり → 2 軸 + 統合タスク。事前合意で軸数を確定すれば翻訳バッチ進行が機械化される
 
 ### 2.6 CONTRIBUTING.md との関係
 
@@ -293,21 +291,21 @@ CONTRIBUTING.md「Phase 6 待ち skill 翻訳時の warning 配置必須」 sect
 | 文字列軸 | path / env / bin 名 / URL 等 | [1.1 機械置換 / 文字列軸](#文字列軸パスbin-名url-等) | 機械化済（positive rules、6 patterns） |
 | 固有名詞軸 | Garry Tan 等 | [1.1 機械置換 / 固有名詞軸](#固有名詞軸) | 機械化済（positive rules） |
 | axis 1（負） | 全角括弧 `（` `）` の voice 規約違反検出 | [1.3 翻案 / bash + 副言語 embedded layer](#bash--副言語-embedded-layer) | #165 で計画中 |
-| axis 2（負） | persona attribution / Mode 名表記の維持 | [1.2 英語維持 / design 固有用語](#design-固有用語--persona-attribution) + [1.3 翻案 / Mode 名](#mode--状態名-layer) + [1.3 翻案 / 経営者思考特性](#経営者思考特性cognitive-patterns) | #165 で計画中 |
+| axis 2（負） | persona attribution / Mode 名表記の維持 | [1.3 翻案](#13-翻案) + [1.2 英語維持](#12-英語維持)（Mode 名 / 経営者思考特性 / persona attribution） | #165 で計画中 |
 | axis 3（負） | 外部 LLM prompt 英語維持 | [1.2 英語維持 / 外部 LLM 向け prompt 本体](#外部-llm-向け-prompt-本体) | #165 で計画中 |
 
 ### 3.2 voice-rules.json schema との cross-ref
 
-`scripts/voice-rules.json` の `patterns` array が validator 側の source of truth。`scripts/skill-validate.ts` が読み込み、`type: translated` な skill file 内の gstack 由来の生 string を検出する。本ガイドとの対応：
+`scripts/voice-rules.json` の `patterns` array が validator 側の source of truth。`scripts/skill-validate.ts` が読み込み、`type: translated` な skill file 内の gstack 由来の生 string を検出する。全 pattern は [1.1 機械置換](#11-機械置換gstack--uzustack) の各軸に対応する：
 
-| voice-rules.json pattern id | 検出対象 | 本ガイド section | 状態 |
+| voice-rules.json pattern id | 検出対象 | 1.1 内軸 | 状態 |
 |---|---|---|---|
-| `gstack_home_path` | `~/.gstack/` (path) | [1.1 文字列軸](#文字列軸パスbin-名url-等) | 機械化済 |
-| `gstack_home_env` | `$GSTACK_HOME` (env var) | [1.1 文字列軸](#文字列軸パスbin-名url-等) | 機械化済 |
-| `gstack_bin_prefix` | `gstack-XXX` (bin 名) | [1.1 文字列軸](#文字列軸パスbin-名url-等) | 機械化済 |
-| `gstack_skill_path` | `~/.claude/skills/gstack/` | [1.1 文字列軸](#文字列軸パスbin-名url-等) | 機械化済 |
-| `gstack_repo_url` | `github.com/garrytan/gstack` | [1.1 文字列軸](#文字列軸パスbin-名url-等) | 機械化済 |
-| `garry_tan_name` | `Garry Tan` (人名) | [1.1 固有名詞軸](#固有名詞軸) | 機械化済 |
+| `gstack_home_path` | `~/.gstack/` (path) | 文字列軸 | 機械化済 |
+| `gstack_home_env` | `$GSTACK_HOME` (env var) | 文字列軸 | 機械化済 |
+| `gstack_bin_prefix` | `gstack-XXX` (bin 名) | 文字列軸 | 機械化済 |
+| `gstack_skill_path` | `~/.claude/skills/gstack/` | 文字列軸 | 機械化済 |
+| `gstack_repo_url` | `github.com/garrytan/gstack` | 文字列軸 | 機械化済 |
+| `garry_tan_name` | `Garry Tan` (人名) | 固有名詞軸 | 機械化済 |
 | （未登録） | axis 1/2/3（negative rules） | 上記 3.1 参照 | #165 で計画中 |
 
 新 pattern を追加する時は `scripts/voice-rules.json` の `patterns` array に entry を追記する（schema は `version` + `description` + `patterns[]` で forward compatible）。

--- a/docs/uzustack/translation-voice-guide.md
+++ b/docs/uzustack/translation-voice-guide.md
@@ -4,13 +4,22 @@
 
 翻訳の入り口（配置とメタデータ・翻訳の粒度・新規翻訳の手順・small batch アプローチ・rebase 手順）は `CONTRIBUTING.md` を参照してください。
 
+**読者目的別の 3 章構成**：
+
+- **第 1 章**：翻訳作業中に参照する（contributor 向け、ルール本体）
+- **第 2 章**：規約を育てる時に参照する（メンテナー向け、meta-rule）
+- **第 3 章**：validator (機械化) で参照する（validator 開発者向け、索引）
+- **Appendix A**：voice 規約の成立履歴（時軸 audit trail）
+
 ---
 
-## 置換ルール表 v1
+## 1. 翻訳作業中に参照する
+
+### 1.1 機械置換（gstack → uzustack）
 
 bin 機械翻訳と既存 skill の .tmpl 化が「**置換ルール表を見るだけ**」で進むよう、`gstack` → `uzustack` の機械置換ルールを明文化しています。3 軸構成。
 
-### 文字列軸（パス・bin 名・URL 等）
+#### 文字列軸（パス・bin 名・URL 等）
 
 | gstack | uzustack |
 |---|---|
@@ -22,7 +31,7 @@ bin 機械翻訳と既存 skill の .tmpl 化が「**置換ルール表を見る
 
 **注意**：長いパターンから先に置換すること。`gstack-config` → `uzustack-config` を先、`gstack` → `uzustack` を後。逆順だと `uzustackconfig` のような壊れ方をする。
 
-### 固有名詞軸
+#### 固有名詞軸
 
 | gstack | uzustack |
 |---|---|
@@ -31,7 +40,7 @@ bin 機械翻訳と既存 skill の .tmpl 化が「**置換ルール表を見る
 | Garry Tan 個人を指す箇所 | OSS メンテナー |
 | Bezos / Munger / Jobs / Hastings / Horowitz / Altman / Rams / Graham / Chesky / Grove | 個人名維持（思考特性の attribution、business persona quote の出典として保持） |
 
-### voice 軸（思想・規律の翻案）
+#### voice 軸（思想・規律の翻案）
 
 原文を尊重する目的で、訳語と併記する形で残す。
 
@@ -43,11 +52,118 @@ bin 機械翻訳と既存 skill の .tmpl 化が「**置換ルール表を見る
 
 ---
 
-## voice 規約 v2 拡張（plan / strategy review 系で確立、PR #66）
+### 1.2 英語維持
 
-`plan-ceo-review` 翻訳（PR #66）で plan / strategy review 系 skill が共有する persona 表現の訳語を確立。後続の plan 系 skill 翻訳（PR #110〜#118）で踏襲。
+翻訳しない対象。頻度順 × coverage scope で、訳者がよく出会う順に並ぶ。
 
-### Mode / 状態名（plan-ceo-review の 4 mode 等）
+#### CLI 名 / env / path 識別子
+
+`base` / `ours` / `theirs`、API 名、bin 名（backtick 囲み、例：`uzustack-config`）等の fixed identifier は英語維持。
+
+#### bash section 見出し
+
+`Usage:` / `Behavior:` / `Exit codes:` 等の section 見出しは英語維持（CLI 慣習に合わせる）。
+
+#### JSON field / enum / inline marker / machine-readable marker
+
+LLM 出力 / tool call / shell parser の機械処理対象は英語維持。reader 想定の言語と機械処理 contract を分離する。
+
+- **machine-readable marker**：`CONFIRMED` / `DISAGREE` / `TASTE DECISION` / `PHASE [N] COMPLETE` / `STATUS` / `SOURCE` / `TIMESTAMP` / `COMMIT` / `RESTORE_PATH` 等
+- **JSON field**：`scope_appetite` / `risk_tolerance` / `detail_preference` / `autonomy` / `architecture_care` 等
+- **enum value**：`never-ask` / `always-ask` / `ask-only-for-one-way` / `SELECTIVE_EXPANSION` / `FULL_REVIEW` / `DX POLISH` 等
+- **dimension 名**：calibration gate threshold（`sample_size` / `skills_covered` / `question_ids_covered` / `days_span`）等
+- **inline marker**：`STOP` / `OK` / `CRITICAL GAP` 等
+- **tool / framework 名**：`AskUserQuestion` / `RECOMMENDATION` 等の fixed identifier
+
+#### 数値 specificity / embedded code structural integrity
+
+訳出時に数値・構造を動かさない。upstream の判断材料を保持する。
+
+- **数値 specificity**：calibration gate threshold（`sample_size >= 20` / `skills_covered >= 3` / `question_ids_covered >= 8` / `days_span >= 7`）、band threshold（0.25 / 0.85 等）の数値はすべて完全保持
+- **embedded code structural integrity**：`fs.writeFileSync` / `fs.renameSync` / `JSON.parse` 等の出現回数も訳出後で同数を保つ。atomic write pattern 等の構造を維持
+
+#### design 固有用語 / persona attribution
+
+design / UI / UX 領域の固有用語と persona attribution は英語維持。design 業界の慣用語と attribution を保持する。
+
+- **design 固有用語**：`Designer's eye` / `AI slop` / `design score` 等
+- **machine-readable marker**：`DESIGN_READY` / `DESIGN_NOT_AVAILABLE` 等の `DESIGN_*` シリーズ
+- **CLI shorthand**：`$D`（design CLI）/ `$B`（browse CLI）等
+- **design 概念名**：`Approved Mockups` 等
+- **persona 出典群**：Rams / Norman / Krug / Gebbia / Ive / Glass / Maeda / Zhuo / Nielsen / Redish / Jarrett 等の attribution
+
+#### 外部 SaaS / 別プロジェクト identifier
+
+`gstack` 由来は `uzustack` に置換するが、以下は維持：
+
+- **外部 CLI 名**：`gbrain`（別プロジェクト）、`Codex CLI` / `Gemini CLI`（外部 product）
+- **外部 path / config**：`~/.gbrain/config.json` / `~/.codex/sessions` / `~/.gemini/projects.json` / `~/.claude/projects`
+- **外部 env**：`GBRAIN_URL` / `GBRAIN_TOKEN` / `CODEX_HOME` / `CODEX_API_KEY` / `OPENAI_API_KEY`
+- **外部プロジェクト共有 config key**：`gbrain_sync_mode` 等（`uzustack-config` に外部プロジェクトと共有する key）
+- **外部 SaaS リソース慣習名**：例 Supabase project name prefix `gbrain`（gbrain CLI で作る project の慣習）
+- **OS / Tool UI 引用**：Chrome の `'Developer mode'` / `'Load unpacked'`（Chrome 自身の英語 UI 引用）
+
+#### 外部 LLM 向け prompt 本体
+
+外部 LLM（codex / openai / gemini 等）に投入する prompt 本体は英語維持。LLM 訓練語の効果を保つ。
+
+- **英語維持対象**：codex / openai-cli / gemini-cli 等への prompt 本体、system prompt、user prompt
+- **uzustack 化対象**：boundary path（`paths containing skills/uzustack`）等の path 識別子のみ
+- **判断軸**：外部 product への入力は外部 product の言語 contract に従う
+
+#### subtree path（`_upstream/gstack/`）
+
+uzustack repo 内の `_upstream/gstack/` は subtree directory 名 = 物理 path。文字列内に `gstack` が出ても置換しない。
+
+- **対象**：`_upstream/gstack/<dir>/...` 形式の path 引用、ドキュメント / コメント内の subtree path
+- **理由**：物理 directory 名としての identifier、置換すると broken reference
+
+---
+
+### 1.3 翻案
+
+日本語に翻案する voice 規約。翻案規模順（small → large）で、bash 内 inline から経営者思考特性の table まで並ぶ。
+
+#### bash + 副言語 embedded layer
+
+bash + 副言語 embedded（Python heredoc / bun -e の JS 等）の翻訳に適用する規律。
+
+- **エラーメッセージは客観形（日本語）**：「〜が必要、実際は N 個」のような客観事実、責難形（「〜してください」）は避ける
+- **インラインコメントは簡潔な日本語**、技術用語は backtick で英語維持
+- **括弧**：半角 `(...)` を維持
+- **embedded code 内コメント**（Python heredoc / bun -e の JS 等）も日本語化、技術用語は英語維持
+- **embedded Python heredoc 内の error 文字列** も日本語化対象（voice 規約 v1 #2 の客観形ルールが境界を貫通する）
+- **TypeScript / 主言語そのもの** は英語維持（reader 想定の言語と一致させる）
+
+#### 単語・短語 layer（Data flow 用語）
+
+データフロー review の path 名は意味重視で訳す。`shadow paths` など voice 概念は原文併記。
+
+| gstack | uzustack |
+|---|---|
+| happy path | 正常路（happy path） |
+| nil path | nil 路 |
+| empty path | 空路 |
+| error path | エラー路（error path） |
+| shadow paths | 影路（shadow paths） |
+
+#### persona / metaphor layer
+
+訳語と併記、初出時に `日本語（English）` で提示。
+
+| gstack | uzustack |
+|---|---|
+| 10x check | 10 倍 check |
+| 10-star product | 10 段階満点の製品 |
+| cathedral | カテドラル |
+| platonic ideal | プラトン的理想形 |
+| dream big | 大きく夢見る |
+| premise | 前提（premise） |
+| Outside Voice | 外部視点（Outside Voice） |
+| founder mode | 創業者モード（founder-mode） |
+| wartime / peacetime | 戦時 / 平時 |
+
+#### Mode / 状態名 layer
 
 訳語と原文の併記形式で、初出時に `日本語（English）` で提示、以降は短縮日本語のみで参照可能。
 
@@ -58,7 +174,7 @@ bin 機械翻訳と既存 skill の .tmpl 化が「**置換ルール表を見る
 | HOLD SCOPE | スコープ維持モード（HOLD SCOPE）→ 短縮：維持モード |
 | SCOPE REDUCTION | スコープ縮減モード（SCOPE REDUCTION）→ 短縮：縮減モード |
 
-### 経営者思考特性（cognitive patterns、industry leader 由来）
+#### 経営者思考特性（cognitive patterns）
 
 各思考特性は具体的経営者・投資家の発言に紐づく persona 概念。訳語は意味重視、原文を併記して identity を保持する。
 
@@ -83,137 +199,42 @@ bin 機械翻訳と既存 skill の .tmpl 化が「**置換ルール表を見る
 | Subtraction default | 引き算的標準 | Rams |
 | Design for trust | 信頼のデザイン | UI 系 |
 
-### 経営者・builder persona 表現（metaphor / vision 系）
+---
 
-訳語と併記、初出時に `日本語（English）` で提示。
+### 1.4 射程外（Phase 6 まで保留）
 
-| gstack | uzustack |
-|---|---|
-| 10x check | 10 倍 check |
-| 10-star product | 10 段階満点の製品 |
-| cathedral | カテドラル |
-| platonic ideal | プラトン的理想形 |
-| dream big | 大きく夢見る |
-| premise | 前提（premise） |
-| Outside Voice | 外部視点（Outside Voice） |
-| founder mode | 創業者モード（founder-mode） |
-| wartime / peacetime | 戦時 / 平時 |
+uzustack の **browse 機構必須 14 skill**（browse / qa / qa-only / canary / benchmark / make-pdf / design-review / design-consultation / devex-review / land-and-deploy / open-uzustack-browser / pair-agent / connect-chrome / setup-browser-cookies）は Phase 6 で実装検討の対象。翻訳作業時の voice 翻案射程を明示する：
 
-### Data flow / review 用語
+#### 射程内（uzustack voice で翻訳）
 
-データフロー review の path 名は意味重視で訳す。`shadow paths` など voice 概念は原文併記。
+- SKILL.md.tmpl 本文（method 説明 / phase 構造 / important rules / report 形式）
+- frontmatter description / triggers / voice-triggers
+- 共通 warning block（詳細：[phase6-warning-block.md](phase6-warning-block.md)）— uzustack voice で記述
 
-| gstack | uzustack |
-|---|---|
-| happy path | 正常路（happy path） |
-| nil path | nil 路 |
-| empty path | 空路 |
-| error path | エラー路（error path） |
-| shadow paths | 影路（shadow paths） |
+#### 射程外（英語のまま動作させる）
 
-### 翻訳指針
+- browse 機構の英語 error / output メッセージ — Playwright / Chromium binary が出力する文字列、翻案するとデバッグ困難になる
+- Chrome extension の sidebar UI 文字列 — Phase 6 実装時に翻案するか別 issue として判断
+- browser-manager 内部の log / debug 出力 — runtime 層に属するため voice 翻案外
+- Playwright の locator API / selector 名 — 外部 protocol identifier として維持
 
-- **persona 表現は意味で訳す**：直訳より「日本語で持つべき重み」を優先。例：`Boil the Lake` の「徹底的にやり切る」感を「一晩でやり切る」で表現
-- **Mode 名は初出併記、以降短縮**：`スコープ拡張モード（SCOPE EXPANSION）` 初出 → 「拡張モード」短縮
-- **思考特性は意味訳 + 出典維持**：個人名（Bezos / Munger 等）は attribution として保持、訳語は意味重視
-- **STOP / OK / CRITICAL GAP 等の inline marker**：英語維持（CLI 慣習との整合、voice 規約 v1 項目 1 と同型）
-- **AskUserQuestion / RECOMMENDATION 等の tool / framework 名**：英語維持（fixed identifier）
+#### 判断基準
+
+「文字列が end user の**目に入る**か」で判定する。SKILL.md instruction や warning block は end user が読む = 翻案射程内。内部 binary の error 出力 / log は debug 用 = 翻案射程外。
+
+**事例**：design-review / design-consultation / land-and-deploy は SKILL.md 本文を翻訳完了したが、内部で呼ぶ browse 機構の error / output は Phase 6 まで英語維持 — これを意図的な「partial 翻案」として明文化する。
 
 ---
 
-## voice 規約 v2 拡張 — Phase 3.5 蓄積（PR #68〜#118 で確立、PR #120 で集約）
+## 2. 規約を育てる時に参照する
 
-Phase 3.5 進行（plan / strategy / cli tuning / design / orchestration 系 skill 翻訳）を通じて確立した英語維持規律。voice 規約 v1 項目 4「fixed identifier 英語維持」を拡張する形で文書化。
+### 2.1 集約タイミング規律
 
-### 外部 LLM 向け prompt 全体の英語維持（autoplan 翻訳時に確立、PR #118）
+翻訳バッチ進行中は規範が PR description / commit message に分散して動いている。**バッチ完了で規範が固まった直後（次バッチ着手前）に本ガイドへ集約**する。Phase 完了判定まで待つとバッチ内参照性が上がらず、PR description を漁る運用になる。
 
-外部 LLM（codex / openai / gemini 等）に投入する prompt 本体は **英語維持**。LLM 訓練語の効果を保つ。voice 規約 v1 項目 4 を「外部 SaaS / 別プロジェクト identifier 維持」から「外部 LLM への prompt 全体」に拡張した解釈。
+### 2.2 規約射程の拡張ルール（ファイル名も射程）
 
-- **英語維持対象**：codex / openai-cli / gemini-cli 等への prompt 本体、system prompt、user prompt
-- **uzustack 化対象**：boundary path（`paths containing skills/uzustack`）等の path 識別子のみ
-- **判断軸**：外部 product への入力は外部 product の言語 contract に従う
-
-### JSON field / enum / inline marker / dimension 名 / machine-readable marker の英語維持（PR #112 / #116 / #118 で蓄積）
-
-LLM 出力 / tool call / shell parser の機械処理対象は **英語維持**。reader 想定の言語と機械処理 contract を分離する。
-
-- **machine-readable marker**：`CONFIRMED` / `DISAGREE` / `TASTE DECISION` / `PHASE [N] COMPLETE` / `STATUS` / `SOURCE` / `TIMESTAMP` / `COMMIT` / `RESTORE_PATH` 等
-- **JSON field**：`scope_appetite` / `risk_tolerance` / `detail_preference` / `autonomy` / `architecture_care` 等
-- **enum value**：`never-ask` / `always-ask` / `ask-only-for-one-way` / `SELECTIVE_EXPANSION` / `FULL_REVIEW` / `DX POLISH` 等
-- **dimension 名**：calibration gate threshold（`sample_size` / `skills_covered` / `question_ids_covered` / `days_span`）等
-
-### 数値 specificity / embedded code structural integrity の完全保持（plan-tune 翻訳時に確立、PR #116）
-
-訳出時に数値・構造を動かさない。upstream の判断材料を保持する。
-
-- **数値 specificity**：calibration gate threshold（`sample_size >= 20` / `skills_covered >= 3` / `question_ids_covered >= 8` / `days_span >= 7`）、band threshold（0.25 / 0.85 等）の数値はすべて完全保持
-- **embedded code structural integrity**：`fs.writeFileSync` / `fs.renameSync` / `JSON.parse` 等の出現回数も訳出後で同数を保つ。atomic write pattern 等の構造を維持
-
-### subtree path (`_upstream/gstack/`) の外部 identifier 維持（PR #116 で確認）
-
-uzustack repo 内の `_upstream/gstack/` は subtree directory 名 = 物理 path。voice 規約 v1 項目 4「外部 identifier 維持」の特殊例として、文字列内に `gstack` が出ても置換しない。
-
-- **対象**：`_upstream/gstack/<dir>/...` 形式の path 引用、ドキュメント / コメント内の subtree path
-- **理由**：物理 directory 名としての identifier、置換すると broken reference
-
-### design 文脈の英語維持（plan-design-review 翻訳時に確立、PR #112）
-
-design / UI / UX 領域の固有用語と persona attribution は **英語維持**。design 業界の慣用語と attribution を保持する。
-
-- **design 固有用語**：`Designer's eye` / `AI slop` / `design score` 等
-- **machine-readable marker**：`DESIGN_READY` / `DESIGN_NOT_AVAILABLE` 等の `DESIGN_*` シリーズ
-- **CLI shorthand**：`$D`（design CLI）/ `$B`（browse CLI）等
-- **design 概念名**：`Approved Mockups` 等
-- **persona 出典群**：Rams / Norman / Krug / Gebbia / Ive / Glass / Maeda / Zhuo / Nielsen / Redish / Jarrett 等の attribution（cognitive pattern table の出典列とは別の文脈で出る attribution として）
-
-### 周辺ルール
-
-- **CONFIG_HEADER の日本語化方針**：`gstack-config` の英語コメント約 70 行は、bin 配置初期段階で英語のままコピーで保留。本ルール表整備後、brain 系翻訳（PR #44）と整合させて日本語化済
-- **DEFAULTS の意味論判断は brain 系翻訳に集中**：gstack 文字を含まない key（例：`gbrain_sync_mode`）は機械置換せず、brain 系翻訳時（PR #44）に集中判断
-- **v1 で完璧を目指さない**：翻訳作業中に増えるケースは追記して育てる方針。迷ったら `v2 で見直し` フラグ付きで暫定採用し、翻訳作業を止めない
-
----
-
-## voice 規約 v1（bin 翻訳時に確立）
-
-Phase 3 の bin 翻訳バッチ（PR #40 / #42 / #44 / #46 / #48）で確立した voice 翻案規律。bash + 副言語 embedded スクリプトの翻訳に適用する。本節は bin 翻訳バッチ完了時に PR description に分散していた規範を集約したもの。
-
-### 7 項目（bin 翻訳着手時に確立、PR #40 commit `d1b2c0f`）
-
-1. **Section 見出し**（`Usage:` / `Behavior:` / `Exit codes:`）は **英語維持** — CLI 慣習に合わせる
-2. **エラーメッセージは客観形（日本語）**：「〜が必要、実際は N 個」のような客観事実、責難形（「〜してください」）は避ける
-3. **インラインコメントは簡潔な日本語**、技術用語は backtick で英語維持
-4. **fixed identifier**（`base` / `ours` / `theirs`、API 名）は **英語維持**
-5. **bin 名**は backtick 囲み（例：`uzustack-config`）
-6. **embedded code** 内コメント（Python heredoc / bun -e の JS 等）も日本語化、技術用語は英語維持
-7. **括弧**は半角 `(...)` を維持
-
-### 運用方針 v1
-
-- **bash + 副言語 embedded** は副言語コメントも日本語化（PR #42 で確立、Python heredoc / bun -e の JS で適用）
-- **TypeScript / 主言語そのもの**は英語維持（reader 想定の言語と一致させる、PR #40 `uzustack-next-version` 477 行 TS で確立）
-- **embedded Python heredoc 内の error 文字列** も日本語化対象（PR #44 `uzustack-brain-init` / `uzustack-brain-restore` で確認、voice 規約 v1 項目 2 が境界を貫通する）
-
-### 外部 SaaS / 別プロジェクト identifier 維持（PR #44 拡張）
-
-voice 規約 v1 項目 4「fixed identifier 英語維持」を、外部 SaaS や別プロジェクトの identifier にも拡張する。`gstack` 由来は `uzustack` に置換するが、以下は **維持**：
-
-- **外部 CLI 名**：`gbrain`（別プロジェクト）、`Codex CLI` / `Gemini CLI`（外部 product）
-- **外部 path / config**：`~/.gbrain/config.json` / `~/.codex/sessions` / `~/.gemini/projects.json` / `~/.claude/projects`
-- **外部 env**：`GBRAIN_URL` / `GBRAIN_TOKEN` / `CODEX_HOME` / `CODEX_API_KEY` / `OPENAI_API_KEY`
-- **外部プロジェクト共有 config key**：`gbrain_sync_mode` 等（`uzustack-config` に外部プロジェクトと共有する key）
-- **外部 SaaS リソース慣習名**：例 Supabase project name prefix `gbrain`（gbrain CLI で作る project の慣習）
-- **OS / Tool UI 引用**：Chrome の `'Developer mode'` / `'Load unpacked'`（Chrome 自身の英語 UI 引用）
-
-### bin 翻訳バッチ完了時の追加観測 3 点（PR #46）
-
-- **機械置換は dangling reference まで忠実に伝播する**：comment 内の他 binary 参照も置換対象。`uzustack-question-log:27` の `uzustack-question-sensitivity`（実体未持ち込み）参照を削除した事例。`/simplify` の quality + reuse agent が独立に同じ findings を発見、cross-validation で confidence 高い
-- **output 表示英語維持の境界線**：sentinel token + 周辺 context は parser 互換重視で **英語維持**。`uzustack-specialist-stats` output / dashboard 系で適用。コメント / status メッセージは日本語化、機械処理される token は英語維持
-- **judgment 軸数の動的性**：外部 CLI 連携の有無で軸数が変動する。PR #44（`gbrain` あり）→ 3 軸 / PR #46（なし）→ 2 軸 / PR #48（なし、CONTRIBUTING 統合あり）→ 2 軸 + 統合タスク。事前合意で軸数を確定すれば翻訳バッチ進行が機械化される
-
-### 規約射程の拡張（PR #48 で確立）— ファイル名も射程に含める
-
-voice 規約 v1（7 項目）+ 外部 identifier 拡張は **ファイル名そのもの** も射程に含める。`bin/<name>` の `<name>` も「ファイル内 identifier」と同じ規律で扱う。bin 翻訳バッチ完了直前に「規約はファイル内 identifier しか射程に入れていなかった」穴が発覚し、バッチ完了タイミングで穴埋めとして確立。
+voice 規約は **ファイル名そのもの** も射程に含める。`bin/<name>` の `<name>` も「ファイル内 identifier」と同じ規律で扱う。
 
 **運用ルール**：外部 product / protocol / tool 名で構成された binary は **`uzustack-` prefix なしで維持** する。
 
@@ -228,35 +249,90 @@ voice 規約 v1（7 項目）+ 外部 identifier 拡張は **ファイル名そ�
 - `bin/chrome-cdp`（Chrome [外部 product 名] + CDP [外部 protocol 名] の合成）— `uzustack-chrome-cdp` ではなく `chrome-cdp` のまま維持
 - 確認 signal：`_upstream/gstack/test/audit-compliance.test.ts` の `bin/chrome-cdp` hardcode（upstream test が path を直接参照、upstream 設計判断の最も強い signal）
 
-### 集約タイミング規律
+### 2.3 v1 で完璧を目指さない方針
 
-翻訳バッチ進行中は規範が PR description / commit message に分散して動いている。**バッチ完了で規範が固まった直後（次バッチ着手前）に本ガイドへ集約**する。Phase 完了判定まで待つとバッチ内参照性が上がらず、PR description を漁る運用になる。本節は bin 翻訳バッチ完了時（PR #48）で集約した。
+翻訳作業中に増えるケースは追記して育てる方針。迷ったら `v2 で見直し` フラグ付きで暫定採用し、翻訳作業を止めない。
+
+**運用方針の補足**：
+
+- **bash + 副言語 embedded** は副言語コメントも日本語化
+- **TypeScript / 主言語そのもの** は英語維持（reader 想定の言語と一致させる）
+- **CONFIG_HEADER の日本語化方針**：英語コメントを bin 配置初期段階で保留する場合は、本ルール表整備後に brain 系翻訳と整合させて日本語化する
+- **DEFAULTS の意味論判断は brain 系翻訳に集中**：gstack 文字を含まない key（例：`gbrain_sync_mode`）は機械置換せず、brain 系翻訳時に集中判断
+
+### 2.4 翻案の指針（meta-rule）
+
+- **persona 表現は意味で訳す**：直訳より「日本語で持つべき重み」を優先。例：`Boil the Lake` の「徹底的にやり切る」感を「一晩でやり切る」で表現
+- **Mode 名は初出併記、以降短縮**：`スコープ拡張モード（SCOPE EXPANSION）` 初出 → 「拡張モード」短縮
+- **思考特性は意味訳 + 出典維持**：個人名（Bezos / Munger 等）は attribution として保持、訳語は意味重視
+- **STOP / OK / CRITICAL GAP 等の inline marker**：英語維持（CLI 慣習との整合）
+- **AskUserQuestion / RECOMMENDATION 等の tool / framework 名**：英語維持（fixed identifier）
+
+### 2.5 蓄積観測
+
+bin 翻訳バッチ完了時の追加観測 3 点：
+
+- **機械置換は dangling reference まで忠実に伝播する**：comment 内の他 binary 参照も置換対象。実体未持ち込みの binary 参照を削除した事例あり。`/simplify` の quality + reuse agent が独立に同じ findings を発見、cross-validation で confidence 高い
+- **output 表示英語維持の境界線**：sentinel token + 周辺 context は parser 互換重視で英語維持。`uzustack-specialist-stats` output / dashboard 系で適用。コメント / status メッセージは日本語化、機械処理される token は英語維持
+- **judgment 軸数の動的性**：外部 CLI 連携の有無で軸数が変動する。事前合意で軸数を確定すれば翻訳バッチ進行が機械化される
+
+### 2.6 CONTRIBUTING.md との関係
+
+CONTRIBUTING.md「Phase 6 待ち skill 翻訳時の warning 配置必須」 section で「frontmatter status + warning block 配置」 規律を明文化。本節は voice 翻案の **射程** を明文化する補完。配置規律（どこに）↔ 翻案射程規律（何を）の 2 軸で運用する。
 
 ---
 
-## Phase 6 待ち skill の voice 翻案射程
+## 3. validator（機械化）で参照する
 
-uzustack の **browse 機構必須 14 skill** (browse / qa / qa-only / canary / benchmark / make-pdf / design-review / design-consultation / devex-review / land-and-deploy / open-uzustack-browser / pair-agent / connect-chrome / setup-browser-cookies) は Phase 6 で実装検討の対象。 翻訳作業時の voice 翻案射程を明示する：
+### 3.1 機械化対象索引
 
-### 射程内（uzustack voice で翻訳）
+`scripts/voice-rules.json` で機械化される pattern と、本ガイドの section との対応表。axis 1/2/3 は #165 で機械化計画中の負の規約軸。
 
-- SKILL.md.tmpl 本文（method 説明 / phase 構造 / important rules / report 形式）
-- frontmatter description / triggers / voice-triggers
-- 共通 warning block (詳細: [phase6-warning-block.md](phase6-warning-block.md)) — uzustack voice で記述
+| axis | 内容 | 本ガイド section | 機械化状態 |
+|---|---|---|---|
+| 文字列軸 | path / env / bin 名 / URL 等 | [1.1 機械置換 / 文字列軸](#文字列軸パスbin-名url-等) | 機械化済（positive rules、6 patterns） |
+| 固有名詞軸 | Garry Tan 等 | [1.1 機械置換 / 固有名詞軸](#固有名詞軸) | 機械化済（positive rules） |
+| axis 1（負） | 全角括弧 `（` `）` の voice 規約違反検出 | [1.3 翻案 / bash + 副言語 embedded layer](#bash--副言語-embedded-layer) | #165 で計画中 |
+| axis 2（負） | persona attribution / Mode 名表記の維持 | [1.2 英語維持 / design 固有用語](#design-固有用語--persona-attribution) + [1.3 翻案 / Mode 名](#mode--状態名-layer) + [1.3 翻案 / 経営者思考特性](#経営者思考特性cognitive-patterns) | #165 で計画中 |
+| axis 3（負） | 外部 LLM prompt 英語維持 | [1.2 英語維持 / 外部 LLM 向け prompt 本体](#外部-llm-向け-prompt-本体) | #165 で計画中 |
 
-### 射程外（Phase 6 まで翻案保留、 英語のまま動作させる）
+### 3.2 voice-rules.json schema との cross-ref
 
-- browse 機構の英語 error / output メッセージ — Playwright / Chromium binary が出力する文字列、 翻案するとデバッグ困難になる
-- Chrome extension の sidebar UI 文字列 — Phase 6 実装時に翻案するか別 issue として判断
-- browser-manager 内部の log / debug 出力 — runtime 層に属するため voice 翻案外
-- Playwright の locator API / selector 名 — 外部 protocol identifier として維持
+`scripts/voice-rules.json` の `patterns` array が validator 側の source of truth。`scripts/skill-validate.ts` が読み込み、`type: translated` な skill file 内の gstack 由来の生 string を検出する。本ガイドとの対応：
 
-### 判断基準
+| voice-rules.json pattern id | 検出対象 | 本ガイド section | 状態 |
+|---|---|---|---|
+| `gstack_home_path` | `~/.gstack/` (path) | [1.1 文字列軸](#文字列軸パスbin-名url-等) | 機械化済 |
+| `gstack_home_env` | `$GSTACK_HOME` (env var) | [1.1 文字列軸](#文字列軸パスbin-名url-等) | 機械化済 |
+| `gstack_bin_prefix` | `gstack-XXX` (bin 名) | [1.1 文字列軸](#文字列軸パスbin-名url-等) | 機械化済 |
+| `gstack_skill_path` | `~/.claude/skills/gstack/` | [1.1 文字列軸](#文字列軸パスbin-名url-等) | 機械化済 |
+| `gstack_repo_url` | `github.com/garrytan/gstack` | [1.1 文字列軸](#文字列軸パスbin-名url-等) | 機械化済 |
+| `garry_tan_name` | `Garry Tan` (人名) | [1.1 固有名詞軸](#固有名詞軸) | 機械化済 |
+| （未登録） | axis 1/2/3（negative rules） | 上記 3.1 参照 | #165 で計画中 |
 
-「文字列が end user の **目に入る** か」 で判定する。 SKILL.md instruction や warning block は end user が読む = 翻案射程内。 内部 binary の error 出力 / log は debug 用 = 翻案射程外。
+新 pattern を追加する時は `scripts/voice-rules.json` の `patterns` array に entry を追記する（schema は `version` + `description` + `patterns[]` で forward compatible）。
 
-**事例**: design-review / design-consultation / land-and-deploy は SKILL.md 本文を Phase 3.5 で翻訳完了したが、 内部で呼ぶ browse 機構の error / output は Phase 6 まで英語維持 — これを意図的な「partial 翻案」 として明文化する。
+---
 
-### CONTRIBUTING.md との関係
+## Appendix A：voice 規約の成立履歴
 
-CONTRIBUTING.md「Phase 6 待ち skill 翻訳時の warning 配置必須」 section で「frontmatter status + warning block 配置」 規律を明文化。 本節は voice 翻案の **射程** を明文化する補完。 配置規律 (どこに) ↔ 翻案射程規律 (何を) の 2 軸で運用する。
+### A.1 v1（Phase 3 bin 翻訳バッチ）
+
+Phase 3 の bin 翻訳バッチ（PR #40 / #42 / #44 / #46 / #48）で voice 規約 v1 を確立。bash + 副言語 embedded スクリプトの翻訳に適用する 7 項目（section 見出し英語維持 / error msg 客観形 / inline comment 日本語 / fixed identifier 英語維持 / bin 名 backtick / embedded code 日本語化 / 半角括弧）に加え、外部 SaaS / 別プロジェクト identifier 維持規律、bin 翻訳バッチ完了時の追加観測 3 点、ファイル名も射程に含める拡張、集約タイミング規律を establish。PR #40 commit `d1b2c0f` で 7 項目、PR #44 で外部 identifier 拡張、PR #46 で観測 3 点、PR #48 でファイル名射程拡張を確立。
+
+### A.2 v2（Phase 3.5 plan / strategy / design 系）
+
+Phase 3.5 進行（plan / strategy / cli tuning / design / orchestration 系 skill 翻訳）で voice 規約 v2 を確立。PR #66 で `plan-ceo-review` 翻訳時に persona 表現の訳語、PR #68〜#118 で Mode 名 / 経営者思考特性 / persona 表現 / Data flow 用語 / 外部 LLM prompt 英語維持 / JSON field / enum / inline marker / 数値 specificity / embedded code structural / subtree path 維持 / design 文脈の英語維持 / 翻訳指針を蓄積。PR #120 で本ガイドへ集約。
+
+### A.3 v2 拡張（Phase 4 機械化）
+
+Phase 4 で voice-rules.json による機械化を開始。PR #164（commit `8d09561`）で `scripts/voice-rules.json` v2 を導入、positive rules 6 patterns（URL + 固有名詞軸を含む）を機械化。`scripts/skill-validate.ts` が読み込み、translated skill での gstack 識別子 leak を CI で検出。#165 で negative rules（axis 1/2/3 = 全角括弧 / persona attribution / external LLM prompt 英語維持）の機械化を計画中。
+
+---
+
+## Related docs
+
+- [CONTRIBUTING.md](../../CONTRIBUTING.md) — 翻訳作業の入り口（配置 / 粒度 / 手順 / rebase）
+- [translation-rebase-fixes.md](translation-rebase-fixes.md) — rebase 時に保持すべき uzustack 独自 fix
+- [phase6-warning-block.md](phase6-warning-block.md) — Phase 6 待ち skill の warning block template
+- [phase-history.md](phase-history.md) — Phase 進捗と主要 PR # 内訳

--- a/docs/uzustack/translation-voice-guide.md
+++ b/docs/uzustack/translation-voice-guide.md
@@ -132,8 +132,8 @@ bash + 副言語 embedded（Python heredoc / bun -e の JS 等）の翻訳に適
 - **インラインコメントは簡潔な日本語**、技術用語は backtick で英語維持
 - **括弧**：半角 `(...)` を維持
 - **embedded code 内コメント**（Python heredoc / bun -e の JS 等）も日本語化、技術用語は英語維持
-- **embedded Python heredoc 内の error 文字列** も日本語化対象（voice 規約 v1 #2 の客観形ルールが境界を貫通する）
-- **TypeScript / 主言語そのもの** は英語維持（reader 想定の言語と一致させる）
+- **embedded Python heredoc 内の error 文字列** も日本語化対象（`uzustack-brain-init` / `uzustack-brain-restore` で確認、voice 規約 v1 #2 の客観形ルールが境界を貫通する）
+- **TypeScript / 主言語そのもの** は英語維持（reader 想定の言語と一致させる、`uzustack-next-version` 477 行 TS で確立）
 
 #### 単語・短語 layer（Data flow 用語）
 
@@ -255,7 +255,7 @@ voice 規約は **ファイル名そのもの** も射程に含める。`bin/<na
 
 **運用方針の補足**：
 
-- **CONFIG_HEADER の日本語化方針**：英語コメントを bin 配置初期段階で保留する場合は、本ルール表整備後に brain 系翻訳と整合させて日本語化する
+- **CONFIG_HEADER の日本語化方針**：`gstack-config` の英語コメント約 70 行は、bin 配置初期段階で英語のままコピーで保留 → 本ルール表整備後、brain 系翻訳と整合させて日本語化済
 - **DEFAULTS の意味論判断は brain 系翻訳に集中**：gstack 文字を含まない key（例：`gbrain_sync_mode`）は機械置換せず、brain 系翻訳時に集中判断
 
 ### 2.4 翻案の指針（meta-rule）
@@ -288,25 +288,24 @@ CONTRIBUTING.md「Phase 6 待ち skill 翻訳時の warning 配置必須」 sect
 
 | axis | 内容 | 本ガイド section | 機械化状態 |
 |---|---|---|---|
-| 文字列軸 | path / env / bin 名 / URL 等 | [1.1 機械置換 / 文字列軸](#文字列軸パスbin-名url-等) | 機械化済（positive rules、6 patterns） |
-| 固有名詞軸 | Garry Tan 等 | [1.1 機械置換 / 固有名詞軸](#固有名詞軸) | 機械化済（positive rules） |
+| 文字列軸 | path / env / bin 名 / URL 等 | [1.1 機械置換 / 文字列軸](#文字列軸パスbin-名url-等) | 機械化済（positive rules、5 patterns） |
+| 固有名詞軸 | Garry Tan 等 | [1.1 機械置換 / 固有名詞軸](#固有名詞軸) | 機械化済（positive rules、1 pattern） |
 | axis 1（負） | 全角括弧 `（` `）` の voice 規約違反検出 | [1.3 翻案 / bash + 副言語 embedded layer](#bash--副言語-embedded-layer) | #165 で計画中 |
 | axis 2（負） | persona attribution / Mode 名表記の維持 | [1.3 翻案](#13-翻案) + [1.2 英語維持](#12-英語維持)（Mode 名 / 経営者思考特性 / persona attribution） | #165 で計画中 |
 | axis 3（負） | 外部 LLM prompt 英語維持 | [1.2 英語維持 / 外部 LLM 向け prompt 本体](#外部-llm-向け-prompt-本体) | #165 で計画中 |
 
 ### 3.2 voice-rules.json schema との cross-ref
 
-`scripts/voice-rules.json` の `patterns` array が validator 側の source of truth。`scripts/skill-validate.ts` が読み込み、`type: translated` な skill file 内の gstack 由来の生 string を検出する。全 pattern は [1.1 機械置換](#11-機械置換gstack--uzustack) の各軸に対応する：
+`scripts/voice-rules.json` の `patterns` array が validator 側の source of truth。`scripts/skill-validate.ts` が読み込み、`type: translated` な skill file 内の gstack 由来の生 string を検出する。全 pattern は [1.1 機械置換](#11-機械置換gstack--uzustack) の各軸に対応する（negative rules = axis 1/2/3 は #165 で計画中、3.1 参照）：
 
-| voice-rules.json pattern id | 検出対象 | 1.1 内軸 | 状態 |
-|---|---|---|---|
-| `gstack_home_path` | `~/.gstack/` (path) | 文字列軸 | 機械化済 |
-| `gstack_home_env` | `$GSTACK_HOME` (env var) | 文字列軸 | 機械化済 |
-| `gstack_bin_prefix` | `gstack-XXX` (bin 名) | 文字列軸 | 機械化済 |
-| `gstack_skill_path` | `~/.claude/skills/gstack/` | 文字列軸 | 機械化済 |
-| `gstack_repo_url` | `github.com/garrytan/gstack` | 文字列軸 | 機械化済 |
-| `garry_tan_name` | `Garry Tan` (人名) | 固有名詞軸 | 機械化済 |
-| （未登録） | axis 1/2/3（negative rules） | 上記 3.1 参照 | #165 で計画中 |
+| voice-rules.json pattern id | 検出対象 | 1.1 内軸 |
+|---|---|---|
+| `gstack_home_path` | `~/.gstack/` (path) | 文字列軸 |
+| `gstack_home_env` | `$GSTACK_HOME` (env var) | 文字列軸 |
+| `gstack_bin_prefix` | `gstack-XXX` (bin 名) | 文字列軸 |
+| `gstack_skill_path` | `~/.claude/skills/gstack/` | 文字列軸 |
+| `gstack_repo_url` | `github.com/garrytan/gstack` | 文字列軸 |
+| `garry_tan_name` | `Garry Tan` (人名) | 固有名詞軸 |
 
 新 pattern を追加する時は `scripts/voice-rules.json` の `patterns` array に entry を追記する（schema は `version` + `description` + `patterns[]` で forward compatible）。
 


### PR DESCRIPTION
## Summary

`docs/uzustack/translation-voice-guide.md` (262 行) を読者目的別の 3 章構成 + Appendix A (成立履歴) に refactor。 #165 (voice 規約 v2 negative rules 機械化) plan-eng-review session の認知負荷縮減を目的とする。 規約内容 (訳語表・ルール本体) は基本 unchanged、 構造再編と重複統合 + voice 規約 v2 訳語 microtuning 1 件。

## Changes

- 旧「成立順」 構造 → 新「読者目的別 3 章構成」 (第 1 章 translator 用 / 第 2 章 メンテナー用 / 第 3 章 validator 用) + Appendix A
- voice 規約成立履歴 (PR # / commit hash) を Appendix A に集約、 本文中の inline reference を strip
- 第 3 章 (validator) を新規追加、 voice-rules.json schema との cross-ref table を 1 箇所に集約
- cross-ref 整合: CLAUDE.md L44 / CONTRIBUTING.md L285 / ARCHITECTURE.md L119 / phase6-warning-block.md L46 の description を新章立てに update
- **voice 規約 v2 訳語 microtuning** (commit `48ab860`): wartime / peacetime → 「戦時 / 平時」 (直訳) を「火消し対応 / 平常運転（wartime / peacetime）」 に置換 (IT 業界 natural + 併記原則準拠)

## Test plan

- [x] /simplify Round 1 (commit `74af5df`、 actionable findings 6 件 fix: DRY 違反 / leaky abstraction / specificity drift 復元)
- [x] /simplify Round 2 (commit `0b244a3`、 specificity drift 5 件 fix: concrete evidence binary names 復元 + section 3 minor)
- [x] voice 規約 v2 訳語 microtuning (commit `48ab860`、 wartime/peacetime)
- [x] bun run skill:validate で 0 violations 維持 (local 実行済、 88 files / 68 translated)
- [x] ~~CI 経由で skill-validate.ts 再確認~~ → 取り消し: 本 repo に PR-trigger workflow が不在と判明、 issue #170 で別 workflow 追加 (Phase 4 active TODO)
- [x] merge 後にメンテナー側 note / 概念マップを sync (merge と同 turn 内で実行)

## Audit trail (Round 2 specificity drift 修正)

Round 2 cross-validation で旧 doc にあった concrete evidence binary names が refactor で脱落していたことを検出、 復元:

- **section 2.3 CONFIG_HEADER 補足**: `gstack-config` の英語コメント約 70 行 + 完了 status (= 「日本語化済」 past tense) を復元
- **section 1.3 TypeScript / 主言語**: `uzustack-next-version` 477 行 TS で確立 evidence を復元
- **section 1.3 embedded Python heredoc error 文字列**: `uzustack-brain-init` / `uzustack-brain-restore` で確認 binary を復元
- **section 3.1**: 「6 patterns」 → 「5 patterns」 + 固有名詞軸 row 「1 pattern」 追加 (実体 = 文字列軸 5 + 固有名詞軸 1 = 計 6)
- **section 3.2**: row 7 (pointer-only 「未登録 = 上記 3.1 参照」) 削除 + 状態 column 削除 (全 row 「機械化済」 で情報密度ゼロ、 negative rules は前文集約済)

Closes #168