### PR TITLE
feat: #188 — _upstream 直接 import 全廃 (browse.ts inline + test/helpers/ mirror) [resurrection of PR #189]

### DIFF
--- a/.github/workflows/bin-smoke-test.yml
+++ b/.github/workflows/bin-smoke-test.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     paths:
       - 'bin/**'
+      - 'test/helpers/**'
       - '_upstream/gstack/test/helpers/**'
       - '.github/workflows/bin-smoke-test.yml'
   push:
@@ -16,6 +17,46 @@ on:
   workflow_dispatch:
 
 jobs:
+  drift-check:
+    # test/helpers/ mirror が upstream と bit-for-bit 同期しているか検証 (header 5 行除く)。
+    # #188 で確立した mirror 規律を CI で enforce。
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v4
+      - name: verify test/helpers/ mirror in sync with _upstream
+        run: |
+          set +e
+          MIRRORS="benchmark-runner.ts benchmark-judge.ts pricing.ts providers/types.ts providers/claude.ts providers/gpt.ts providers/gemini.ts"
+          DRIFT=0
+          for f in $MIRRORS; do
+            LOCAL="test/helpers/$f"
+            UPSTREAM="_upstream/gstack/test/helpers/$f"
+            if [ ! -f "$LOCAL" ]; then
+              echo "::error file=$LOCAL::missing mirror file"
+              DRIFT=1
+              continue
+            fi
+            if [ ! -f "$UPSTREAM" ]; then
+              echo "::error file=$UPSTREAM::missing upstream source — file may have been moved/deleted by subtree pull. update mirror or fix grep target."
+              DRIFT=1
+              continue
+            fi
+            if ! diff -q <(tail -n +6 "$LOCAL") "$UPSTREAM" > /dev/null 2>&1; then
+              echo "::error file=$LOCAL::DRIFT detected: $LOCAL differs from $UPSTREAM (modulo 5-line header)"
+              echo "--- drift diff ---"
+              diff <(tail -n +6 "$LOCAL") "$UPSTREAM" | head -30
+              DRIFT=1
+            fi
+          done
+          if [ "$DRIFT" -eq 0 ]; then
+            echo "All 7 mirror files in sync with upstream ✓"
+          else
+            echo ""
+            echo "FIX: re-run 'cp _upstream/gstack/test/helpers/<file> test/helpers/<file>' then re-prepend the 5-line header. See CONTRIBUTING.md mirror-sync section."
+          fi
+          exit "$DRIFT"
+
   discover:
     runs-on: ubuntu-latest
     outputs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -204,7 +204,8 @@ uzustack は upstream の以下 2 site を **mirror 複製** で参照してい�
 | uzustack 側 | upstream | 複製方式 |
 |---|---|---|
 | `test/helpers/` (7 file) | `_upstream/gstack/test/helpers/` | file mirror（各 file 冒頭に 5 行 drift 確認 JSDoc を prepend） |
-| `scripts/resolvers/browse.ts` の inline `COMMAND_DESCRIPTIONS` | `_upstream/gstack/browse/src/commands.ts` line 87-177 | data inline |
+| `scripts/resolvers/browse.ts` の inline `COMMAND_DESCRIPTIONS` | `_upstream/gstack/browse/src/commands.ts` line 87-177 | data inline（issue #188 / PR #189 で _upstream 直接 import を全廃） |
+| `scripts/resolvers/browse.ts` の inline `SNAPSHOT_FLAGS` | `_upstream/gstack/browse/src/snapshot.ts` line 53-70 | data inline（Phase 3 以前から、 upstream snapshot.ts の `import * as Diff from 'diff'` 依存を避けるため） |
 
 **自動 drift detection（CI 化済）**: `.github/workflows/bin-smoke-test.yml` の `drift-check` job が PR ごとに `test/helpers/` 側 mirror が upstream と bit-for-bit 一致しているか（header 5 行除く）を verify します。 drift があれば `::error` で fail。
 
@@ -213,13 +214,17 @@ uzustack は upstream の以下 2 site を **mirror 複製** で参照してい�
 **subtree pull 後の手動 sync 手順**: 月次の subtree pull PR で `_upstream/gstack/test/helpers/<file>` が更新されていた場合、 同 PR 内で uzustack 側 mirror も update：
 
 ```bash
-# 1. 該当 mirror file を upstream から再 copy（5 行 header を保持しつつ）
+# 1. 該当 mirror file を upstream から再 copy（5 行 header を保持しつつ、 file-based merge で
+#    line 5 の空行も保持する。 bash の $(head -5 ...) は trailing newlines を strip するため
+#    HEADER 変数経由だと line 5 空行が失われて drift detection が永続 fail する）
 for f in benchmark-runner.ts benchmark-judge.ts pricing.ts providers/types.ts providers/claude.ts providers/gpt.ts providers/gemini.ts; do
-  if ! diff -q <(tail -n +6 "test/helpers/$f") "_upstream/gstack/test/helpers/$f" > /dev/null 2>&1; then
-    HEADER=$(head -5 "test/helpers/$f")
-    cp "_upstream/gstack/test/helpers/$f" "test/helpers/$f"
-    # 既存 header を再 prepend
-    printf '%s\n%s' "$HEADER" "$(cat test/helpers/$f)" > "test/helpers/$f"
+  LOCAL="test/helpers/$f"
+  UPSTREAM="_upstream/gstack/test/helpers/$f"
+  if ! diff -q <(tail -n +6 "$LOCAL") "$UPSTREAM" > /dev/null 2>&1; then
+    HEADER_TMP=$(mktemp)
+    head -5 "$LOCAL" > "$HEADER_TMP"
+    cat "$HEADER_TMP" "$UPSTREAM" > "$LOCAL"
+    rm -f "$HEADER_TMP"
     echo "synced: $f"
   fi
 done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,6 +197,48 @@ gh pr create
 
 自動 PR の中に翻訳済み skill（`type: translated`）の上流変更が含まれていたら、[翻訳ガイド](#翻訳ガイドgstack-の英語スキルを翻訳する場合) の「rebase の手順」を参照して再翻訳します。uzustack 独自部分（`type: native`）は gstack 更新と無関係。
 
+### mirror file の sync（test/helpers/ + browse.ts inline COMMAND_DESCRIPTIONS）
+
+uzustack は upstream の以下 2 site を **mirror 複製** で参照しています（issue #188 / PR #189 で確立、 uzustack コードから `_upstream/gstack/` への直接 import を全廃するため）：
+
+| uzustack 側 | upstream | 複製方式 |
+|---|---|---|
+| `test/helpers/` (7 file) | `_upstream/gstack/test/helpers/` | file mirror（各 file 冒頭に 5 行 drift 確認 JSDoc を prepend） |
+| `scripts/resolvers/browse.ts` の inline `COMMAND_DESCRIPTIONS` | `_upstream/gstack/browse/src/commands.ts` line 87-177 | data inline |
+
+**自動 drift detection（CI 化済）**: `.github/workflows/bin-smoke-test.yml` の `drift-check` job が PR ごとに `test/helpers/` 側 mirror が upstream と bit-for-bit 一致しているか（header 5 行除く）を verify します。 drift があれば `::error` で fail。
+
+注: browse.ts inline COMMAND_DESCRIPTIONS の drift detection は #190 で別途追跡（regex 抽出 + 比較が必要なため別 scope）。 現状は手動 review に依存。
+
+**subtree pull 後の手動 sync 手順**: 月次の subtree pull PR で `_upstream/gstack/test/helpers/<file>` が更新されていた場合、 同 PR 内で uzustack 側 mirror も update：
+
+```bash
+# 1. 該当 mirror file を upstream から再 copy（5 行 header を保持しつつ）
+for f in benchmark-runner.ts benchmark-judge.ts pricing.ts providers/types.ts providers/claude.ts providers/gpt.ts providers/gemini.ts; do
+  if ! diff -q <(tail -n +6 "test/helpers/$f") "_upstream/gstack/test/helpers/$f" > /dev/null 2>&1; then
+    HEADER=$(head -5 "test/helpers/$f")
+    cp "_upstream/gstack/test/helpers/$f" "test/helpers/$f"
+    # 既存 header を再 prepend
+    printf '%s\n%s' "$HEADER" "$(cat test/helpers/$f)" > "test/helpers/$f"
+    echo "synced: $f"
+  fi
+done
+
+# 2. local で drift-check 同等 logic を verify
+bash -c '
+MIRRORS="benchmark-runner.ts benchmark-judge.ts pricing.ts providers/types.ts providers/claude.ts providers/gpt.ts providers/gemini.ts"
+for f in $MIRRORS; do
+  diff -q <(tail -n +6 "test/helpers/$f") "_upstream/gstack/test/helpers/$f" > /dev/null || echo "DRIFT: $f"
+done
+'
+```
+
+drift detection が catch する failure mode:
+- file 削除 / rename（= `LOCAL` または `UPSTREAM` 不在 → `::error` + 該当 file 名表示）
+- content drift（= 内容差分 → `diff` head -30 で内容表示）
+
+**新規 mirror site の追加手順**: 将来 upstream の別 file を mirror する場合、 (1) `test/helpers/` 配下に複製、 (2) 5 行 header prepend、 (3) workflow の `MIRRORS` 環境変数に追加、 (4) 本 section の table に追記。
+
 ### `_upstream/gstack/setup` を実行しない（effect 軸）
 
 **禁止**：`_upstream/gstack/setup` の execution。 invocation method (= cd した手動 invocation / `bun test` 経由 / bin script からの spawn / 他いずれの経路でも) に関わらず、 **gstack setup script の execution 自体が禁止**。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -209,7 +209,7 @@ uzustack は upstream の以下 2 site を **mirror 複製** で参照してい�
 
 **自動 drift detection（CI 化済）**: `.github/workflows/bin-smoke-test.yml` の `drift-check` job が PR ごとに `test/helpers/` 側 mirror が upstream と bit-for-bit 一致しているか（header 5 行除く）を verify します。 drift があれば `::error` で fail。
 
-注: browse.ts inline COMMAND_DESCRIPTIONS の drift detection は #190 で別途追跡（regex 抽出 + 比較が必要なため別 scope）。 現状は手動 review に依存。
+注: browse.ts inline COMMAND_DESCRIPTIONS の drift detection は手動 review に依存（regex 抽出 + 比較が必要で test/helpers/ の file-level diff より複雑）。 browse skill 実装方針 (= upstream browse.ts 全体に対する戦略) 確定後に CI 化判断する。
 
 **subtree pull 後の手動 sync 手順**: 月次の subtree pull PR で `_upstream/gstack/test/helpers/<file>` が更新されていた場合、 同 PR 内で uzustack 側 mirror も update：
 

--- a/bin/uzustack-model-benchmark
+++ b/bin/uzustack-model-benchmark
@@ -26,10 +26,10 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { runBenchmark, formatTable, formatJson, formatMarkdown, type BenchmarkInput } from '../_upstream/gstack/test/helpers/benchmark-runner';
-import { ClaudeAdapter } from '../_upstream/gstack/test/helpers/providers/claude';
-import { GptAdapter } from '../_upstream/gstack/test/helpers/providers/gpt';
-import { GeminiAdapter } from '../_upstream/gstack/test/helpers/providers/gemini';
+import { runBenchmark, formatTable, formatJson, formatMarkdown, type BenchmarkInput } from '../test/helpers/benchmark-runner';
+import { ClaudeAdapter } from '../test/helpers/providers/claude';
+import { GptAdapter } from '../test/helpers/providers/gpt';
+import { GeminiAdapter } from '../test/helpers/providers/gemini';
 
 const ADAPTER_FACTORIES = {
   claude: () => new ClaudeAdapter(),
@@ -105,7 +105,7 @@ async function main(): Promise<void> {
 
   if (doJudge) {
     try {
-      const { judgeEntries } = await import('../_upstream/gstack/test/helpers/benchmark-judge');
+      const { judgeEntries } = await import('../test/helpers/benchmark-judge');
       await judgeEntries(report);
     } catch (err) {
       console.error(`WARN: judge unavailable: ${(err as Error).message}`);

--- a/scripts/resolvers/browse.ts
+++ b/scripts/resolvers/browse.ts
@@ -2,13 +2,15 @@
  * Browse resolver — COMMAND_REFERENCE / SNAPSHOT_FLAGS / BROWSE_SETUP を emit。
  *
  * uzustack には browse binary の実体 source (browse/src/) が無い (Phase 6 予約)。
- * このため:
- * - COMMAND_DESCRIPTIONS は upstream gstack の data export から import (commands.ts は
- *   playwright / diff package を runtime import しない pure data なので安全)。
+ * このため 2 site とも upstream からの data clone を本 file 内に inline:
+ * - COMMAND_DESCRIPTIONS は upstream `_upstream/gstack/browse/src/commands.ts` line 87-177
+ *   の data clone (issue #188 / PR #189 で _upstream 直接 import を全廃、 詳細 JSDoc は
+ *   定数定義直前を参照)。
  * - SNAPSHOT_FLAGS は upstream の snapshot.ts が `import * as Diff from 'diff'` 経由で
  *   未インストール package を引きずるため、 データ部のみ local に inline。
- *   月次 subtree pull で _upstream/gstack/browse/src/snapshot.ts の SNAPSHOT_FLAGS と
- *   drift していないか手動 sync 確認すること。
+ * 月次 subtree pull で `_upstream/gstack/browse/src/commands.ts` と
+ * `_upstream/gstack/browse/src/snapshot.ts` の両 data と drift していないか手動 sync 確認すること
+ * (mirror sync 手順は CONTRIBUTING.md「mirror file の sync」 section 参照)。
  */
 import type { TemplateContext } from './types';
 

--- a/scripts/resolvers/browse.ts
+++ b/scripts/resolvers/browse.ts
@@ -11,7 +11,106 @@
  *   drift していないか手動 sync 確認すること。
  */
 import type { TemplateContext } from './types';
-import { COMMAND_DESCRIPTIONS } from '../../_upstream/gstack/browse/src/commands';
+
+/**
+ * COMMAND_DESCRIPTIONS の data clone — upstream `_upstream/gstack/browse/src/commands.ts`
+ * line 87-177 の COMMAND_DESCRIPTIONS 定数のみを inline 複製。
+ * subtree pull 時に drift していないか手動 sync 確認すること。
+ * commands.ts の他 export (READ_COMMANDS / WRITE_COMMANDS / META_COMMANDS / ALL_COMMANDS /
+ * PAGE_CONTENT_COMMANDS / DOM_CONTENT_COMMANDS / wrapUntrustedContent / COMMAND_ALIASES /
+ * canonicalizeCommand / NEW_IN_VERSION / buildUnknownCommandError) は本 file で使用しないため複製しない。
+ */
+const COMMAND_DESCRIPTIONS: Record<string, { category: string; description: string; usage?: string }> = {
+  // Navigation
+  'goto':    { category: 'Navigation', description: 'Navigate to URL (http://, https://, or file:// scoped to cwd/TEMP_DIR)', usage: 'goto <url>' },
+  'load-html': { category: 'Navigation', description: 'Load HTML via setContent. Accepts a file path under safe-dirs (validated), OR --from-file <payload.json> with {"html":"...","waitUntil":"..."} for large inline HTML (Windows argv safe).', usage: 'load-html <file> [--wait-until load|domcontentloaded|networkidle] [--tab-id <N>]  |  load-html --from-file <payload.json> [--tab-id <N>]' },
+  'back':    { category: 'Navigation', description: 'History back' },
+  'forward': { category: 'Navigation', description: 'History forward' },
+  'reload':  { category: 'Navigation', description: 'Reload page' },
+  'url':     { category: 'Navigation', description: 'Print current URL' },
+  // Reading
+  'text':    { category: 'Reading', description: 'Cleaned page text' },
+  'html':    { category: 'Reading', description: 'innerHTML of selector (throws if not found), or full page HTML if no selector given', usage: 'html [selector]' },
+  'links':   { category: 'Reading', description: 'All links as "text → href"' },
+  'forms':   { category: 'Reading', description: 'Form fields as JSON' },
+  'accessibility': { category: 'Reading', description: 'Full ARIA tree' },
+  'media':   { category: 'Reading', description: 'All media elements (images, videos, audio) with URLs, dimensions, types', usage: 'media [--images|--videos|--audio] [selector]' },
+  'data':    { category: 'Reading', description: 'Structured data: JSON-LD, Open Graph, Twitter Cards, meta tags', usage: 'data [--jsonld|--og|--meta|--twitter]' },
+  // Inspection
+  'js':      { category: 'Inspection', description: 'Run JavaScript expression and return result as string', usage: 'js <expr>' },
+  'eval':    { category: 'Inspection', description: 'Run JavaScript from file and return result as string (path must be under /tmp or cwd)', usage: 'eval <file>' },
+  'css':     { category: 'Inspection', description: 'Computed CSS value', usage: 'css <sel> <prop>' },
+  'attrs':   { category: 'Inspection', description: 'Element attributes as JSON', usage: 'attrs <sel|@ref>' },
+  'is':      { category: 'Inspection', description: 'State check (visible/hidden/enabled/disabled/checked/editable/focused)', usage: 'is <prop> <sel>' },
+  'console': { category: 'Inspection', description: 'Console messages (--errors filters to error/warning)', usage: 'console [--clear|--errors]' },
+  'network': { category: 'Inspection', description: 'Network requests', usage: 'network [--clear]' },
+  'dialog':  { category: 'Inspection', description: 'Dialog messages', usage: 'dialog [--clear]' },
+  'cookies': { category: 'Inspection', description: 'All cookies as JSON' },
+  'storage': { category: 'Inspection', description: 'Read all localStorage + sessionStorage as JSON, or set <key> <value> to write localStorage', usage: 'storage [set k v]' },
+  'perf':    { category: 'Inspection', description: 'Page load timings' },
+  // Interaction
+  'click':   { category: 'Interaction', description: 'Click element', usage: 'click <sel>' },
+  'fill':    { category: 'Interaction', description: 'Fill input', usage: 'fill <sel> <val>' },
+  'select':  { category: 'Interaction', description: 'Select dropdown option by value, label, or visible text', usage: 'select <sel> <val>' },
+  'hover':   { category: 'Interaction', description: 'Hover element', usage: 'hover <sel>' },
+  'type':    { category: 'Interaction', description: 'Type into focused element', usage: 'type <text>' },
+  'press':   { category: 'Interaction', description: 'Press key — Enter, Tab, Escape, ArrowUp/Down/Left/Right, Backspace, Delete, Home, End, PageUp, PageDown, or modifiers like Shift+Enter', usage: 'press <key>' },
+  'scroll':  { category: 'Interaction', description: 'Scroll element into view, or scroll to page bottom if no selector', usage: 'scroll [sel]' },
+  'wait':    { category: 'Interaction', description: 'Wait for element, network idle, or page load (timeout: 15s)', usage: 'wait <sel|--networkidle|--load>' },
+  'upload':  { category: 'Interaction', description: 'Upload file(s)', usage: 'upload <sel> <file> [file2...]' },
+  'viewport':{ category: 'Interaction', description: 'Set viewport size and optional deviceScaleFactor (1-3, for retina screenshots). --scale requires a context rebuild.', usage: 'viewport [<WxH>] [--scale <n>]' },
+  'cookie':  { category: 'Interaction', description: 'Set cookie on current page domain', usage: 'cookie <name>=<value>' },
+  'cookie-import': { category: 'Interaction', description: 'Import cookies from JSON file', usage: 'cookie-import <json>' },
+  'cookie-import-browser': { category: 'Interaction', description: 'Import cookies from installed Chromium browsers (opens picker, or use --domain for direct import)', usage: 'cookie-import-browser [browser] [--domain d]' },
+  'header':  { category: 'Interaction', description: 'Set custom request header (colon-separated, sensitive values auto-redacted)', usage: 'header <name>:<value>' },
+  'useragent': { category: 'Interaction', description: 'Set user agent', usage: 'useragent <string>' },
+  'dialog-accept': { category: 'Interaction', description: 'Auto-accept next alert/confirm/prompt. Optional text is sent as the prompt response', usage: 'dialog-accept [text]' },
+  'dialog-dismiss': { category: 'Interaction', description: 'Auto-dismiss next dialog' },
+  // Data extraction
+  'download': { category: 'Extraction', description: 'Download URL or media element to disk using browser cookies', usage: 'download <url|@ref> [path] [--base64]' },
+  'scrape':   { category: 'Extraction', description: 'Bulk download all media from page. Writes manifest.json', usage: 'scrape <images|videos|media> [--selector sel] [--dir path] [--limit N]' },
+  'archive':  { category: 'Extraction', description: 'Save complete page as MHTML via CDP', usage: 'archive [path]' },
+  // Visual
+  'screenshot': { category: 'Visual', description: 'Save screenshot. --selector targets a specific element (explicit flag form). Positional selectors starting with ./#/@/[ still work.', usage: 'screenshot [--selector <css>] [--viewport] [--clip x,y,w,h] [--base64] [selector|@ref] [path]' },
+  'pdf':     { category: 'Visual', description: 'Save the current page as PDF. Supports page layout (--format, --width, --height, --margins, --margin-*), structure (--toc waits for Paged.js), branding (--header-template, --footer-template, --page-numbers), accessibility (--tagged, --outline), and --from-file <payload.json> for large payloads. Use --tab-id <N> to target a specific tab.', usage: 'pdf [path] [--format letter|a4|legal] [--width <dim> --height <dim>] [--margins <dim>] [--margin-top <dim> --margin-right <dim> --margin-bottom <dim> --margin-left <dim>] [--header-template <html>] [--footer-template <html>] [--page-numbers] [--tagged] [--outline] [--print-background] [--prefer-css-page-size] [--toc] [--tab-id <N>]  |  pdf --from-file <payload.json> [--tab-id <N>]' },
+  'responsive': { category: 'Visual', description: 'Screenshots at mobile (375x812), tablet (768x1024), desktop (1280x720). Saves as {prefix}-mobile.png etc.', usage: 'responsive [prefix]' },
+  'diff':    { category: 'Visual', description: 'Text diff between pages', usage: 'diff <url1> <url2>' },
+  // Tabs
+  'tabs':    { category: 'Tabs', description: 'List open tabs' },
+  'tab':     { category: 'Tabs', description: 'Switch to tab', usage: 'tab <id>' },
+  'newtab':  { category: 'Tabs', description: 'Open new tab. With --json, returns {"tabId":N,"url":...} for programmatic use (make-pdf).', usage: 'newtab [url] [--json]' },
+  'closetab':{ category: 'Tabs', description: 'Close tab', usage: 'closetab [id]' },
+  'tab-each':{ category: 'Tabs', description: 'Run a command on every open tab. Returns JSON with per-tab results.', usage: 'tab-each <command> [args...]' },
+  // Server
+  'status':  { category: 'Server', description: 'Health check' },
+  'stop':    { category: 'Server', description: 'Shutdown server' },
+  'restart': { category: 'Server', description: 'Restart server' },
+  // Meta
+  'snapshot':{ category: 'Snapshot', description: 'Accessibility tree with @e refs for element selection. Flags: -i interactive only, -c compact, -d N depth limit, -s sel scope, -D diff vs previous, -a annotated screenshot, -o path output, -C cursor-interactive @c refs', usage: 'snapshot [flags]' },
+  'chain':   { category: 'Meta', description: 'Run commands from JSON stdin. Format: [["cmd","arg1",...],...]' },
+  // Handoff
+  'handoff': { category: 'Server', description: 'Open visible Chrome at current page for user takeover', usage: 'handoff [message]' },
+  'resume':  { category: 'Server', description: 'Re-snapshot after user takeover, return control to AI', usage: 'resume' },
+  // Headed mode
+  'connect': { category: 'Server', description: 'Launch headed Chromium with Chrome extension', usage: 'connect' },
+  'disconnect': { category: 'Server', description: 'Disconnect headed browser, return to headless mode' },
+  'focus':   { category: 'Server', description: 'Bring headed browser window to foreground (macOS)', usage: 'focus [@ref]' },
+  // Inbox
+  'inbox':   { category: 'Meta', description: 'List messages from sidebar scout inbox', usage: 'inbox [--clear]' },
+  // Watch
+  'watch':   { category: 'Meta', description: 'Passive observation — periodic snapshots while user browses', usage: 'watch [stop]' },
+  // State
+  'state':   { category: 'Server', description: 'Save/load browser state (cookies + URLs)', usage: 'state save|load <name>' },
+  // Frame
+  'frame':   { category: 'Meta', description: 'Switch to iframe context (or main to return)', usage: 'frame <sel|@ref|--name n|--url pattern|main>' },
+  // CSS Inspector
+  'inspect': { category: 'Inspection', description: 'Deep CSS inspection via CDP — full rule cascade, box model, computed styles', usage: 'inspect [selector] [--all] [--history]' },
+  'style':   { category: 'Interaction', description: 'Modify CSS property on element (with undo support)', usage: 'style <sel> <prop> <value> | style --undo [N]' },
+  'cleanup': { category: 'Interaction', description: 'Remove page clutter (ads, cookie banners, sticky elements, social widgets)', usage: 'cleanup [--ads] [--cookies] [--sticky] [--social] [--all]' },
+  'prettyscreenshot': { category: 'Visual', description: 'Clean screenshot with optional cleanup, scroll positioning, and element hiding', usage: 'prettyscreenshot [--scroll-to sel|text] [--cleanup] [--hide sel...] [--width px] [path]' },
+  // UX Audit
+  'ux-audit': { category: 'Inspection', description: 'Extract page structure for UX behavioral analysis — site ID, nav, headings, text blocks, interactive elements. Returns JSON for agent interpretation.', usage: 'ux-audit' },
+};
 
 /**
  * SNAPSHOT_FLAGS の data clone — upstream `_upstream/gstack/browse/src/snapshot.ts` line 53-70。

--- a/test/helpers/benchmark-judge.ts
+++ b/test/helpers/benchmark-judge.ts
@@ -1,0 +1,106 @@
+/**
+ * upstream `_upstream/gstack/test/helpers/benchmark-judge.ts` からの data clone。
+ * subtree pull 時に drift していないか手動確認すること。
+ */
+
+/**
+ * Benchmark quality judge — wraps llm-judge.ts for multi-provider scoring.
+ *
+ * The judge is always Anthropic SDK (claude-sonnet-4-6) for stability. It sees
+ * the prompt + N provider outputs and scores each on: correctness, completeness,
+ * code quality, edge case handling. 0-10 per dimension; overall = average.
+ *
+ * Judge adds ~$0.05 per benchmark run. Gated by --judge CLI flag.
+ */
+
+import type { BenchmarkReport, BenchmarkEntry } from './benchmark-runner';
+
+export async function judgeEntries(report: BenchmarkReport): Promise<void> {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    throw new Error('ANTHROPIC_API_KEY not set — judge requires Anthropic access.');
+  }
+  const { default: Anthropic } = await import('@anthropic-ai/sdk').catch(() => {
+    throw new Error('@anthropic-ai/sdk not installed — run `bun add @anthropic-ai/sdk` if you want the judge.');
+  });
+  const client = new (Anthropic as unknown as new (opts: { apiKey: string }) => {
+    messages: { create: (params: Record<string, unknown>) => Promise<{ content: Array<{ type: string; text: string }> }> };
+  })({ apiKey: process.env.ANTHROPIC_API_KEY! });
+
+  const successful = report.entries.filter(e => e.available && e.result && !e.result.error);
+  if (successful.length === 0) return;
+
+  const judgePrompt = buildJudgePrompt(report.prompt, successful);
+  const msg = await client.messages.create({
+    model: 'claude-sonnet-4-6',
+    max_tokens: 2048,
+    messages: [{ role: 'user', content: judgePrompt }],
+  });
+  const textBlock = msg.content.find(c => c.type === 'text');
+  if (!textBlock) return;
+
+  const scores = parseScores(textBlock.text, successful.length);
+  for (let i = 0; i < successful.length; i++) {
+    const s = scores[i];
+    if (!s) continue;
+    successful[i].qualityScore = s.overall;
+    successful[i].qualityDetails = s.dimensions;
+  }
+}
+
+function buildJudgePrompt(prompt: string, entries: BenchmarkEntry[]): string {
+  const lines: string[] = [
+    'You are a strict, fair technical reviewer scoring N model outputs against the same prompt.',
+    '',
+    '--- PROMPT ---',
+    prompt.length > 4000 ? prompt.slice(0, 4000) + '\n[...truncated for judge budget...]' : prompt,
+    '',
+    '--- OUTPUTS ---',
+  ];
+  entries.forEach((e, i) => {
+    const r = e.result!;
+    const out = r.output.length > 3000 ? r.output.slice(0, 3000) + '\n[...truncated...]' : r.output;
+    lines.push(`=== Output ${i + 1}: ${r.modelUsed} ===`);
+    lines.push(out);
+    lines.push('');
+  });
+  lines.push('');
+  lines.push('Score each output on these dimensions (0-10 per dimension):');
+  lines.push('  - correctness:   does it solve what the prompt asked?');
+  lines.push('  - completeness:  are edge cases and error paths addressed?');
+  lines.push('  - code_quality:  naming, structure, explicitness');
+  lines.push('  - edge_cases:    handling of nil/empty/invalid input');
+  lines.push('');
+  lines.push('Return JSON only, in this exact shape:');
+  lines.push('{"scores":[');
+  lines.push('  {"output":1,"correctness":N,"completeness":N,"code_quality":N,"edge_cases":N,"overall":N,"notes":"..."},');
+  lines.push('  ...');
+  lines.push(']}');
+  lines.push('');
+  lines.push('overall = rounded average of the 4 dimensions. No other commentary.');
+  return lines.join('\n');
+}
+
+interface ParsedScore {
+  overall: number;
+  dimensions: Record<string, number>;
+}
+
+function parseScores(raw: string, expectedCount: number): ParsedScore[] {
+  const match = raw.match(/\{[\s\S]*\}/);
+  if (!match) return [];
+  try {
+    const obj = JSON.parse(match[0]);
+    if (!Array.isArray(obj.scores)) return [];
+    return obj.scores.slice(0, expectedCount).map((s: Record<string, number>) => ({
+      overall: Number(s.overall ?? 0),
+      dimensions: {
+        correctness: Number(s.correctness ?? 0),
+        completeness: Number(s.completeness ?? 0),
+        code_quality: Number(s.code_quality ?? 0),
+        edge_cases: Number(s.edge_cases ?? 0),
+      },
+    }));
+  } catch {
+    return [];
+  }
+}

--- a/test/helpers/benchmark-runner.ts
+++ b/test/helpers/benchmark-runner.ts
@@ -1,0 +1,170 @@
+/**
+ * upstream `_upstream/gstack/test/helpers/benchmark-runner.ts` からの data clone。
+ * subtree pull 時に drift していないか手動確認すること。
+ */
+
+/**
+ * Multi-provider benchmark runner.
+ *
+ * Orchestrates running the same prompt across multiple provider adapters and
+ * aggregates RunResult outputs + judge scores into a single report. Adapters
+ * run in parallel (Promise.allSettled) so a slow provider doesn't block a fast
+ * one. Per-provider auth/timeout/rate-limit errors don't abort the batch.
+ */
+
+import type { ProviderAdapter, RunOpts, RunResult } from './providers/types';
+import { ClaudeAdapter } from './providers/claude';
+import { GptAdapter } from './providers/gpt';
+import { GeminiAdapter } from './providers/gemini';
+
+export interface BenchmarkInput {
+  prompt: string;
+  workdir: string;
+  timeoutMs?: number;
+  /** Adapter names to run (e.g., ['claude', 'gpt', 'gemini']). */
+  providers: Array<'claude' | 'gpt' | 'gemini'>;
+  /** Optional per-provider model overrides. */
+  models?: Partial<Record<'claude' | 'gpt' | 'gemini', string>>;
+  /** If true, skip providers whose available() returns !ok. If false, include them with error. */
+  skipUnavailable?: boolean;
+}
+
+export interface BenchmarkEntry {
+  provider: string;
+  family: 'claude' | 'gpt' | 'gemini';
+  available: boolean;
+  unavailable_reason?: string;
+  result?: RunResult;
+  costUsd?: number;
+  /** Judge score 0-10 across dimensions. Populated separately by the judge step. */
+  qualityScore?: number;
+  qualityDetails?: Record<string, number>;
+}
+
+export interface BenchmarkReport {
+  prompt: string;
+  workdir: string;
+  startedAt: string;
+  durationMs: number;
+  entries: BenchmarkEntry[];
+}
+
+const ADAPTERS: Record<'claude' | 'gpt' | 'gemini', () => ProviderAdapter> = {
+  claude: () => new ClaudeAdapter(),
+  gpt: () => new GptAdapter(),
+  gemini: () => new GeminiAdapter(),
+};
+
+export async function runBenchmark(input: BenchmarkInput): Promise<BenchmarkReport> {
+  const startedAtMs = Date.now();
+  const startedAt = new Date(startedAtMs).toISOString();
+  const timeoutMs = input.timeoutMs ?? 300_000;
+
+  const entries: BenchmarkEntry[] = [];
+  const runPromises: Array<Promise<void>> = [];
+
+  for (const name of input.providers) {
+    const factory = ADAPTERS[name];
+    if (!factory) {
+      entries.push({ provider: name, family: 'claude', available: false, unavailable_reason: `unknown provider: ${name}` });
+      continue;
+    }
+    const adapter = factory();
+    const entry: BenchmarkEntry = { provider: adapter.name, family: adapter.family, available: true };
+    entries.push(entry);
+
+    runPromises.push((async () => {
+      const check = await adapter.available();
+      entry.available = check.ok;
+      if (!check.ok) {
+        entry.unavailable_reason = check.reason;
+        if (input.skipUnavailable) return;
+      }
+      const opts: RunOpts = {
+        prompt: input.prompt,
+        workdir: input.workdir,
+        timeoutMs,
+        model: input.models?.[name],
+      };
+      const res = await adapter.run(opts);
+      entry.result = res;
+      entry.costUsd = adapter.estimateCost(res.tokens, res.modelUsed);
+    })());
+  }
+
+  await Promise.allSettled(runPromises);
+
+  return {
+    prompt: input.prompt,
+    workdir: input.workdir,
+    startedAt,
+    durationMs: Date.now() - startedAtMs,
+    entries,
+  };
+}
+
+export function formatTable(report: BenchmarkReport): string {
+  const header = `Model                Latency   In→Out Tokens       Cost       Quality   Tool Calls   Notes`;
+  const sep = '-'.repeat(header.length);
+  const rows: string[] = [header, sep];
+  for (const e of report.entries) {
+    if (!e.available) {
+      rows.push(`${pad(e.provider, 20)} ${pad('-', 9)} ${pad('-', 20)} ${pad('-', 10)} ${pad('-', 9)} ${pad('-', 12)} unavailable: ${e.unavailable_reason ?? 'unknown'}`);
+      continue;
+    }
+    const r = e.result!;
+    if (r.error) {
+      rows.push(`${pad(r.modelUsed, 20)} ${pad(msToStr(r.durationMs), 9)} ${pad(`${r.tokens.input}→${r.tokens.output}`, 20)} ${pad(fmtCost(e.costUsd), 10)} ${pad('-', 9)} ${pad(String(r.toolCalls), 12)} ERROR ${r.error.code}: ${r.error.reason.slice(0, 40)}`);
+      continue;
+    }
+    const quality = e.qualityScore !== undefined ? `${e.qualityScore.toFixed(1)}/10` : '-';
+    rows.push(`${pad(r.modelUsed, 20)} ${pad(msToStr(r.durationMs), 9)} ${pad(`${r.tokens.input}→${r.tokens.output}`, 20)} ${pad(fmtCost(e.costUsd), 10)} ${pad(quality, 9)} ${pad(String(r.toolCalls), 12)}`);
+  }
+  return rows.join('\n');
+}
+
+export function formatJson(report: BenchmarkReport): string {
+  return JSON.stringify(report, null, 2);
+}
+
+export function formatMarkdown(report: BenchmarkReport): string {
+  const lines: string[] = [
+    `# Benchmark report — ${report.startedAt}`,
+    '',
+    `**Prompt:** ${report.prompt.length > 200 ? report.prompt.slice(0, 200) + '…' : report.prompt}`,
+    `**Workdir:** \`${report.workdir}\``,
+    `**Total duration:** ${msToStr(report.durationMs)}`,
+    '',
+    '| Model | Latency | Tokens (in→out) | Cost | Quality | Tools | Notes |',
+    '|-------|---------|-----------------|------|---------|-------|-------|',
+  ];
+  for (const e of report.entries) {
+    if (!e.available) {
+      lines.push(`| ${e.provider} | - | - | - | - | - | unavailable: ${e.unavailable_reason ?? 'unknown'} |`);
+      continue;
+    }
+    const r = e.result!;
+    if (r.error) {
+      lines.push(`| ${r.modelUsed} | ${msToStr(r.durationMs)} | ${r.tokens.input}→${r.tokens.output} | ${fmtCost(e.costUsd)} | - | ${r.toolCalls} | ERROR ${r.error.code}: ${r.error.reason.slice(0, 80)} |`);
+      continue;
+    }
+    const quality = e.qualityScore !== undefined ? `${e.qualityScore.toFixed(1)}/10` : '-';
+    lines.push(`| ${r.modelUsed} | ${msToStr(r.durationMs)} | ${r.tokens.input}→${r.tokens.output} | ${fmtCost(e.costUsd)} | ${quality} | ${r.toolCalls} | |`);
+  }
+  return lines.join('\n');
+}
+
+function pad(s: string, n: number): string {
+  return s.length >= n ? s.slice(0, n) : s + ' '.repeat(n - s.length);
+}
+
+function msToStr(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+function fmtCost(usd?: number): string {
+  if (usd === undefined) return '-';
+  if (usd < 0.01) return `$${usd.toFixed(4)}`;
+  return `$${usd.toFixed(2)}`;
+}

--- a/test/helpers/pricing.ts
+++ b/test/helpers/pricing.ts
@@ -1,0 +1,66 @@
+/**
+ * upstream `_upstream/gstack/test/helpers/pricing.ts` からの data clone。
+ * subtree pull 時に drift していないか手動確認すること。
+ */
+
+/**
+ * Per-model pricing tables.
+ *
+ * Prices are USD per million tokens as of `as_of`. Update quarterly.
+ * Link to provider pricing pages:
+ *   - Anthropic: https://www.anthropic.com/pricing#api
+ *   - OpenAI: https://openai.com/api/pricing/
+ *   - Google AI: https://ai.google.dev/pricing
+ *
+ * When a model isn't in the table, estimateCost returns 0 with a console warning.
+ * Prefer adding a new row to the table over guessing.
+ */
+
+export interface ModelPricing {
+  input_per_mtok: number;
+  output_per_mtok: number;
+  as_of: string; // YYYY-MM
+}
+
+export const PRICING: Record<string, ModelPricing> = {
+  // Claude (Anthropic)
+  'claude-opus-4-7':    { input_per_mtok: 15.00, output_per_mtok: 75.00, as_of: '2026-04' },
+  'claude-sonnet-4-6':  { input_per_mtok: 3.00,  output_per_mtok: 15.00, as_of: '2026-04' },
+  'claude-haiku-4-5':   { input_per_mtok: 1.00,  output_per_mtok: 5.00,  as_of: '2026-04' },
+
+  // OpenAI (GPT + o-series)
+  'gpt-5.4':            { input_per_mtok: 2.50,  output_per_mtok: 10.00, as_of: '2026-04' },
+  'gpt-5.4-mini':       { input_per_mtok: 0.60,  output_per_mtok: 2.40,  as_of: '2026-04' },
+  'o3':                 { input_per_mtok: 15.00, output_per_mtok: 60.00, as_of: '2026-04' },
+  'o4-mini':            { input_per_mtok: 1.10,  output_per_mtok: 4.40,  as_of: '2026-04' },
+
+  // Google
+  'gemini-2.5-pro':     { input_per_mtok: 1.25,  output_per_mtok: 5.00,  as_of: '2026-04' },
+  'gemini-2.5-flash':   { input_per_mtok: 0.30,  output_per_mtok: 1.20,  as_of: '2026-04' },
+};
+
+const WARNED = new Set<string>();
+
+export function estimateCostUsd(
+  tokens: { input: number; output: number; cached?: number },
+  model: string | undefined
+): number {
+  if (!model) return 0;
+  const row = PRICING[model];
+  if (!row) {
+    if (!WARNED.has(model)) {
+      WARNED.add(model);
+      console.error(`WARN: no pricing for model ${model}; returning 0. Add it to test/helpers/pricing.ts.`);
+    }
+    return 0;
+  }
+  // Anthropic and OpenAI report cached tokens as a separate (disjoint) field from
+  // uncached input tokens. tokens.input is already the uncached portion; tokens.cached
+  // is the cache-read count billed at 10% of the regular input rate. Do NOT subtract
+  // cached from input — they don't overlap.
+  const cachedDiscount = 0.1;
+  const inputCost = tokens.input * row.input_per_mtok / 1_000_000;
+  const cachedCost = (tokens.cached ?? 0) * row.input_per_mtok * cachedDiscount / 1_000_000;
+  const outputCost = tokens.output * row.output_per_mtok / 1_000_000;
+  return +(inputCost + cachedCost + outputCost).toFixed(6);
+}

--- a/test/helpers/providers/claude.ts
+++ b/test/helpers/providers/claude.ts
@@ -1,0 +1,121 @@
+/**
+ * upstream `_upstream/gstack/test/helpers/providers/claude.ts` からの data clone。
+ * subtree pull 時に drift していないか手動確認すること。
+ */
+
+import type { ProviderAdapter, RunOpts, RunResult, AvailabilityCheck } from './types';
+import { estimateCostUsd } from '../pricing';
+import { execFileSync, spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+/**
+ * Claude adapter — wraps the `claude` CLI via claude -p.
+ *
+ * For brevity and to avoid duplicating the full stream-json parser, this adapter
+ * uses claude CLI in non-interactive mode (--print) with the simpler JSON output
+ * format. If richer event-level metrics are needed (per-tool timing etc.),
+ * swap to session-runner's full stream-json parser.
+ */
+export class ClaudeAdapter implements ProviderAdapter {
+  readonly name = 'claude';
+  readonly family = 'claude' as const;
+
+  async available(): Promise<AvailabilityCheck> {
+    // Binary on PATH?
+    const res = spawnSync('sh', ['-c', 'command -v claude'], { timeout: 2000 });
+    if (res.status !== 0) {
+      return { ok: false, reason: 'claude CLI not found on PATH. Install from https://claude.ai/download or npm i -g @anthropic-ai/claude-code' };
+    }
+    // Auth sniff: ~/.claude/.credentials.json OR ANTHROPIC_API_KEY
+    const credsPath = path.join(os.homedir(), '.claude', '.credentials.json');
+    const hasCreds = fs.existsSync(credsPath);
+    const hasKey = !!process.env.ANTHROPIC_API_KEY;
+    if (!hasCreds && !hasKey) {
+      return { ok: false, reason: 'No Claude auth found. Log in via `claude` interactive session, or export ANTHROPIC_API_KEY.' };
+    }
+    return { ok: true };
+  }
+
+  async run(opts: RunOpts): Promise<RunResult> {
+    const start = Date.now();
+    const args = ['-p', '--output-format', 'json'];
+    if (opts.model) args.push('--model', opts.model);
+    if (opts.extraArgs) args.push(...opts.extraArgs);
+
+    try {
+      const out = execFileSync('claude', args, {
+        input: opts.prompt,
+        cwd: opts.workdir,
+        timeout: opts.timeoutMs,
+        encoding: 'utf-8',
+        maxBuffer: 32 * 1024 * 1024,
+      });
+      const parsed = this.parseOutput(out);
+      return {
+        output: parsed.output,
+        tokens: parsed.tokens,
+        durationMs: Date.now() - start,
+        toolCalls: parsed.toolCalls,
+        modelUsed: parsed.modelUsed || opts.model || 'claude-opus-4-7',
+      };
+    } catch (err: unknown) {
+      const durationMs = Date.now() - start;
+      const e = err as { code?: string; stderr?: Buffer; signal?: string; message?: string };
+      const stderr = e.stderr?.toString() ?? '';
+      if (e.signal === 'SIGTERM' || e.code === 'ETIMEDOUT') {
+        return this.emptyResult(durationMs, { code: 'timeout', reason: `exceeded ${opts.timeoutMs}ms` }, opts.model);
+      }
+      if (/unauthorized|auth|login/i.test(stderr)) {
+        return this.emptyResult(durationMs, { code: 'auth', reason: stderr.slice(0, 400) }, opts.model);
+      }
+      if (/rate[- ]?limit|429/i.test(stderr)) {
+        return this.emptyResult(durationMs, { code: 'rate_limit', reason: stderr.slice(0, 400) }, opts.model);
+      }
+      return this.emptyResult(durationMs, { code: 'unknown', reason: (e.message ?? stderr ?? 'unknown').slice(0, 400) }, opts.model);
+    }
+  }
+
+  estimateCost(tokens: { input: number; output: number; cached?: number }, model?: string): number {
+    return estimateCostUsd(tokens, model ?? 'claude-opus-4-7');
+  }
+
+  /**
+   * Parse claude -p --output-format json output. Shape (as of 2026-04):
+   *   { type: "result", result: "<assistant text>", usage: { input_tokens, output_tokens, ... },
+   *     num_turns, session_id, ... }
+   * Older formats may differ — adapter is best-effort.
+   */
+  private parseOutput(raw: string): { output: string; tokens: { input: number; output: number; cached?: number }; toolCalls: number; modelUsed?: string } {
+    try {
+      const obj = JSON.parse(raw);
+      const result = typeof obj.result === 'string' ? obj.result : String(obj.result ?? '');
+      const u = obj.usage ?? {};
+      return {
+        output: result,
+        tokens: {
+          input: u.input_tokens ?? 0,
+          output: u.output_tokens ?? 0,
+          cached: u.cache_read_input_tokens,
+        },
+        toolCalls: obj.num_turns ?? 0,
+        modelUsed: obj.model,
+      };
+    } catch {
+      // Non-JSON output: treat as plain text.
+      return { output: raw, tokens: { input: 0, output: 0 }, toolCalls: 0 };
+    }
+  }
+
+  private emptyResult(durationMs: number, error: RunResult['error'], model?: string): RunResult {
+    return {
+      output: '',
+      tokens: { input: 0, output: 0 },
+      durationMs,
+      toolCalls: 0,
+      modelUsed: model ?? 'claude-opus-4-7',
+      error,
+    };
+  }
+}

--- a/test/helpers/providers/gemini.ts
+++ b/test/helpers/providers/gemini.ts
@@ -1,0 +1,128 @@
+/**
+ * upstream `_upstream/gstack/test/helpers/providers/gemini.ts` からの data clone。
+ * subtree pull 時に drift していないか手動確認すること。
+ */
+
+import type { ProviderAdapter, RunOpts, RunResult, AvailabilityCheck } from './types';
+import { estimateCostUsd } from '../pricing';
+import { execFileSync, spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+/**
+ * Gemini adapter — wraps the `gemini` CLI.
+ *
+ * Gemini CLI auth comes from either ~/.config/gemini/ or GOOGLE_API_KEY. Output
+ * format is NDJSON with `message`/`tool_use`/`result` events when `--output-format
+ * stream-json` is requested. This adapter uses a single-response form for simplicity
+ * in benchmarks; richer streaming lives in gemini-session-runner.ts.
+ */
+export class GeminiAdapter implements ProviderAdapter {
+  readonly name = 'gemini';
+  readonly family = 'gemini' as const;
+
+  async available(): Promise<AvailabilityCheck> {
+    const res = spawnSync('sh', ['-c', 'command -v gemini'], { timeout: 2000 });
+    if (res.status !== 0) {
+      return { ok: false, reason: 'gemini CLI not found on PATH. Install per https://github.com/google-gemini/gemini-cli' };
+    }
+    const cfgDir = path.join(os.homedir(), '.config', 'gemini');
+    const hasCfg = fs.existsSync(cfgDir);
+    const hasKey = !!process.env.GOOGLE_API_KEY;
+    if (!hasCfg && !hasKey) {
+      return { ok: false, reason: 'No Gemini auth found. Log in via `gemini login` or export GOOGLE_API_KEY.' };
+    }
+    return { ok: true };
+  }
+
+  async run(opts: RunOpts): Promise<RunResult> {
+    const start = Date.now();
+    // Default to --yolo (non-interactive) and stream-json output so we can parse
+    // tokens + tool calls. Callers can override via extraArgs.
+    const args = ['-p', opts.prompt, '--output-format', 'stream-json', '--yolo'];
+    if (opts.model) args.push('--model', opts.model);
+    if (opts.extraArgs) args.push(...opts.extraArgs);
+
+    try {
+      const out = execFileSync('gemini', args, {
+        cwd: opts.workdir,
+        timeout: opts.timeoutMs,
+        encoding: 'utf-8',
+        maxBuffer: 32 * 1024 * 1024,
+      });
+      const parsed = this.parseStreamJson(out);
+      return {
+        output: parsed.output,
+        tokens: parsed.tokens,
+        durationMs: Date.now() - start,
+        toolCalls: parsed.toolCalls,
+        modelUsed: parsed.modelUsed || opts.model || 'gemini-2.5-pro',
+      };
+    } catch (err: unknown) {
+      const durationMs = Date.now() - start;
+      const e = err as { code?: string; stderr?: Buffer; signal?: string; message?: string };
+      const stderr = e.stderr?.toString() ?? '';
+      if (e.signal === 'SIGTERM' || e.code === 'ETIMEDOUT') {
+        return this.emptyResult(durationMs, { code: 'timeout', reason: `exceeded ${opts.timeoutMs}ms` }, opts.model);
+      }
+      if (/unauthorized|auth|login|api key/i.test(stderr)) {
+        return this.emptyResult(durationMs, { code: 'auth', reason: stderr.slice(0, 400) }, opts.model);
+      }
+      if (/rate[- ]?limit|429|quota/i.test(stderr)) {
+        return this.emptyResult(durationMs, { code: 'rate_limit', reason: stderr.slice(0, 400) }, opts.model);
+      }
+      return this.emptyResult(durationMs, { code: 'unknown', reason: (e.message ?? stderr ?? 'unknown').slice(0, 400) }, opts.model);
+    }
+  }
+
+  estimateCost(tokens: { input: number; output: number; cached?: number }, model?: string): number {
+    return estimateCostUsd(tokens, model ?? 'gemini-2.5-pro');
+  }
+
+  /**
+   * Parse gemini NDJSON stream events:
+   *   init  → session id (discarded here)
+   *   message { delta: true, text } → concat to output
+   *   tool_use { name } → increment toolCalls
+   *   result { usage: { input_token_count, output_token_count } } → tokens
+   */
+  private parseStreamJson(raw: string): { output: string; tokens: { input: number; output: number }; toolCalls: number; modelUsed?: string } {
+    let output = '';
+    let input = 0;
+    let out = 0;
+    let toolCalls = 0;
+    let modelUsed: string | undefined;
+    for (const line of raw.split('\n')) {
+      const s = line.trim();
+      if (!s) continue;
+      try {
+        const obj = JSON.parse(s);
+        if (obj.type === 'message' && typeof obj.text === 'string') {
+          output += obj.text;
+        } else if (obj.type === 'tool_use') {
+          toolCalls += 1;
+        } else if (obj.type === 'result') {
+          const u = obj.usage ?? {};
+          input += u.input_token_count ?? u.prompt_tokens ?? 0;
+          out += u.output_token_count ?? u.completion_tokens ?? 0;
+          if (obj.model) modelUsed = obj.model;
+        }
+      } catch {
+        // skip malformed lines
+      }
+    }
+    return { output, tokens: { input, output: out }, toolCalls, modelUsed };
+  }
+
+  private emptyResult(durationMs: number, error: RunResult['error'], model?: string): RunResult {
+    return {
+      output: '',
+      tokens: { input: 0, output: 0 },
+      durationMs,
+      toolCalls: 0,
+      modelUsed: model ?? 'gemini-2.5-pro',
+      error,
+    };
+  }
+}

--- a/test/helpers/providers/gpt.ts
+++ b/test/helpers/providers/gpt.ts
@@ -1,0 +1,132 @@
+/**
+ * upstream `_upstream/gstack/test/helpers/providers/gpt.ts` からの data clone。
+ * subtree pull 時に drift していないか手動確認すること。
+ */
+
+import type { ProviderAdapter, RunOpts, RunResult, AvailabilityCheck } from './types';
+import { estimateCostUsd } from '../pricing';
+import { execFileSync, spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+/**
+ * GPT adapter — wraps the OpenAI `codex` CLI (codex exec with --json output).
+ *
+ * Codex uses ~/.codex/ for auth (not OPENAI_API_KEY). The --json flag emits
+ * JSONL events; we parse `turn.completed` for usage and `agent_message` / etc.
+ * for output aggregation.
+ */
+export class GptAdapter implements ProviderAdapter {
+  readonly name = 'gpt';
+  readonly family = 'gpt' as const;
+
+  async available(): Promise<AvailabilityCheck> {
+    const res = spawnSync('sh', ['-c', 'command -v codex'], { timeout: 2000 });
+    if (res.status !== 0) {
+      return { ok: false, reason: 'codex CLI not found on PATH. Install: npm i -g @openai/codex' };
+    }
+    // Auth sniff: ~/.codex/ should contain auth state after `codex login`
+    const codexDir = path.join(os.homedir(), '.codex');
+    if (!fs.existsSync(codexDir)) {
+      return { ok: false, reason: 'No ~/.codex/ found. Run `codex login` to authenticate via ChatGPT.' };
+    }
+    return { ok: true };
+  }
+
+  async run(opts: RunOpts): Promise<RunResult> {
+    const start = Date.now();
+    // `-s read-only` is load-bearing safety. With `--skip-git-repo-check` we
+    // bypass codex's interactive trust prompt for unknown directories (benchmarks
+    // often run in temp dirs / non-git paths), so the read-only sandbox is now
+    // the only boundary preventing codex from mutating the workdir. If you ever
+    // remove `-s read-only`, drop `--skip-git-repo-check` too.
+    const args = ['exec', opts.prompt, '-C', opts.workdir, '-s', 'read-only', '--skip-git-repo-check', '--json'];
+    if (opts.model) args.push('-m', opts.model);
+    if (opts.extraArgs) args.push(...opts.extraArgs);
+
+    try {
+      const out = execFileSync('codex', args, {
+        cwd: opts.workdir,
+        timeout: opts.timeoutMs,
+        encoding: 'utf-8',
+        maxBuffer: 32 * 1024 * 1024,
+      });
+      const parsed = this.parseJsonl(out);
+      return {
+        output: parsed.output,
+        tokens: parsed.tokens,
+        durationMs: Date.now() - start,
+        toolCalls: parsed.toolCalls,
+        modelUsed: parsed.modelUsed || opts.model || 'gpt-5.4',
+      };
+    } catch (err: unknown) {
+      const durationMs = Date.now() - start;
+      const e = err as { code?: string; stderr?: Buffer; signal?: string; message?: string };
+      const stderr = e.stderr?.toString() ?? '';
+      if (e.signal === 'SIGTERM' || e.code === 'ETIMEDOUT') {
+        return this.emptyResult(durationMs, { code: 'timeout', reason: `exceeded ${opts.timeoutMs}ms` }, opts.model);
+      }
+      if (/unauthorized|auth|login/i.test(stderr)) {
+        return this.emptyResult(durationMs, { code: 'auth', reason: stderr.slice(0, 400) }, opts.model);
+      }
+      if (/rate[- ]?limit|429/i.test(stderr)) {
+        return this.emptyResult(durationMs, { code: 'rate_limit', reason: stderr.slice(0, 400) }, opts.model);
+      }
+      return this.emptyResult(durationMs, { code: 'unknown', reason: (e.message ?? stderr ?? 'unknown').slice(0, 400) }, opts.model);
+    }
+  }
+
+  estimateCost(tokens: { input: number; output: number; cached?: number }, model?: string): number {
+    return estimateCostUsd(tokens, model ?? 'gpt-5.4');
+  }
+
+  /**
+   * Parse codex exec --json JSONL stream.
+   * Key events:
+   *   - item.completed with item.type === 'agent_message' → text output
+   *   - item.completed with item.type === 'command_execution' → tool call
+   *   - turn.completed → usage.input_tokens, usage.output_tokens
+   *   - thread.started → session id (not used here)
+   */
+  private parseJsonl(raw: string): { output: string; tokens: { input: number; output: number }; toolCalls: number; modelUsed?: string } {
+    let output = '';
+    let input = 0;
+    let out = 0;
+    let toolCalls = 0;
+    let modelUsed: string | undefined;
+    for (const line of raw.split('\n')) {
+      const s = line.trim();
+      if (!s) continue;
+      try {
+        const obj = JSON.parse(s);
+        if (obj.type === 'item.completed' && obj.item) {
+          if (obj.item.type === 'agent_message' && typeof obj.item.text === 'string') {
+            output += (output ? '\n' : '') + obj.item.text;
+          } else if (obj.item.type === 'command_execution') {
+            toolCalls += 1;
+          }
+        } else if (obj.type === 'turn.completed') {
+          const u = obj.usage ?? {};
+          input += u.input_tokens ?? 0;
+          out += u.output_tokens ?? 0;
+          if (obj.model) modelUsed = obj.model;
+        }
+      } catch {
+        // skip malformed lines — codex stderr can leak in
+      }
+    }
+    return { output, tokens: { input, output: out }, toolCalls, modelUsed };
+  }
+
+  private emptyResult(durationMs: number, error: RunResult['error'], model?: string): RunResult {
+    return {
+      output: '',
+      tokens: { input: 0, output: 0 },
+      durationMs,
+      toolCalls: 0,
+      modelUsed: model ?? 'gpt-5.4',
+      error,
+    };
+  }
+}

--- a/test/helpers/providers/types.ts
+++ b/test/helpers/providers/types.ts
@@ -1,0 +1,79 @@
+/**
+ * upstream `_upstream/gstack/test/helpers/providers/types.ts` からの data clone。
+ * subtree pull 時に drift していないか手動確認すること。
+ */
+
+/**
+ * Provider adapter interface — uniform contract for Claude, GPT, Gemini.
+ *
+ * Each adapter wraps an existing runner (session-runner.ts, codex-session-runner.ts,
+ * gemini-session-runner.ts) and normalizes its per-provider result shape into the
+ * RunResult below. The benchmark harness only talks to adapters through this
+ * interface, never to the underlying runners directly.
+ */
+
+export interface RunOpts {
+  /** The prompt to send to the model. */
+  prompt: string;
+  /** Working directory passed to the underlying CLI. */
+  workdir: string;
+  /** Hard wall-clock timeout in ms. Default: 300000 (5 min). */
+  timeoutMs: number;
+  /** Specific model within the family, optional. Adapters pass through to provider. */
+  model?: string;
+  /** Extra flags per-provider (escape hatch for rare cases). Prefer staying generic. */
+  extraArgs?: string[];
+}
+
+export interface TokenUsage {
+  input: number;
+  output: number;
+  /** Cached input tokens (Anthropic/OpenAI support). Undefined if provider doesn't report. */
+  cached?: number;
+}
+
+export type RunError =
+  | 'auth'       // Credentials missing or invalid.
+  | 'timeout'    // Exceeded timeoutMs.
+  | 'rate_limit' // Provider rate-limited us; backoff exceeded.
+  | 'binary_missing' // CLI not found on PATH.
+  | 'unknown';   // Catch-all with reason populated.
+
+export interface RunResult {
+  /** Provider's textual output for the prompt. */
+  output: string;
+  /** Normalized token usage. 0s if unreported. */
+  tokens: TokenUsage;
+  /** Wall-clock duration. */
+  durationMs: number;
+  /** Count of tool/function calls made during the run (0 if unsupported). */
+  toolCalls: number;
+  /** Actual model ID the provider reports using (may be a variant of the family). */
+  modelUsed: string;
+  /** If the run failed, error code + human reason. output/tokens may be partial. */
+  error?: { code: RunError; reason: string };
+}
+
+export interface AvailabilityCheck {
+  ok: boolean;
+  /** When !ok: short reason shown to user. Includes install / login / env var hint. */
+  reason?: string;
+}
+
+export type Family = 'claude' | 'gpt' | 'gemini';
+
+export interface ProviderAdapter {
+  /** Stable name used in output tables and config (e.g., 'claude', 'gpt', 'gemini'). */
+  readonly name: string;
+  /** Model family this adapter targets. */
+  readonly family: Family;
+  /**
+   * Check whether the provider's CLI binary is present and authenticated.
+   * Should never block >2s. Non-throwing: returns { ok: false, reason } on failure.
+   */
+  available(): Promise<AvailabilityCheck>;
+  /** Run a prompt and return normalized RunResult. Non-throwing. Errors go in result.error. */
+  run(opts: RunOpts): Promise<RunResult>;
+  /** Estimate USD cost for the reported token usage and model. */
+  estimateCost(tokens: TokenUsage, model?: string): number;
+}


### PR DESCRIPTION
## Summary

設計規律: uzustack コードから `_upstream/gstack/` への直接 import を全廃 (= subtree pull で上書きされる領域への依存を解消)。

**本 PR は PR #189 (CLOSED) の resurrection です。** PR #189 は stacked PR pattern で base = `feature/186-l2-19-l2-18-ci-gate` (PR #187) で起票されていたが、 PR #187 squash merge 時に `--delete-branch` flag で base branch が削除され、 GitHub が PR #189 を auto-close。 本 PR は同じ feature branch (`feature/188-upstream-import-elimination`、 rebase onto main 済) を head に、 base=main で再起票したもの。 commit content は PR #189 と同じ (R0 + R1 + R2 + R3 cleanup)。

## 変更内容 (cumulative、 全 4 commits)

### Round 0 (bc0cd8f): _upstream 直接 import 全廃

#### 1. scripts/resolvers/browse.ts
- line 14 の `import { COMMAND_DESCRIPTIONS } from '../../_upstream/gstack/browse/src/commands'` を削除
- `COMMAND_DESCRIPTIONS` 定数 (browse コマンド名/カテゴリ/説明文の対応表 90 行) を file 内に inline 複製
- 冒頭 JSDoc に「upstream `_upstream/gstack/browse/src/commands.ts` line 87-177 からの data clone、 subtree pull 時に drift していないか手動 sync 確認」 を明記

#### 2. test/helpers/ + providers/ (新規 7 file)
upstream `_upstream/gstack/test/helpers/` から mirror 複製。 各 file 冒頭に drift 確認 JSDoc を 5 行 prepend。 self-contained (= 7 file 内 relative import 閉じている)。

#### 3. bin/uzustack-model-benchmark
5 import path を `../_upstream/gstack/test/helpers/...` → `../test/helpers/...` に書き換え。

### Round 1 (e4dafef): drift detection CI 化 + workflow path trigger + 規律 documentation

- workflow path trigger に `test/helpers/**` 追加
- bin-smoke-test workflow に `drift-check` job 新規 (7 mirror file bit-for-bit 比較)
- CONTRIBUTING.md に「mirror file の sync」 section 追加
- browse.ts inline drift check follow-up: 当初 #190 起票 → R3 cleanup で取り下げ (browse skill 実装方針未決定段階での先走起票)

### Round 2 (b472a4b): bash snippet bug fix + SNAPSHOT_FLAGS sync 規律明示 + JSDoc update

- CONTRIBUTING bash snippet の `$(head -5)` blank line loss bug fix (= file-based merge approach に書き換え)
- CONTRIBUTING table に SNAPSHOT_FLAGS 行追加
- browse.ts top-level JSDoc を「import から data clone」 に update

### R3 cleanup (9ed8959): #190 follow-up 取り下げ + CONTRIBUTING.md reference 除去

- CONTRIBUTING.md:212 の #190 reference を「browse skill 実装方針確定後に CI 化判断」 に書き換え
- #190 は close 済 (close note 添付: browse skill 実装方針確定時に再評価、 必要なら新規 issue 起票)
- 理由: workflow.md 規律「step 着手 = issue 起票を機械適用しない」 遵守

## Acceptance criteria

- [x] scripts/resolvers/browse.ts:14 の `_upstream` import 削除、 COMMAND_DESCRIPTIONS inline 化、 drift コメント追記
- [x] uzustack root に test/helpers/ + providers/ directory 作成、 7 file 複製
- [x] 複製 file 全てに drift 確認コメント追記 (各 5 行 header)
- [x] bin/uzustack-model-benchmark の 5 import path を `../test/helpers/...` に書き換え
- [x] `_upstream` 直接 import 全廃 grep 0 件確認 (uzustack 配下 = `_upstream` / `node_modules` を除く全 file、 拡張子問わず)
- [ ] CI bin-smoke-test workflow 緑 (本 PR push 後の Actions で確認)
- [ ] `bun bin/uzustack-model-benchmark --dry-run --prompt "test" --models claude` で exit 0、 import 解決成功
- [x] `bun run gen:skill-docs` で browse.ts inline 化 + Round 2 JSDoc update が resolver 経由で正しく動く (= 3 SKILL.md 再生成成功)
- [x] sanitize 規律: 個人 path / vault 名 / OS user 名 grep 0 件

## Test plan

- [ ] PR push 後の GH Actions 緑期待 (= 48/48 SUCCESS、 PR #189 で実証済)
- [x] drift-check job が実機で動作確認 (PR #189 の Round 1 push 時 SUCCESS)
- [x] CONTRIBUTING bash snippet を実機 test (PR #189 の Round 2 で実証済)
- [x] Round 0 で意図的 import 破壊 test を別 branch で実施 (PR #187 の test plan、 当該 1 bin だけ赤 = precision 100% / recall 100% 実証済)

## Code review log

PR #189 で実施済 (= Round 1 + Round 2 + R3 cleanup の 3 周分)。 詳細は PR #189 body 参照。 本 PR は同じ commit content の resurrection なので /code-review x2 規律は再実行不要 (= review.md「3 周目はやらない」 と同精神)。

## 位置付け

- 元 PR #189 (CLOSED、 audit trail 維持) の resurrection
- 事故記録: PR #187 を `gh pr merge --squash --delete-branch` で land した際、 PR #189 の base branch が削除されて auto-close + 復旧不可になった (= stacked PR base を delete-branch する事故)
- 学習: stacked PR の land 順序で `--delete-branch` flag を base に適用する場合、 stacked head の reopen が GitHub 仕様で不可能。 stacked PR が複数ある場合、 base を delete せず手動 cleanup する規律必要
- Phase 4 close 前の規律 cluster の一部
- merge 後 = uzustack コードから `_upstream/gstack/` 直接 import は永続的に 0 件 + CI で drift 検出 (test/helpers/ mirror) + browse.ts inline は手動 review + 規律 documented

Closes #188
Refs #189 (CLOSED、 resurrection 元)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
