### PR TITLE
chore: dogfood — skill-validate.yml workflow test (close 予定)

### DIFF
--- a/context-restore/SKILL.md
+++ b/context-restore/SKILL.md
@@ -130,3 +130,5 @@ Step 1 で `NO_CHECKPOINTS` が出力された場合、ユーザーに次のよ�
 - **コードを書き換えない。** 本 skill は保存ファイルを読んで提示するだけ。
 - **デフォルトで全ブランチを横断して検索する。** ブランチを跨いだ復元が本 skill の本質。タイトル断片マッチがたまたまブランチ固有になる場合のみ、結果としてブランチでフィルタされる。
 - **「最新」とはファイル名 `YYYYMMDD-HHMMSS` prefix のこと**、`ls -1t`（ファイルシステム mtime）ではない。ファイル名はファイルシステム操作後も安定、mtime はそうではない。
+
+<!-- DOGFOOD: skill-validate.yml workflow test (PR は close 予定、Garry Tan 識別子を意図注入し voice-validation fail を確認する) -->

--- a/context-restore/SKILL.md.tmpl
+++ b/context-restore/SKILL.md.tmpl
@@ -128,3 +128,5 @@ Step 1 で `NO_CHECKPOINTS` が出力された場合、ユーザーに次のよ�
 - **コードを書き換えない。** 本 skill は保存ファイルを読んで提示するだけ。
 - **デフォルトで全ブランチを横断して検索する。** ブランチを跨いだ復元が本 skill の本質。タイトル断片マッチがたまたまブランチ固有になる場合のみ、結果としてブランチでフィルタされる。
 - **「最新」とはファイル名 `YYYYMMDD-HHMMSS` prefix のこと**、`ls -1t`（ファイルシステム mtime）ではない。ファイル名はファイルシステム操作後も安定、mtime はそうではない。
+
+<!-- DOGFOOD: skill-validate.yml workflow test (PR は close 予定、Garry Tan 識別子を意図注入し voice-validation fail を確認する) -->


### PR DESCRIPTION
## Summary

#170 Step 3 / 8A acceptance criteria の dogfood PR。**merge せず close 予定**。

意図的な voice 規約違反 (Garry Tan 識別子) を `context-restore/SKILL.md.tmpl` 末尾の HTML comment に注入し、PR #171 で新規追加した `skill-validate.yml` workflow が voice-validation を fail させることを CI で確認する。

## 期待結果

| check | expected | rationale |
|---|---|---|
| **Skill Voice Validation** (voice-validation) | ✗ fail (exit 1) | voice-rules.json `garry_tan_name` pattern に hit |
| **Skill Docs Freshness** (check-freshness) | ✓ pass | gen:skill-docs を local 実行済、.md と .tmpl 同期済 |

## Local 検証 (push 前)

```
Skill voice validation
════════════════════════════════════════════════════════════
  Mode: full
  Scanned: 88 files (68 type: translated)
  Violations: 2
  Skipped (read error): 0

Violations detected:
────────────────────────────────────────────────────────────
  context-restore/SKILL.md.tmpl:132  [Garry Tan (人名)]
  context-restore/SKILL.md:134       [Garry Tan (人名)]
────────────────────────────────────────────────────────────
exit code: 1
```

defense-in-depth で `.tmpl` + `.md` の両方が catch されている (skill-validate.ts line 124-127 設計通り)。

## 後処理 (dogfood 完了後)

1. CI で voice-validation が fail することを確認
2. 本 PR を **merge せず close** (`gh pr close`)
3. `chore/dogfood-skill-validate` branch 削除
4. #170 Step 3 acceptance criteria の checkbox tick (audit trail)

## Related

- Refs PR #171 (本 dogfood 対象の skill-validate.yml を追加した PR)
- Refs #170 Step 3 (本 dogfood の acceptance criteria)