### PR TITLE
docs: voice 規約 v2 negative rules (axis 1/2/3) を機械化対象外と判定 — Closes #165

### DIFF
--- a/docs/uzustack/translation-voice-guide.md
+++ b/docs/uzustack/translation-voice-guide.md
@@ -289,13 +289,13 @@ CONTRIBUTING.md「Phase 6 待ち skill 翻訳時の warning 配置必須」 sect
 |---|---|---|---|
 | 文字列軸 | path / env / bin 名 / URL 等 | [1.1 機械置換 / 文字列軸](#文字列軸パスbin-名url-等) | 機械化済（positive rules、5 patterns） |
 | 固有名詞軸 | Garry Tan 等 | [1.1 機械置換 / 固有名詞軸](#固有名詞軸) | 機械化済（positive rules、1 pattern） |
-| axis 1（負） | 全角括弧 `（` `）` の voice 規約違反検出 | [1.3 翻案 / bash + 副言語 embedded layer](#bash--副言語-embedded-layer) | 機械化対象外（bash code block + string literal 検出に state machine 必須、実装コスト不釣り合い、#165） |
-| axis 2（負） | persona attribution / Mode 名表記の維持 | [1.3 翻案](#13-翻案) + [1.2 英語維持](#12-英語維持)（Mode 名 / 経営者思考特性 / persona attribution） | 機械化対象外（30+ identifier の near-miss 検出に file-level state + table drift 管理が必要、line-based validator 設計と質的乖離、#165） |
-| axis 3（負） | 外部 LLM prompt 英語維持 | [1.2 英語維持 / 外部 LLM 向け prompt 本体](#外部-llm-向け-prompt-本体) | 機械化対象外（bash 内 codex exec の入れ子 string literal 構造、codex 将来日本語対応で規律 re-evaluation 可能性、#165） |
+| axis 1（負） | 全角括弧 `（` `）` の voice 規約違反検出 | [1.3 翻案 / bash + 副言語 embedded layer](#bash--副言語-embedded-layer) | 機械化対象外（bash code block + string literal 検出に state machine 必須、実装コスト不釣り合い） |
+| axis 2（負） | persona attribution / Mode 名表記の維持 | [1.3 翻案](#13-翻案) + [1.2 英語維持](#12-英語維持)（Mode 名 / 経営者思考特性 / persona attribution） | 機械化対象外（30+ identifier の near-miss 検出に file-level state + table drift 管理が必要、line-based validator 設計と質的乖離） |
+| axis 3（負） | 外部 LLM prompt 英語維持 | [1.2 英語維持 / 外部 LLM 向け prompt 本体](#外部-llm-向け-prompt-本体) | 機械化対象外（bash 内 codex exec の入れ子 string literal 構造、規律自体が外部 product の言語 contract に依存） |
 
 ### 3.2 voice-rules.json schema との cross-ref
 
-`scripts/voice-rules.json` の `patterns` array が validator 側の source of truth。`scripts/skill-validate.ts` が読み込み、`type: translated` な skill file 内の gstack 由来の生 string を検出する。全 pattern は [1.1 機械置換](#11-機械置換gstack--uzustack) の各軸に対応する（negative rules = axis 1/2/3 は #165 で計画中、3.1 参照）：
+`scripts/voice-rules.json` の `patterns` array が validator 側の source of truth。`scripts/skill-validate.ts` が読み込み、`type: translated` な skill file 内の gstack 由来の生 string を検出する。全 pattern は [1.1 機械置換](#11-機械置換gstack--uzustack) の各軸に対応する（negative rules = axis 1/2/3 は機械化対象外、[3.1](#31-機械化対象索引) 参照）：
 
 | voice-rules.json pattern id | 検出対象 | 1.1 内軸 |
 |---|---|---|
@@ -306,7 +306,7 @@ CONTRIBUTING.md「Phase 6 待ち skill 翻訳時の warning 配置必須」 sect
 | `gstack_repo_url` | `github.com/garrytan/gstack` | 文字列軸 |
 | `garry_tan_name` | `Garry Tan` (人名) | 固有名詞軸 |
 
-新 pattern を追加する時は `scripts/voice-rules.json` の `patterns` array に entry を追記する（schema は `version` + `description` + `patterns[]` で forward compatible）。axis 1/2/3 は #165 で機械化対象外確定（理由は §3.1 各 row 併記 + §A.3 末尾の audit trail）、将来 Phase 5 #166 hook 機構と一体で再 design 候補。
+新 pattern を追加する時は `scripts/voice-rules.json` の `patterns` array に entry を追記する（schema は `version` + `description` + `patterns[]` で forward compatible）。axis 1/2/3 は機械化対象外確定（経緯は [§A.3](#a3-v2-拡張phase-4-機械化) 参照）。
 
 ---
 
@@ -322,15 +322,15 @@ Phase 3.5 進行（plan / strategy / cli tuning / design / orchestration 系 ski
 
 ### A.3 v2 拡張（Phase 4 機械化）
 
-Phase 4 で voice-rules.json による機械化を開始。PR #164（commit `8d09561`）で `scripts/voice-rules.json` v2 を導入、positive rules 6 patterns（URL + 固有名詞軸を含む）を機械化。`scripts/skill-validate.ts` が読み込み、translated skill での gstack 識別子 leak を CI で検出。#165 で negative rules（axis 1/2/3 = 全角括弧 / persona attribution / external LLM prompt 英語維持）の機械化を検討、plan-eng-review session（本 PR）で 3 軸全て機械化対象外と判定。
+Phase 4 で voice-rules.json による機械化を開始。PR #164（commit `8d09561`）で `scripts/voice-rules.json` v2 を導入、positive rules 6 patterns（URL + 固有名詞軸を含む）を機械化。`scripts/skill-validate.ts` が読み込み、translated skill での gstack 識別子 leak を CI で検出。#165 で negative rules（axis 1/2/3 = 全角括弧 / persona attribution / external LLM prompt 英語維持）の機械化を検討、PR #175 の plan-eng-review session で 3 軸全て機械化対象外と判定。
 
 判定の根拠（軸別）：
 
-- **axis 1（全角括弧）**：machine 化対象を正確に区別するには bash code block の境界検出に加え bash 内 string literal（subagent prompt / heredoc 等の multi-line 引数）検出が必要、state machine 実装が axis 3 と同コスト。fact check で translated skill の bash code block 内に全角括弧 34 instances / 10 files が既存、すべて bash comment 行（`# ...（注記）`）で日本語 punctuation として運用、voice 規約 v1 #7（bash 括弧は半角維持）と実態 drift。machine 化 attempt は voice 規約 v1 #7 改定（Phase 3 確立済規律の re-evaluation）か state machine 実装の二択になり、現時点で機械化対象外。
+- **axis 1（全角括弧）**：machine 化対象を正確に区別するには bash code block の境界検出に加え bash 内 string literal（subagent prompt / heredoc 等の multi-line 引数）検出が必要、state machine 実装が axis 3 と同コスト。fact check（plan-eng-review session の grep 検証）で translated skill の bash code block 内に全角括弧 34 instances / 10 files が既存（観測）、すべて bash comment 行（`# ...（注記）`）で日本語 punctuation として運用、voice 規約 v1 #7（[§A.1](#a1-v1phase-3-bin-翻訳バッチ) enumeration 7 番目「半角括弧」、bash 括弧は半角維持）と実態 drift。machine 化 attempt は voice 規約 v1 #7 改定（Phase 3 確立済規律の re-evaluation）か state machine 実装の二択になり、現時点で機械化対象外。
 - **axis 2（persona attribution / Mode 名）**：Mode 名 4 + 経営者思考特性 18 + persona attribution 10+ の 30+ identifier の near-miss 検出に file-level state（同 file 内で初出併記済か）+ identifier table drift 管理が必要、line-based 1-pass scan の validator 責務と質的乖離。docs §1.3 が source of truth として運用、翻訳作業時の reviewer 軸で覆う。
-- **axis 3（外部 LLM prompt 英語維持）**：bash 内 `codex exec "..."` の複数行引数として書かれた入れ子 string literal 構造（autoplan/SKILL.md.tmpl L253-261 / L359-373 / L437-446 / L552-566 等）で、region 検出に bash + string literal の二段 state machine が必須。codex / openai-cli / gemini-cli が将来日本語対応した場合に規律ごと見直しになる可能性があり、現時点で機械化必要性が低い。
+- **axis 3（外部 LLM prompt 英語維持）**：bash 内 `codex exec "..."` の複数行引数として書かれた入れ子 string literal 構造（autoplan/SKILL.md.tmpl L253-261 / L359-373 / L437-446 / L552-566 等）で、region 検出に bash + string literal の二段 state machine が必須。規律自体が外部 product の言語 contract に依存する（codex / openai-cli / gemini-cli の input 言語 contract が変われば規律も連動）ため、現時点で機械化対象外。
 
-Phase 5 #166 hook 機構の発動経路検証と一体で 3 軸の機械化を再 design する候補（PR merge 経路で hook が enforce する path を整備する文脈で、region 検出機構と統合）。
+#166 hook 機構の発動経路検証と一体で 3 軸の機械化を再 design する選択肢を残す（PR merge 経路で hook が enforce する path を整備する文脈で、region 検出機構と統合）。
 
 ---
 

--- a/docs/uzustack/translation-voice-guide.md
+++ b/docs/uzustack/translation-voice-guide.md
@@ -105,11 +105,10 @@ design / UI / UX 領域の固有用語と persona attribution は英語維持。
 
 #### 外部 LLM 向け prompt 本体
 
-外部 LLM（codex / openai / gemini 等）に投入する prompt 本体は英語維持。LLM 訓練語の効果を保つ。
+外部 LLM（codex / openai / gemini 等）に投入する prompt 本体は英語維持。判断軸：外部 product への入力は外部 product の言語 contract に従う。Claude Code は uzustack の言語方針（日本語化）を適用するため対象外。
 
 - **英語維持対象**：codex / openai-cli / gemini-cli 等への prompt 本体、system prompt、user prompt
 - **uzustack 化対象**：boundary path（`paths containing skills/uzustack`）等の path 識別子のみ
-- **判断軸**：外部 product への入力は外部 product の言語 contract に従う
 
 #### subtree path（`_upstream/gstack/`）
 
@@ -284,15 +283,15 @@ CONTRIBUTING.md「Phase 6 待ち skill 翻訳時の warning 配置必須」 sect
 
 ### 3.1 機械化対象索引
 
-`scripts/voice-rules.json` で機械化される pattern と、本ガイドの section との対応表。axis 1/2/3 は #165 で機械化計画中の負の規約軸。
+`scripts/voice-rules.json` で機械化される pattern と、本ガイドの section との対応表。axis 1/2/3 は #165 plan-eng-review で機械化対象外と判定された負の規約軸（rationale は各 row 併記、詳細は [§A.3](#a3-v2-拡張phase-4-機械化)）。
 
 | axis | 内容 | 本ガイド section | 機械化状態 |
 |---|---|---|---|
 | 文字列軸 | path / env / bin 名 / URL 等 | [1.1 機械置換 / 文字列軸](#文字列軸パスbin-名url-等) | 機械化済（positive rules、5 patterns） |
 | 固有名詞軸 | Garry Tan 等 | [1.1 機械置換 / 固有名詞軸](#固有名詞軸) | 機械化済（positive rules、1 pattern） |
-| axis 1（負） | 全角括弧 `（` `）` の voice 規約違反検出 | [1.3 翻案 / bash + 副言語 embedded layer](#bash--副言語-embedded-layer) | #165 で計画中 |
-| axis 2（負） | persona attribution / Mode 名表記の維持 | [1.3 翻案](#13-翻案) + [1.2 英語維持](#12-英語維持)（Mode 名 / 経営者思考特性 / persona attribution） | #165 で計画中 |
-| axis 3（負） | 外部 LLM prompt 英語維持 | [1.2 英語維持 / 外部 LLM 向け prompt 本体](#外部-llm-向け-prompt-本体) | #165 で計画中 |
+| axis 1（負） | 全角括弧 `（` `）` の voice 規約違反検出 | [1.3 翻案 / bash + 副言語 embedded layer](#bash--副言語-embedded-layer) | 機械化対象外（bash code block + string literal 検出に state machine 必須、実装コスト不釣り合い、#165） |
+| axis 2（負） | persona attribution / Mode 名表記の維持 | [1.3 翻案](#13-翻案) + [1.2 英語維持](#12-英語維持)（Mode 名 / 経営者思考特性 / persona attribution） | 機械化対象外（30+ identifier の near-miss 検出に file-level state + table drift 管理が必要、line-based validator 設計と質的乖離、#165） |
+| axis 3（負） | 外部 LLM prompt 英語維持 | [1.2 英語維持 / 外部 LLM 向け prompt 本体](#外部-llm-向け-prompt-本体) | 機械化対象外（bash 内 codex exec の入れ子 string literal 構造、codex 将来日本語対応で規律 re-evaluation 可能性、#165） |
 
 ### 3.2 voice-rules.json schema との cross-ref
 
@@ -307,7 +306,7 @@ CONTRIBUTING.md「Phase 6 待ち skill 翻訳時の warning 配置必須」 sect
 | `gstack_repo_url` | `github.com/garrytan/gstack` | 文字列軸 |
 | `garry_tan_name` | `Garry Tan` (人名) | 固有名詞軸 |
 
-新 pattern を追加する時は `scripts/voice-rules.json` の `patterns` array に entry を追記する（schema は `version` + `description` + `patterns[]` で forward compatible）。
+新 pattern を追加する時は `scripts/voice-rules.json` の `patterns` array に entry を追記する（schema は `version` + `description` + `patterns[]` で forward compatible）。axis 1/2/3 は #165 で機械化対象外確定（理由は §3.1 各 row 併記 + §A.3 末尾の audit trail）、将来 Phase 5 #166 hook 機構と一体で再 design 候補。
 
 ---
 
@@ -323,7 +322,15 @@ Phase 3.5 進行（plan / strategy / cli tuning / design / orchestration 系 ski
 
 ### A.3 v2 拡張（Phase 4 機械化）
 
-Phase 4 で voice-rules.json による機械化を開始。PR #164（commit `8d09561`）で `scripts/voice-rules.json` v2 を導入、positive rules 6 patterns（URL + 固有名詞軸を含む）を機械化。`scripts/skill-validate.ts` が読み込み、translated skill での gstack 識別子 leak を CI で検出。#165 で negative rules（axis 1/2/3 = 全角括弧 / persona attribution / external LLM prompt 英語維持）の機械化を計画中。
+Phase 4 で voice-rules.json による機械化を開始。PR #164（commit `8d09561`）で `scripts/voice-rules.json` v2 を導入、positive rules 6 patterns（URL + 固有名詞軸を含む）を機械化。`scripts/skill-validate.ts` が読み込み、translated skill での gstack 識別子 leak を CI で検出。#165 で negative rules（axis 1/2/3 = 全角括弧 / persona attribution / external LLM prompt 英語維持）の機械化を検討、plan-eng-review session（本 PR）で 3 軸全て機械化対象外と判定。
+
+判定の根拠（軸別）：
+
+- **axis 1（全角括弧）**：machine 化対象を正確に区別するには bash code block の境界検出に加え bash 内 string literal（subagent prompt / heredoc 等の multi-line 引数）検出が必要、state machine 実装が axis 3 と同コスト。fact check で translated skill の bash code block 内に全角括弧 34 instances / 10 files が既存、すべて bash comment 行（`# ...（注記）`）で日本語 punctuation として運用、voice 規約 v1 #7（bash 括弧は半角維持）と実態 drift。machine 化 attempt は voice 規約 v1 #7 改定（Phase 3 確立済規律の re-evaluation）か state machine 実装の二択になり、現時点で機械化対象外。
+- **axis 2（persona attribution / Mode 名）**：Mode 名 4 + 経営者思考特性 18 + persona attribution 10+ の 30+ identifier の near-miss 検出に file-level state（同 file 内で初出併記済か）+ identifier table drift 管理が必要、line-based 1-pass scan の validator 責務と質的乖離。docs §1.3 が source of truth として運用、翻訳作業時の reviewer 軸で覆う。
+- **axis 3（外部 LLM prompt 英語維持）**：bash 内 `codex exec "..."` の複数行引数として書かれた入れ子 string literal 構造（autoplan/SKILL.md.tmpl L253-261 / L359-373 / L437-446 / L552-566 等）で、region 検出に bash + string literal の二段 state machine が必須。codex / openai-cli / gemini-cli が将来日本語対応した場合に規律ごと見直しになる可能性があり、現時点で機械化必要性が低い。
+
+Phase 5 #166 hook 機構の発動経路検証と一体で 3 軸の機械化を再 design する候補（PR merge 経路で hook が enforce する path を整備する文脈で、region 検出機構と統合）。
 
 ---
 


### PR DESCRIPTION
## Summary

- plan-eng-review session で voice 規約 v2 negative rules (axis 1/2/3) の false positive 設計を 4 段階 scope challenge で検討、 全 3 軸機械化対象外と判定
- docs/uzustack/translation-voice-guide.md §1.2 L108 / §3.1 機械化対象索引 table / §3.2 / §A.3 末尾を update、 軸別 rationale を audit trail として正典化
- `scripts/voice-rules.json` + `scripts/skill-validate.ts` は touch なし、 既存 6 positive patterns 維持 (regression 0、 full scan 88 files / 68 translated で All clean 確認済)

## Background

issue #165 は voice 規約 v2 拡張 (PR #164) の延長として 3 軸 (axis 1 = 全角括弧 / axis 2 = persona attribution / axis 3 = 外部 LLM prompt 英語維持) の機械化を計画していた。 plan-eng-review session で fact check の結果、 以下 3 点で全 3 軸機械化対象外と判定：

- **axis 1**: bash code block + string literal 入れ子検出に state machine が必要、 実態 fact check で translated skill の bash code block 内に全角括弧 34 instances / 10 files 既存 (= voice 規約 v1 #7 と実態 drift) と判明
- **axis 2**: Mode 名 4 + 経営者思考特性 18 + persona attribution 10+ の 30+ identifier の near-miss 検出に file-level state + table drift 管理が必要、 line-based 1-pass scan validator 設計と質的乖離
- **axis 3**: bash 内 `codex exec "..."` の入れ子 string literal 構造で region 検出に state machine 必須、 規律自体が外部 product の言語 contract に依存

## Changes

- **§1.2 L108**: 「LLM 訓練語の効果を保つ」 → 「判断軸：外部 product への入力は外部 product の言語 contract に従う。Claude Code は uzustack の言語方針 (日本語化) を適用するため対象外」 に文言更新、 旧「判断軸」 bullet を削除 (重複解消)
- **§3.1 機械化対象索引 table**: axis 1/2/3 行の機械化状態列を「#165 で計画中」 → 「機械化対象外 + rationale 1 行併記」 に変更
- **§3.2 voice-rules.json schema cross-ref**: preamble (`#165 で計画中` → `機械化対象外`) + 末尾追記 (axis 1/2/3 対象外確定、 経緯 §A.3 ref)
- **§A.3 v2 拡張 audit trail**: 「#165 で計画中」 → 「PR #175 plan-eng-review session で 3 軸全て機械化対象外と判定」 に書き換え、 軸別判定根拠 3 段落 + #166 hook 機構との再 design 選択肢を追加

## /simplify audit trail

Round 1 (3 sub-agent 並列レビュー: reuse / quality / efficiency) で 7 findings 適用 (commit `a14f54e`):
- §3.2 preamble L298 の「#165 で計画中」 stale state 残存を「機械化対象外」 に fix (critical drift)
- 「Phase 5」 → 削除 (project taxonomy 違反、 既存 Phase 4/Phase 6 のみ)
- future-prediction 表現を事実 / 規範表現に修正 (3 箇所、 voice 規範違反)
- §3.2 末尾 forward reference を §A.3 link に簡潔化 (二重表現解消)
- §3.1 table 3 rows の「、#165」 削除 (preamble で文脈化済)、 axis 3 row future-prediction 修正
- §A.3「本 PR」 → 「PR #175」 (merge 後 reference 解決)
- §A.3 axis 1 段落に出典 type 併記 (axis 3 段落の rigor と整合)

Round 2 (main loop direct grep 検証、 過去 learning「small 構成 = main loop direct で代替」 適用) で specificity drift / project taxonomy / voice 規範整合すべて確認、 追加 finding なし、 3 周目 skip。

## NOT in scope

- voice-rules.json schema 拡張 (scope field 追加) — axis 1 out-of-scope 確定で moot
- skill-validate.ts state machine 拡張 — 同上
- voice 規約 v1 #7 (bash 括弧は半角維持) と実態 drift の docs §1.3 articulate — 機械化対象外確定で対応不要 (#166 hook 機構の検討時に再訪候補)
- positive rules 追加拡張 (bare `gstack` / `Y Combinator` 等) — PR #164 で false positive 多発、 inline allow-list 機構待ち (別 issue 候補)

## Test plan

- [x] `bun run scripts/skill-validate.ts` を full scan で実行、 88 files / 68 translated / 0 violations を確認 (= 既存 positive patterns の regression なし)
- [x] docs/uzustack/translation-voice-guide.md の §3.1 table が 5 行で markdown render される (axis 1/2/3 機械化状態列の長文 rationale で table 崩れがないこと、 GitHub PR diff preview で確認可能)
- [x] §A.3 末尾の rationale 段落 3 件が markdown render で正しく表示される
- [x] §1.2 L108 patch 後の文言が natural な日本語として読める
- [x] /simplify を 2 回実行 (Round 1 actionable fix 7 件適用 / Round 2 cross-validation 追加 finding なし)

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)