### PR TITLE
feat: skill-validate.yml CI workflow 追加 — skill-docs.yml から voice validation step 剥がし役割分離

### DIFF
--- a/.github/workflows/skill-validate.yml
+++ b/.github/workflows/skill-validate.yml
@@ -8,7 +8,7 @@ name: Skill Voice Validation
 # 不整合）を CI で捕まえるため（defense-in-depth）。
 #
 # 役割分離：freshness check（gen:skill-docs ↔ SKILL.md 整合性）は skill-docs.yml、
-# voice validation（voice 規約違反検出）は本 workflow。並列実行で fail-fast。
+# voice validation（voice 規約違反検出）は本 workflow。skill-docs.yml と独立 trigger で並列実行。
 
 on:
   push:

--- a/.github/workflows/skill-validate.yml
+++ b/.github/workflows/skill-validate.yml
@@ -1,4 +1,4 @@
-name: Skill Docs Freshness
+name: Skill Voice Validation
 
 # Scope: skill directories at the repo top (those containing SKILL.md.tmpl).
 # Type 1/3 区別は SKILL.md.tmpl の frontmatter `type:` で表現される（ディレクトリ
@@ -6,6 +6,9 @@ name: Skill Docs Freshness
 # nested な _upstream/gstack/<skill>/SKILL.md.tmpl は path filter にかからない。
 # `*/SKILL.md` も filter に含めるのは、`.md` だけ手動編集された drift（.tmpl と
 # 不整合）を CI で捕まえるため（defense-in-depth）。
+#
+# 役割分離：freshness check（gen:skill-docs ↔ SKILL.md 整合性）は skill-docs.yml、
+# voice validation（voice 規約違反検出）は本 workflow。並列実行で fail-fast。
 
 on:
   push:
@@ -16,7 +19,7 @@ on:
       - 'scripts/**'
       - 'package.json'
       - 'bun.lock'
-      - '.github/workflows/skill-docs.yml'
+      - '.github/workflows/skill-validate.yml'
   pull_request:
     paths:
       - '*/SKILL.md.tmpl'
@@ -24,20 +27,14 @@ on:
       - 'scripts/**'
       - 'package.json'
       - 'bun.lock'
-      - '.github/workflows/skill-docs.yml'
+      - '.github/workflows/skill-validate.yml'
 
 jobs:
-  check-freshness:
+  voice-validation:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
       - run: bun install --frozen-lockfile
-      - name: Regenerate SKILL.md files
-        run: bun run gen:skill-docs
-      - name: Verify working tree is clean
-        run: |
-          git diff --exit-code || {
-            echo "::error::Generated files are stale or gen:skill-docs wrote outside skills/. Run: bun run gen:skill-docs"
-            exit 1
-          }
+      - name: Voice validation (voice 規約 v1+v2)
+        run: bun run skill:validate

--- a/.github/workflows/skill-validate.yml
+++ b/.github/workflows/skill-validate.yml
@@ -36,5 +36,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
       - run: bun install --frozen-lockfile
-      - name: Voice validation (voice 規約 v1+v2)
+      - name: Voice validation
         run: bun run skill:validate

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -134,6 +134,10 @@ voice 規約 v1（Phase 3 bin 翻訳）+ v2（Phase 3.5 plan / strategy / design
 
 「ソース定義（`.tmpl` + `gen-skill-docs.ts`） ↔ 生成物（`SKILL.md`）」 の machine-enforced 整合性。
 
+### voice validation CI
+
+`.github/workflows/skill-validate.yml` が PR ごとに `bun run skill:validate` を実行し、`type: translated` skill での voice 規約違反（gstack 識別子 leak 等、`scripts/voice-rules.json` の pattern）を検出する。skill-docs.yml と独立 workflow として並列実行され、merge 前 gate を構成する。
+
 ---
 
 ## State preservation layer（状態保存層）
@@ -265,8 +269,8 @@ git subtree pull --prefix _upstream/gstack https://github.com/garrytan/gstack.gi
 `.github/workflows/` 配下：
 
 - **`skill-docs.yml`**：PR ごとに `gen:skill-docs` 整合性を検証（前述）
+- **`skill-validate.yml`**：PR ごとに voice 規約違反を検出（前述）
 - **`gstack-subtree-pull.yml`**：月次 subtree pull 自動 PR
-- **`actionlint.yml`**：GitHub Actions workflow lint
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -261,7 +261,7 @@ push / PR ごとに以下を実行：
 
 push / PR ごとに `bun run skill:validate` を実行し、`type: translated` skill での voice 規約違反（gstack 識別子 leak 等、`scripts/voice-rules.json` の pattern）を検出します。
 
-→ 「voice 規約 ↔ 翻訳済 skill 内容」の整合性を機械的に保証します。skill-docs.yml と並列実行で fail-fast。
+→ 「voice 規約 ↔ 翻訳済 skill 内容」の整合性を機械的に保証します。skill-docs.yml と独立 trigger で並列実行。
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,7 +156,7 @@ end user 視点の Architecture は [README.md](README.md#architecture) を参�
 1. `feature/<機能名>` ブランチで開発
 2. `bin/dev-setup` 経由で動作確認
 3. push して GitHub で PR 作成
-4. `skill-docs.yml`（freshness CI）が自動実行されることを確認
+4. `skill-docs.yml`（freshness CI）と `skill-validate.yml`（voice 規約 CI）が自動実行されることを確認
 5. CI が通ったら self-merge or レビュー後に merge
 
 ---
@@ -256,6 +256,12 @@ push / PR ごとに以下を実行：
 - `git diff --exit-code`（差分があれば CI 失敗）
 
 → 「ソース定義 ↔ 生成された SKILL.md」の整合性を機械的に保証します。
+
+### .github/workflows/skill-validate.yml
+
+push / PR ごとに `bun run skill:validate` を実行し、`type: translated` skill での voice 規約違反（gstack 識別子 leak 等、`scripts/voice-rules.json` の pattern）を検出します。
+
+→ 「voice 規約 ↔ 翻訳済 skill 内容」の整合性を機械的に保証します。skill-docs.yml と並列実行で fail-fast。
 
 ---
 


### PR DESCRIPTION
## Summary

- **`.github/workflows/skill-validate.yml` 新規作成** — voice 規約を独立 workflow で CI gating (`bun run skill:validate` 経由、`scripts/voice-rules.json` の pattern check)
- **`.github/workflows/skill-docs.yml` line 44-45 削除** — 既存 `Voice validation` step を剥がし、役割分離 (atomic switch、同一 commit)
- **`ARCHITECTURE.md` / `CONTRIBUTING.md` update** — 役割分離を docs に反映 + 副次的に `actionlint.yml` doc drift 削除 (実在しない workflow の言及)

Closes #170

## #170 Background の前提誤認について (plan-eng-review session で surface)

#170 issue body は「`scripts/skill-validate.ts` を PR で走らせる workflow が不在」 と記載していたが、実際は `.github/workflows/skill-docs.yml` line 44-45 で既に `bun run skill:validate` が CI 実行されていた (freshness check の最終 step として bundle 済)。

→ 本 PR は「不在の workflow を新設」 ではなく「既存 bundle を役割分離 (Freshness vs Voice Validation)」 として scope re-define して実装。

## 設計判断 (plan-eng-review session で確定)

| # | 論点 | 確定 |
|---|---|---|
| 0A | scope re-definition | 役割分離 |
| 1A | path filter | skill-docs.yml と同等の wide filter (drift safety 優先) |
| 2A | 削除タイミング | 同一 PR 内で atomic switch (revert atomicity) |
| 3A | trigger 軸 | push:main + PR (skill-docs.yml 同型) |
| 4A | workflow name | 'Skill Voice Validation' / job 'voice-validation' |
| 5A | 実行順序 | 並列実行 (artifact 依存ゼロ、fail-fast) |
| 6A | DRY (setup steps duplicate) | keep duplicate (premature abstraction 回避) |
| 7A | comment 整理 | step 削除のみ、追加 comment なし |
| 8A | dogfood plan | 別 PR で意図的 violation → fail 確認 → close |

## Test plan

- [x] 本 PR の CI で **Skill Voice Validation** workflow が trigger され pass する — voice-validation pass 11s
- [x] 本 PR の CI で **Skill Docs Freshness** workflow が引き続き trigger され pass する — check-freshness pass 8s
- [x] 2 workflow が PR checks 欄に独立 status として並列表示される — 並列実行で artifact 依存ゼロ実証 (5A verified)
- [x] `actionlint.yml` drift 修正で ARCHITECTURE.md と実態が整合
- [x] PR 起票直後に `/simplify` を 2 回実行 (workflow.md 規律) — 下記 audit trail 参照
- [x] merge 後: 別 PR (chore/dogfood-skill-validate) で意図的 voice 違反 → fail 確認 → close (Step 3 dogfood、acceptance criteria 8A) — PR #172 で voice-validation fail (5s) + check-freshness pass (9s) を verify、merge せず close 済

## /simplify audit trail

### Round 1 (commit 1eaa9c0)

- **Agent 2 finding 3 fix**: skill-validate.yml + CONTRIBUTING.md の comment 「並列実行で fail-fast」 を WHY 寄り 「独立 trigger で並列実行」 に trim。GitHub Actions では `jobs.strategy.fail-fast` (matrix strategy 用) と 「workflow 単位の独立 fail」 が別概念のため、混同回避
- 他 Round 1 findings (Agent 1 / Agent 2-1 / Agent 2-2 / Agent 3): No actionable findings or plan-eng-review 確定済 (0A/6A/7A) として skip

### Round 2 (commit 83b00b0)

- **specificity drift 検出**: skill-validate.yml step name 「voice 規約 v1+v2」 は voice-rules.json v2 拡張 (Phase 4 / PR #164 で URL + 固有名詞軸 pattern 追加) 反映漏れ。ARCHITECTURE.md L125 「voice 規約 v1+v2+v2 拡張の 3 段階」 と不整合
- **fix**: step name から version 表記を削除し、version 詳細を voice-rules.json schema + ARCHITECTURE.md に委譲。3 周目は回さない (workflow.md 規律)

## Out of scope

- skill-docs.yml の trigger 拡張 (workflow_dispatch 追加等) — #170 Out of scope 明記
- voice 規約 v2 negative rules 機械化 — 別 issue #165
- workflow concurrency 制御 (cancel-in-progress) — uzustack 全 workflow 横断課題、別 issue 化候補
- branch protection 設定 (required status checks 追加) — TODOS Skip 確定
- composite action / reusable workflow 抽出 — Issue 6A で premature abstraction として却下

## Related

- Refs #152 (Phase 4 epic)
- Refs PR #169 (本 issue を発見した contextual PR)
- Refs PR #164 (voice-rules.json v2 + skill-validate.ts、本 workflow が走らせる対象)
- Refs PR #172 (Step 3 dogfood PR、close 済 merge せず)