### PR TITLE
docs: phase-history.md に Phase 3.6 + Phase 4 cluster section を追加 — v0.3.6.0 release milestone 正典化

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -281,6 +281,6 @@ git subtree pull --prefix _upstream/gstack https://github.com/garrytan/gstack.gi
 - [CLAUDE.md](CLAUDE.md) — Claude Code session 向け project context
 - [CHANGELOG.md](CHANGELOG.md) — release notes
 - [ETHOS.md](ETHOS.md) — 構築哲学・原則（Boil the Lake / Search Before Building / User Sovereignty / Build for Yourself）
-- [docs/uzustack/phase-history.md](docs/uzustack/phase-history.md) — Phase 0c〜3.5 進捗 + 主要 PR # 内訳
+- [docs/uzustack/phase-history.md](docs/uzustack/phase-history.md) — Phase 0c〜現在（Phase 4 進行中）進捗 + 主要 PR # 内訳
 - [docs/uzustack/translation-voice-guide.md](docs/uzustack/translation-voice-guide.md) — 翻訳 voice ガイド + 訳語表
 - [docs/uzustack/translation-rebase-fixes.md](docs/uzustack/translation-rebase-fixes.md) — rebase 時 uzustack 独自 fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,5 +99,7 @@ uzustack の **初回公開 release**。「型の取り込み」 完遂時点（
 - **Supabase 連携の検証未実施** — gbrain（クロスマシン記憶同期機構）の Supabase 連携 binary は配置済（`bin/uzustack-gbrain-supabase-provision` / `bin/uzustack-gbrain-supabase-verify`）だが、実機 Supabase 接続による検証は未完了。`bash -n` syntax check と `--help` 出力の確認のみ完了。Supabase アカウントを持つ user は gstack 側の動作確認 evidence を参照しながら使用すること
 - **Phase 6 予約スタブ 10 件は未検証** — subtree pull で取り込めるかの実機検証が Phase 6 で実施予定
 
+[0.3.6.0]: https://github.com/uzumaki-inc/uzustack/releases/tag/v0.3.6.0
+[0.3.5.2]: https://github.com/uzumaki-inc/uzustack/releases/tag/v0.3.5.2
 [0.3.5.1]: https://github.com/uzumaki-inc/uzustack/releases/tag/v0.3.5.1
 [0.3.5.0]: https://github.com/uzumaki-inc/uzustack/releases/tag/v0.3.5.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ skill 実行の中間成果物（checkpoint / timeline / 学習履歴）は `~/.
 
 ## 守破離 / Phase 進捗
 
-現在は **Phase 3.6（進行中）**。型の取り込みは Phase 3.5 で完了（2026-05-02）、守の完成は Phase 6 で達成予定。
+現在は **Phase 4 cluster（絆を結ぶ、進行中）**。Phase 3.6 で OSS 公開準備 + 守完走判定 reframe を完遂（v0.3.5.2 まで、2026-05-15）、型の取り込みは Phase 3.5 で完了（2026-05-02）、守の完成は Phase 6 で達成予定。Phase 4 cluster は v0.3.6.0 milestone（2026-05-18、PR #173）まで達成済、残作業は voice 規約 v2 negative rules 機械化（#165）+ hook 機構の発動経路検証（#166）+ Phase 4 epic（#152）auto-close。
 
 守破離の概念詳細は [README.md](README.md#守破離uzustack-の進化段階)、各 Phase の主要 PR # は [docs/uzustack/phase-history.md](docs/uzustack/phase-history.md) と [ARCHITECTURE.md](ARCHITECTURE.md) の Phase progression section を参照。
 
@@ -85,4 +85,4 @@ skill 実行の中間成果物（checkpoint / timeline / 学習履歴）は `~/.
 - [ETHOS.md](ETHOS.md) — uzustack の構築哲学・原則（Boil the Lake / Search Before Building / User Sovereignty / Build for Yourself）
 - [docs/uzustack/translation-voice-guide.md](docs/uzustack/translation-voice-guide.md) — 翻訳 voice ガイド + 訳語表
 - [docs/uzustack/translation-rebase-fixes.md](docs/uzustack/translation-rebase-fixes.md) — rebase 時に保持すべき uzustack 独自 fix
-- [docs/uzustack/phase-history.md](docs/uzustack/phase-history.md) — Phase 0c〜3.5 進捗 + 主要 PR # 内訳
+- [docs/uzustack/phase-history.md](docs/uzustack/phase-history.md) — Phase 0c〜現在（Phase 4 進行中）進捗 + 主要 PR # 内訳

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ uzustack は **uzustack プロジェクト全体** として、守破離の段�
 | **破**（Phase 6 完了後） | 個別スキルが Type 2 → Type 3 の進化を繰り返す |
 | **離** | gstack 由来（Type 1）が全て Type 3 化 or 削除された独立期 |
 
-**Phase 3 + Phase 3.5 で型の取り込み完了（2026-05-02）**: runtime（bin 約 50 個 + テンプレート機構 + voice 翻案ガイドライン v1/v2 + ETHOS.md）と動作する Type 1 実翻訳 26 skill + browse 機構必須 14 skill (翻訳済 stub) = 翻訳完了 40 skill が揃った。Phase 4（連鎖機構）/ Phase 5（記憶機構）に進む段階に到達、**守の完成は Phase 6 で達成**（browse 機構実装 + 14 skill の動作実装）。Phase 1〜3.5 の詳細は [docs/uzustack/phase-history.md](docs/uzustack/phase-history.md) を参照。
+**Phase 3 + Phase 3.5 で型の取り込み完了（2026-05-02）**: runtime（bin 約 50 個 + テンプレート機構 + voice 翻案ガイドライン v1/v2 + ETHOS.md）と動作する Type 1 実翻訳 26 skill + browse 機構必須 14 skill (翻訳済 stub) = 翻訳完了 40 skill が揃った。Phase 4（連鎖機構）/ Phase 5（記憶機構）に進む段階に到達、**守の完成は Phase 6 で達成**（browse 機構実装 + 14 skill の動作実装）。Phase 0c〜現在（Phase 4 進行中）の詳細は [docs/uzustack/phase-history.md](docs/uzustack/phase-history.md) を参照。
 
 ---
 
@@ -261,6 +261,6 @@ uzustack は [`garrytan/gstack`](https://github.com/garrytan/gstack)（MIT Licen
 - [CONTRIBUTING.md](CONTRIBUTING.md) ― 開発者・コントリビューター向けガイド
 - [ARCHITECTURE.md](ARCHITECTURE.md) ― 3 場所 layout / skill typology / Phase progression / runtime / state 層の設計詳細
 - [CHANGELOG.md](CHANGELOG.md) ― release notes（Keep a Changelog 形式）
-- [docs/uzustack/phase-history.md](docs/uzustack/phase-history.md) ― Phase 1〜3.5 の進捗履歴と主要 PR # 内訳
+- [docs/uzustack/phase-history.md](docs/uzustack/phase-history.md) ― Phase 0c〜現在（Phase 4 進行中）の進捗履歴と主要 PR # 内訳
 - [docs/uzustack/translation-voice-guide.md](docs/uzustack/translation-voice-guide.md) ― 翻訳 voice ガイド + 訳語表（メンテナー向け）
 - [docs/uzustack/translation-rebase-fixes.md](docs/uzustack/translation-rebase-fixes.md) ― rebase 時に保持すべき uzustack 独自 fix

--- a/docs/uzustack/phase-history.md
+++ b/docs/uzustack/phase-history.md
@@ -1,8 +1,8 @@
 # Phase 進捗履歴（uzustack）
 
-このドキュメントは uzustack の Phase 1〜3.5 までの進捗を追跡できる **単一の参照点** です。Contributor が過去の意思決定・主要 PR を辿れるよう、各 Phase の意図と完遂事項、主要 PR # を時系列で記録します。
+このドキュメントは uzustack の Phase 0c〜現在（Phase 4 進行中）までの進捗を追跡できる **単一の参照点** です。Contributor が過去の意思決定・主要 PR を辿れるよう、各 Phase の意図と完遂事項、主要 PR # を時系列で記録します。
 
-進行中・今後の Phase（4 / 5 / 6）は `CONTRIBUTING.md` の「Phase 進捗」 section を参照してください。
+今後の Phase（5 / 6）は `CONTRIBUTING.md` の「Phase 進捗」 section を参照してください。
 
 ---
 
@@ -75,9 +75,41 @@ Phase 3 で確立した翻訳機構を使って、残り 27 skill を一気に�
 
 ---
 
+## Phase 3.6 — OSS 公開準備 + 守完走判定 reframe（PR #122〜#151）
+
+uzustack の **初回 OSS 公開** と、それに伴う **守完走判定の再定義** + Phase 3 で空 stub のまま残っていた resolver の実装を行う段階。
+
+- **Root file 4 件 配置（公開の足回り）**：PR #122（README + CONTRIBUTING + docs/uzustack 整理、Phase 4 着手準備）/ PR #124（VERSION + CHANGELOG + CLAUDE + ARCHITECTURE 配置、step-80 / Issue #123）/ PR #126（`docs/ja` を `docs/upstream/gstack/ja` にリネーム、複数 upstream 対応への命名整理）
+- **/learn skill 翻訳化**：PR #127（step-82、Approach A 実装、Type 1 翻訳 26 件目）
+- **守完走判定 reframe**：PR #140（browse 機構必須 14 skill を Phase 6 で実装検討 stub として正式に明文化、守完走 base を「Phase 6 予約スタブ 10 件 → 30 skill」 に再定義）→ v0.3.5.1 release
+- **broken bin reference fix**：PR #147（plan-\* skill の broken bin 参照を `uzustack-slug` 直呼びに切替、issue #137 / step-97）/ PR #149（`greptile-triage` の broken bin 参照を `uzustack-slug` 直呼びに切替、issue #148 / step-98）
+- **learnings resolver port**：PR #151（Phase 3 で空 stub だった `scripts/resolvers/learnings.ts` を upstream gstack から port、`{{LEARNINGS_SEARCH}}` / `{{LEARNINGS_LOG}}` placeholder が空展開から実体に変わり 13 skill で過去学習検索・記録の指示文が展開、Closes #150）→ v0.3.5.2 release
+- **周辺整備 + sanitize 規律**：PR #129（`bin/dev-setup` に slug-cache redirect 追加、step-84 サブタスク 8 = 4 GAP bin pilot）/ PR #131（`~/.gstack` pollution fix、`_upstream` symlink 経路 + hardcode bin redirect 拡張）/ PR #133（`_upstream/gstack/` 内 setup 実行禁止規律を 3 docs に明記）/ PR #142（misc updates）/ PR #143 / PR #144（extend `review.md`）/ PR #146（OSS 公開時 sanitize 規律を `CLAUDE.md` に追加）
+
+このフェーズで **初回 OSS 公開（v0.3.5.0）** + **守完走判定の対象を browse 機構必須 14 skill / 動作する 30 skill base に reframe（v0.3.5.1）** + **learnings resolver の空 stub 解消（v0.3.5.2）** が完成し、Phase 4 cluster（contributor 受け入れ準備）の着手条件が揃った。
+
+---
+
+## Phase 4 cluster — 絆を結ぶ（PR #128〜進行中）
+
+**contributor 受け入れ準備の足腰** を固める段階。voice 規約の機械チェック基盤 + 並走発火源 skill の翻訳化 + CI gating の役割分離を中心に進行。**v0.3.6.0 release（PR #173）を進行中 milestone として 9 PR を bundle**。
+
+- **voice 規約 機械チェック基盤**：PR #128（skill voice 規約 v1 機械チェック、Tier 1+2 達成、step-83 = `skill:validate` コマンドの起点）
+- **freeze + unfreeze + guard 翻訳化**（cluster の並走発火源 3 skill）：PR #153（`freeze` + `unfreeze` pair）/ PR #154（`guard` = `careful` + `freeze` combo）
+- **Voice 規約 CI gating 確立**：PR #160（`skill:validate` を 30 翻訳済 skill に横展開 + `CONTRIBUTING.md` skill 数 doc 同期、Closes #159）/ PR #162（`scripts/skill-validate.ts` 改善 6 項目：frontmatter 共通 utility 抽出 / voice-rules.json への config 化 / Promise.all 並列化 / regex merge / diff-based fast mode（`--diff` flag）/ error handling 強化、Closes #161）/ PR #164（`voice-rules.json` v2 拡張：URL pattern + 固有名詞軸 pattern を追加）/ PR #171（`.github/workflows/skill-validate.yml` 新規追加 + `skill-docs.yml` から voice validation step 剥がし、freshness check と voice validation の役割分離、Closes #170）
+- **translation-voice-guide.md 構造再編**：PR #169（読者目的別 3 章構成 = translator / メンテナー / validator + Appendix A audit trail 化）
+- **周辺修正**：PR #156（`bunfig.toml` に `pathIgnorePatterns = ["**/_upstream/**"]` を追加、`bun test` が `_upstream/gstack/setup` を spawn して symlink を上書きする経路を block、Closes #155）/ PR #158（gstack 専用 dir 削除規律を「翻訳済のため不要」 と明確化、step-84-1 PR-C）
+- **release v0.3.6.0 bundle**：PR #173（9 PR を Phase 4 cluster 進行中の milestone として minor bump で bundle、VERSION + CHANGELOG drift 解消）
+
+このフェーズで **Voice 規約 CI gating（`skill:validate` の PR-trigger 自動実行 + 役割分離 workflow）** + **freeze / unfreeze / guard の発火経路整備** + **voice-guide の reader-task 別構造化** が確立し、contributor の merge 前に gstack 識別子 leak を機械的に catch できる足腰が完成した。
+
+**Phase 4 cluster 残**：**voice 規約 v2 negative rules 機械化（#165）** + **hook 機構の発動経路検証（#166）** + 子 issue 全 close 後の **Phase 4 epic（#152）auto-close**。
+
+---
+
 ## 用語
 
-- **Phase 6 予約スタブ**：subtree pull で取り込めるか実機検証が必要な skill（`browse` / `qa` / `qa-only` / `canary` / `setup-browser-cookies` / `open-uzustack-browser` / `connect-chrome` / `make-pdf` / `pair-agent` / `benchmark` の 10 件）。Phase 6 で Type 1 / Type 3 を判定する
+- **Phase 6 予約スタブ**：当初は subtree pull で取り込めるか実機検証が必要な skill 10 件（`browse` / `qa` / `qa-only` / `canary` / `setup-browser-cookies` / `open-uzustack-browser` / `connect-chrome` / `make-pdf` / `pair-agent` / `benchmark`）として定義。Phase 3.6（PR #140）で **browse 機構必須 14 skill** に reframe（上記 10 件 + `design-review` / `design-consultation` / `devex-review` / `land-and-deploy`）
 - **Type 1**：gstack を翻訳・検証したスキル（`type: translated`）
 - **Type 3**：Type 2（個人運用）から属人性を抜いた汎用版（`type: native`）
-- **守の完成**：Phase 6 で予約スタブ 10 件の Type 1/3 判定が完了した時点で達成
+- **守の完成**：当初は「Phase 6 予約スタブ 10 件の Type 1/3 判定完了」 と定義。Phase 3.6（PR #140）で **browse 機構必須 14 skill の動作実装完了** に reframe、Phase 6 で達成予定

--- a/docs/uzustack/phase-history.md
+++ b/docs/uzustack/phase-history.md
@@ -77,14 +77,14 @@ Phase 3 で確立した翻訳機構を使って、残り 27 skill を一気に�
 
 ## Phase 3.6 — OSS 公開準備 + 守完走判定 reframe（PR #122〜#151）
 
-uzustack の **初回 OSS 公開** と、それに伴う **守完走判定の再定義** + Phase 3 で空 stub のまま残っていた resolver の実装を行う段階。
+uzustack の **初回 OSS 公開** と、それに伴う **守完走判定の再定義** + **Phase 3 で空 stub のまま残っていた resolver の実装** を行う段階。
 
-- **Root file 4 件 配置（公開の足回り）**：PR #122（README + CONTRIBUTING + docs/uzustack 整理、Phase 4 着手準備）/ PR #124（VERSION + CHANGELOG + CLAUDE + ARCHITECTURE 配置、step-80 / Issue #123）/ PR #126（`docs/ja` を `docs/upstream/gstack/ja` にリネーム、複数 upstream 対応への命名整理）
+- **Root file 4 件 配置（公開の足回り）**：PR #122（README + CONTRIBUTING + docs/uzustack 整理、Phase 4 着手準備）/ PR #124（VERSION + CHANGELOG + CLAUDE + ARCHITECTURE 配置、step-80 / issue #123）/ PR #126（`docs/ja` を `docs/upstream/gstack/ja` にリネーム、複数 upstream 対応への命名整理）
 - **/learn skill 翻訳化**：PR #127（step-82、Approach A 実装、Type 1 翻訳 26 件目）
-- **守完走判定 reframe**：PR #140（browse 機構必須 14 skill を Phase 6 で実装検討 stub として正式に明文化、守完走 base を「Phase 6 予約スタブ 10 件 → 30 skill」 に再定義）→ v0.3.5.1 release
-- **broken bin reference fix**：PR #147（plan-\* skill の broken bin 参照を `uzustack-slug` 直呼びに切替、issue #137 / step-97）/ PR #149（`greptile-triage` の broken bin 参照を `uzustack-slug` 直呼びに切替、issue #148 / step-98）
-- **learnings resolver port**：PR #151（Phase 3 で空 stub だった `scripts/resolvers/learnings.ts` を upstream gstack から port、`{{LEARNINGS_SEARCH}}` / `{{LEARNINGS_LOG}}` placeholder が空展開から実体に変わり 13 skill で過去学習検索・記録の指示文が展開、Closes #150）→ v0.3.5.2 release
-- **周辺整備 + sanitize 規律**：PR #129（`bin/dev-setup` に slug-cache redirect 追加、step-84 サブタスク 8 = 4 GAP bin pilot）/ PR #131（`~/.gstack` pollution fix、`_upstream` symlink 経路 + hardcode bin redirect 拡張）/ PR #133（`_upstream/gstack/` 内 setup 実行禁止規律を 3 docs に明記）/ PR #142（misc updates）/ PR #143 / PR #144（extend `review.md`）/ PR #146（OSS 公開時 sanitize 規律を `CLAUDE.md` に追加）
+- **守完走判定 reframe**：PR #140（browse 機構必須 14 skill を Phase 6 で実装検討 stub として正式に明文化、守完走 base を「Phase 6 予約スタブ 10 件 → 30 skill」 に再定義）
+- **broken bin reference fix**：PR #147（`plan-*` skill、issue #137 / step-97）/ PR #149（`greptile-triage`、issue #148 / step-98）の broken bin 参照を `uzustack-slug` 直呼びに切替
+- **learnings resolver port**：PR #151（Phase 3 で空 stub だった `scripts/resolvers/learnings.ts` を upstream gstack から port、`{{LEARNINGS_SEARCH}}` / `{{LEARNINGS_LOG}}` placeholder が空展開から実体に変わり 13 skill で過去学習検索・記録の指示文が展開、Closes #150）
+- **周辺整備 + sanitize 規律**：PR #129（`bin/dev-setup` に slug-cache redirect 追加、step-84 サブタスク 8 = 4 GAP bin pilot）/ PR #131（`~/.gstack` pollution fix、`_upstream` symlink 経路 + hardcode bin redirect 拡張）/ PR #133（`_upstream/gstack/` 内 setup 実行禁止規律を 3 docs に明記）/ PR #142（`.claude/rules/` への規律 segregate + `.gitignore` + `docs/uzustack/placeholder-convention.md` 追加 + `translation-rebase-fixes.md` 拡張）/ PR #146（OSS 公開時 sanitize 規律を `CLAUDE.md` に追加）
 
 このフェーズで **初回 OSS 公開（v0.3.5.0）** + **守完走判定の対象を browse 機構必須 14 skill / 動作する 30 skill base に reframe（v0.3.5.1）** + **learnings resolver の空 stub 解消（v0.3.5.2）** が完成し、Phase 4 cluster（contributor 受け入れ準備）の着手条件が揃った。
 
@@ -92,7 +92,7 @@ uzustack の **初回 OSS 公開** と、それに伴う **守完走判定の再
 
 ## Phase 4 cluster — 絆を結ぶ（PR #128〜進行中）
 
-**contributor 受け入れ準備の足腰** を固める段階。voice 規約の機械チェック基盤 + 並走発火源 skill の翻訳化 + CI gating の役割分離を中心に進行。**v0.3.6.0 release（PR #173）を進行中 milestone として 9 PR を bundle**。
+**contributor 受け入れ準備の足腰** を固める段階。voice 規約の機械チェック基盤 + 並走発火源 skill の翻訳化 + CI gating の役割分離を中心に進行。**v0.3.6.0 release（PR #173）** を進行中 milestone として 9 PR を bundle。
 
 - **voice 規約 機械チェック基盤**：PR #128（skill voice 規約 v1 機械チェック、Tier 1+2 達成、step-83 = `skill:validate` コマンドの起点）
 - **freeze + unfreeze + guard 翻訳化**（cluster の並走発火源 3 skill）：PR #153（`freeze` + `unfreeze` pair）/ PR #154（`guard` = `careful` + `freeze` combo）
@@ -101,9 +101,7 @@ uzustack の **初回 OSS 公開** と、それに伴う **守完走判定の再
 - **周辺修正**：PR #156（`bunfig.toml` に `pathIgnorePatterns = ["**/_upstream/**"]` を追加、`bun test` が `_upstream/gstack/setup` を spawn して symlink を上書きする経路を block、Closes #155）/ PR #158（gstack 専用 dir 削除規律を「翻訳済のため不要」 と明確化、step-84-1 PR-C）
 - **release v0.3.6.0 bundle**：PR #173（9 PR を Phase 4 cluster 進行中の milestone として minor bump で bundle、VERSION + CHANGELOG drift 解消）
 
-このフェーズで **Voice 規約 CI gating（`skill:validate` の PR-trigger 自動実行 + 役割分離 workflow）** + **freeze / unfreeze / guard の発火経路整備** + **voice-guide の reader-task 別構造化** が確立し、contributor の merge 前に gstack 識別子 leak を機械的に catch できる足腰が完成した。
-
-**Phase 4 cluster 残**：**voice 規約 v2 negative rules 機械化（#165）** + **hook 機構の発動経路検証（#166）** + 子 issue 全 close 後の **Phase 4 epic（#152）auto-close**。
+このフェーズで **Voice 規約 CI gating**（`skill:validate` の PR-trigger 自動実行 + 役割分離 workflow）+ **freeze / unfreeze / guard の発火経路整備** + **voice-guide の 3 章構成化**（translator / メンテナー / validator 別）が確立し、contributor の merge 前に gstack 識別子 leak を機械的に catch できる足腰が v0.3.6.0 milestone までに完成した。残作業（#165 voice 規約 v2 negative rules 機械化 / #166 hook 機構の発動経路検証 / 子 issue 全 close 後の Phase 4 epic #152 auto-close）は `CONTRIBUTING.md` の「Phase 進捗」 section を参照。
 
 ---
 

--- a/docs/uzustack/phase6-pending-skills.md
+++ b/docs/uzustack/phase6-pending-skills.md
@@ -68,6 +68,6 @@ uzustack の守期間の前半 (Phase 0c〜3.5 = 型の取り込み完了) で�
 
 - [phase6-warning-block.md](phase6-warning-block.md) — 共通 warning block の source of truth + 配置規律
 - [translation-voice-guide.md](translation-voice-guide.md) — voice 翻案の射程 (browse 機構関連用語の取扱)
-- [phase-history.md](phase-history.md) — Phase 0c〜3.5 進捗 + 主要 PR # 内訳
+- [phase-history.md](phase-history.md) — Phase 0c〜現在（Phase 4 進行中）進捗 + 主要 PR # 内訳
 - 上位 doc: `ARCHITECTURE.md` の「(1) browser 機構 と (2) ワークフロー skill の依存関係」 + 「守破離における Phase 6 の位置付け」 section
 - 関連 issue: #134 (placeholder engine 空 stub 解決) / #135 (learn skill 機能性検証) / #138 (本作業のメイン issue)


### PR DESCRIPTION
## Summary

post-release 残作業 (前 session checkpoint で持ち越し) として、`docs/uzustack/phase-history.md` の scope を「Phase 1〜3.5 のみ」 から「Phase 0c〜現在 (Phase 4 進行中)」 に拡張し、**Phase 3.6** (OSS 公開準備 + 守完走判定 reframe) と **Phase 4 cluster** (絆を結ぶ、進行中) の 2 section を追加します。

- **Phase 3.6 section 新設** (PR #122〜#151)：root file 4 件配置 (v0.3.5.0) / 守完走判定 reframe (v0.3.5.1、PR #140 で base を 10 件 → 14 skill に再定義) / learnings resolver port (v0.3.5.2、PR #151) / broken bin reference fix / 周辺整備 + sanitize 規律
- **Phase 4 cluster section 新設** (PR #128〜進行中)：voice 規約 機械チェック基盤 (#128) / freeze + unfreeze + guard 翻訳化 (#153-#154) / Voice 規約 CI gating 確立 (#160-#171) / translation-voice-guide.md 構造再編 (#169) / 周辺修正 / **v0.3.6.0 release bundle (#173) を進行中 milestone として正典化**
- **intro + 用語 section 更新**：scope 拡張、進行中 Phase の CONTRIBUTING.md 委譲を「Phase 5 / 6」 に絞る、「Phase 6 予約スタブ」 + 「守の完成」 定義に Phase 3.6 reframe 反映

## Background

v0.3.6.0 release (PR #173、`bd01b0b`) で 9 PR (#153-#171) を Phase 4 cluster 進行中の milestone として bundle したが、phase-history.md は Phase 3.5 完遂 (PR #120) で止まっていた。CHANGELOG の release entry より詳細な per-PR scope / 設計判断 / audit trail を Phase 履歴として正典化する。

前 session の checkpoint で post-release 残作業の 1 件目として持ち越し。

## Scope (拡張済)

当初は `docs/uzustack/phase-history.md` 単一 file 想定だったが、/simplify Round 1 (Agent 3) で **cross-file stale reference** が 5 件 + **CHANGELOG.md footer link refs 漏れ** が 1 件検出されたため、post-release docs sync の scope として 6 files に sweep を拡張：

- `docs/uzustack/phase-history.md` — Phase 3.6 + Phase 4 cluster section 新設 + 用語 section update
- `CLAUDE.md` — 「現在は Phase 4 cluster」 framing + Related docs pointer 拡張
- `README.md` — 「Phase 1〜3.5 の詳細」 + Related Documentation pointer 拡張
- `ARCHITECTURE.md` — Related docs pointer 拡張
- `docs/uzustack/phase6-pending-skills.md` — 関連 doc pointer 拡張
- `CHANGELOG.md` — `[0.3.6.0]:` + `[0.3.5.2]:` footer link reference 補完

## Out of scope

- **/ship trigger 規律化** — post-release 残作業 2 件目。別 issue / 別 PR で扱う
- **Phase 4 cluster 残 (#165 / #166 / #152)** — 進行中の作業。完了時に本 file に追加 entry / closing 文修正

## /simplify Round 1 audit trail (本 PR の 2 commit 目で適用済)

trivial fix exception で Round 1 のみ実行 (Agent 1 = code reuse、Agent 2 = code quality、Agent 3 = cross-file consistency)。Round 2 は skip。検出 findings 11 件 + cross-file findings 6 件 = 計 17 件を即時適用：

phase-history.md fix (Agent 1 + 2):
1. Phase 3.6 intro 3-item parallelism: 3 項目目 (resolver の実装) も bold 化で揃え
2. `Issue #123` → `issue #123` (capitalization 統一)
3. `plan-\*` markdown escape leak → `` `plan-*` `` (backtick で wildcard を保護)
4. PR #147 + #149 「broken bin 参照を切替」 重複表現を 1 文に集約
5. inline `→ vX release` tag (PR #140 / #151) を削除 (closing 文の release 集約と重複)
6. PR #142 を `.claude/rules/ 規律 segregate + .gitignore + placeholder-convention.md / translation-rebase-fixes.md 拡張` と concrete 化、PR #143 / #144 は project-scoped rule extension で contributor-facing 価値が薄いため bullet から削除
7. Phase 4 cluster intro: 長い 1 文 bold を `**v0.3.6.0 release（PR #173）**` まで縮め
8. Phase 4 cluster closing: 3 連続 bold を de-emphasize + 残課題 separate line を closing 内に統合 + `voice-guide の reader-task 別構造化` を `voice-guide の 3 章構成化（translator / メンテナー / validator 別）` で specificity 確保

cross-file sweep (Agent 3 findings 1 + 2 + 6):
9. CLAUDE.md line 75: `現在は Phase 3.6（進行中）` → Phase 4 cluster framing (v0.3.6.0 milestone + 残作業明示) に update
10. CLAUDE.md line 88 / README.md line 264 / ARCHITECTURE.md line 284 / phase6-pending-skills.md line 71: Related docs pointer description を `Phase 0c〜3.5` / `Phase 1〜3.5` → `Phase 0c〜現在（Phase 4 進行中）` に統一拡張
11. README.md line 225: 本文中 「Phase 1〜3.5 の詳細」 も同様に拡張
12. CHANGELOG.md footer: `[0.3.6.0]:` + `[0.3.5.2]:` link reference 補完 (前回 release PR #173 で漏れた sweep)

skip した findings:
- Agent 1 finding 5 (Phase 4 cluster の PR #128〜進行中 range が非連続) — 既存 closing 文に 4 cluster の意味は伝わるので footnote 不要 (低優先 finding)
- Agent 1 finding 1 (CHANGELOG ↔ phase-history.md 内容重複) — CHANGELOG line 5 で「per-PR 詳細は phase-history.md に委譲」 と委譲方針が明示済、設計通りの abstraction 層分離

## Test plan

- [x] markdown render を GitHub PR diff view で確認 (新規 section の見出し階層 / bullet ネスト / 引用符)
- [x] `_upstream/gstack/` 配下に同 pattern が存在しないことを確認 (uzustack 独自 docs)
- [x] PR # 引用が gh pr list (#122〜#173) と一致することを確認 (Agent 3 cross-check で spot-check 15 件 PASS)
- [x] /simplify を 1 周実行 (1 file 想定が 6 files に sweep 拡張のため Round 2 候補だが、Round 1 で content drift / cross-file stale ともに sweep 済、Round 2 で追加 finding 見込みが薄いため trivial fix exception 適用)
- [x] /simplify findings 17 件を即時適用 + PR body audit trail 記載
- [ ] merge 前に上記 checkbox を tick (本 PR body update 時に完了)

🤖 Generated with [Claude Code](https://claude.com/claude-code)