### PR TITLE
feat: #196 — subtree-coverage.ts (gstack vs uzustack 4 値判定 + scope 拡張 baseline)

### DIFF
--- a/scripts/parity-audit.ts
+++ b/scripts/parity-audit.ts
@@ -1,0 +1,206 @@
+#!/usr/bin/env bun
+/**
+ * Parity audit — gstack subtree vs uzustack top の対応 file 機械判定。
+ *
+ * `_upstream/gstack/` 配下の全 tracked file について uzustack 側の対応 file 存在を判定し、
+ * 4 値に分類する：
+ *
+ *   (a) 完璧複製       — 両側存在 + frontmatter `status` が phase6-reserved でない
+ *   (b1) 意図的 stub   — file 存在 + frontmatter `status: phase6-reserved` (= 14 件 Phase 6 予約)
+ *   (b2) 意図的取り込まない — 対応 file 不在 + `docs/uzustack/intentionally-excluded-files.md` 記載
+ *   (c) 漏れ           — 上記いずれにも該当しない
+ *
+ * D2 (upstream_sync 自動化) の baseline、月次 subtree pull 後の drift detection に活用。
+ *
+ * Modes:
+ *   default                                — human-readable summary + (c) 一覧
+ *   --json                                 — 全 entries の json output
+ *   --only a|b1|b2|c                       — category filter
+ *
+ * 対応 file 検出 rule (= uzustack 側で期待する path):
+ *   - prefix swap: `bin/gstack-*` → `bin/uzustack-*`、 `<gstack-name>/` → `<uzustack-name>/`
+ *   - `open-gstack-browser/` → `open-uzustack-browser/`
+ *   - 例外 (= upstream signal で確定の同名 mirror): chrome-cdp / dev-setup / dev-teardown
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { execSync } from 'child_process';
+import { parseFrontmatter } from './frontmatter';
+
+const ROOT = path.resolve(import.meta.dir, '..');
+const GSTACK_SUBTREE = '_upstream/gstack';
+
+type Category = 'a' | 'b1' | 'b2' | 'c';
+
+interface FileEntry {
+  gstack_path: string;          // gstack subtree 内 path (= _upstream/gstack/ prefix 削除済)
+  uzustack_path: string;        // uzustack 側で期待する path
+  uzustack_exists: boolean;
+  category: Category;
+  reason: string;
+}
+
+interface AuditSummary {
+  total: number;
+  a: number;
+  b1: number;
+  b2: number;
+  c: number;
+}
+
+// ─── upstream signal で「同名 mirror」 確定の例外 file ──────────────
+// `.claude/rules/review.md` 規律: upstream が prefix なしで運用している file は uzustack も同名
+const PREFIX_SWAP_EXCEPTIONS = new Set([
+  'bin/chrome-cdp',
+  'bin/dev-setup',
+  'bin/dev-teardown',
+]);
+
+// ─── (b2) 意図的取り込まない list ────────────────────────────
+// docs/uzustack/intentionally-excluded-files.md と sync (= 後続 PR で確立、本 PR では空)
+const B2_LIST = new Set<string>([
+  // PR-2 で工藤さん taste call 後に充填
+]);
+
+// ─── path 変換: gstack 内 path → uzustack 側で期待する path ───
+function expectedUzustackPath(gstackInnerPath: string): string {
+  if (PREFIX_SWAP_EXCEPTIONS.has(gstackInnerPath)) return gstackInnerPath;
+
+  return gstackInnerPath
+    .replace(/(^|\/)gstack-/g, '$1uzustack-')
+    .replace(/(^|\/)open-gstack-browser(\/|$)/g, '$1open-uzustack-browser$2');
+}
+
+// ─── frontmatter status 抽出 (= phase6-reserved 判定用) ─────
+function extractStatus(absPath: string): string | null {
+  try {
+    const content = fs.readFileSync(absPath, 'utf-8');
+    const fm = parseFrontmatter(content);
+    if (!fm) return null;
+    const statusLine = fm.split('\n').find(l => l.startsWith('status:'));
+    if (!statusLine) return null;
+    return statusLine.replace(/^status:\s*/, '').trim();
+  } catch {
+    return null;
+  }
+}
+
+// ─── main audit ────────────────────────────────────────────
+function audit(): FileEntry[] {
+  const rawList = execSync(`git ls-files ${GSTACK_SUBTREE}`, {
+    cwd: ROOT,
+    encoding: 'utf-8',
+  });
+
+  const gstackFiles = rawList
+    .trim()
+    .split('\n')
+    .filter(p => p.length > 0)
+    .map(p => p.replace(`${GSTACK_SUBTREE}/`, ''));
+
+  // Pass 1: phase6-reserved skill directory の特定
+  // SKILL.md.tmpl が status: phase6-reserved の skill dir は配下 file 全部 (b1) 扱い
+  const phase6SkillDirs = new Set<string>();
+  for (const gpath of gstackFiles) {
+    if (!gpath.endsWith('/SKILL.md.tmpl') && gpath !== 'SKILL.md.tmpl') continue;
+    const uzPath = expectedUzustackPath(gpath);
+    const uzAbs = path.join(ROOT, uzPath);
+    if (!fs.existsSync(uzAbs)) continue;
+    if (extractStatus(uzAbs) !== 'phase6-reserved') continue;
+    const skillDir = gpath.replace(/\/?SKILL\.md\.tmpl$/, '');
+    if (skillDir) phase6SkillDirs.add(skillDir);
+  }
+
+  const inPhase6SkillDir = (gpath: string): string | null => {
+    for (const dir of phase6SkillDirs) {
+      if (gpath === `${dir}/SKILL.md.tmpl`) return dir;
+      if (gpath.startsWith(`${dir}/`)) return dir;
+    }
+    return null;
+  };
+
+  // Pass 2: per-file 判定
+  const entries: FileEntry[] = [];
+
+  for (const gpath of gstackFiles) {
+    const uzPath = expectedUzustackPath(gpath);
+    const uzAbs = path.join(ROOT, uzPath);
+    const uzExists = fs.existsSync(uzAbs);
+
+    let category: Category;
+    let reason: string;
+
+    const phase6Dir = inPhase6SkillDir(gpath);
+    if (phase6Dir !== null) {
+      category = 'b1';
+      reason = gpath === `${phase6Dir}/SKILL.md.tmpl`
+        ? `意図的 stub (frontmatter status: phase6-reserved、 skill: ${phase6Dir})`
+        : `意図的 stub (Phase 6 予約 skill 配下、 parent: ${phase6Dir})`;
+    } else if (uzExists) {
+      const status = uzPath.endsWith('SKILL.md.tmpl') ? extractStatus(uzAbs) : null;
+      category = 'a';
+      reason = status
+        ? `完璧複製 candidate (uzustack 側存在、 status: ${status})`
+        : '完璧複製 candidate (uzustack 側存在)';
+    } else {
+      if (B2_LIST.has(gpath) || B2_LIST.has(uzPath)) {
+        category = 'b2';
+        reason = '意図的取り込まない (intentionally-excluded-files.md 記載)';
+      } else {
+        category = 'c';
+        reason = `漏れ (期待 path: ${uzPath})`;
+      }
+    }
+
+    entries.push({
+      gstack_path: gpath,
+      uzustack_path: uzPath,
+      uzustack_exists: uzExists,
+      category,
+      reason,
+    });
+  }
+
+  return entries;
+}
+
+function buildSummary(entries: FileEntry[]): AuditSummary {
+  return {
+    total: entries.length,
+    a: entries.filter(e => e.category === 'a').length,
+    b1: entries.filter(e => e.category === 'b1').length,
+    b2: entries.filter(e => e.category === 'b2').length,
+    c: entries.filter(e => e.category === 'c').length,
+  };
+}
+
+// ─── CLI ───────────────────────────────────────────────────
+const args = process.argv.slice(2);
+const jsonMode = args.includes('--json');
+const onlyIdx = args.indexOf('--only');
+const filterCategory = onlyIdx >= 0 ? (args[onlyIdx + 1] as Category) : null;
+
+const entries = audit();
+const summary = buildSummary(entries);
+const filtered = filterCategory
+  ? entries.filter(e => e.category === filterCategory)
+  : entries;
+
+if (jsonMode) {
+  console.log(JSON.stringify({ summary, entries: filtered }, null, 2));
+} else {
+  console.log('=== parity audit summary ===');
+  console.log(`  total: ${summary.total}`);
+  console.log(`  (a) 完璧複製: ${summary.a}`);
+  console.log(`  (b1) 意図的 stub: ${summary.b1}`);
+  console.log(`  (b2) 意図的取り込まない: ${summary.b2}`);
+  console.log(`  (c) 漏れ: ${summary.c}`);
+  console.log();
+  if (summary.c > 0) {
+    console.log('=== (c) 漏れ list ===');
+    for (const e of entries.filter(e => e.category === 'c')) {
+      console.log(`  - ${e.gstack_path}  →  ${e.uzustack_path}`);
+    }
+  }
+}

--- a/scripts/subtree-coverage.ts
+++ b/scripts/subtree-coverage.ts
@@ -6,13 +6,13 @@
  * 4 値に分類する：
  *
  *   (a) 完璧複製       — 両側存在 + frontmatter `status` が「予約 status」 でない
- *   (b1) 意図的 stub   — file 存在 + frontmatter `status` が「予約 status」 (= 14 件 Phase 6 予約等)
+ *   (b1) 意図的 stub   — file 存在 + frontmatter `status` が「予約 status」 (= `RESERVED_STATUSES` 参照)
  *   (b2) 意図的取り込まない — 対応 file 不在 + `docs/uzustack/intentionally-excluded-files.md` 記載
  *   (c) 漏れ           — 上記いずれにも該当しない
  *
  * D2 (upstream_sync 自動化) の baseline、月次 subtree pull 後の drift detection に活用。
  *
- * 「予約 status」 は将来の phase 拡張で増える前提 (= `RESERVED_STATUSES` Set で集約、 phase7-reserved 等の追加点)。
+ * 「予約 status」 は将来の phase 拡張で増える前提 (= `RESERVED_STATUSES` Set で集約)。
  *
  * Modes:
  *   default                                — human-readable summary + (c) 一覧
@@ -52,7 +52,7 @@ interface CoverageSummary {
 }
 
 // ─── 予約 status: (b1) 意図的 stub の source-of-truth ────────────
-// 将来の phase 拡張で増える前提 (= phase7-reserved 等の追加点を本 Set に集約)
+// 将来の phase 拡張で増える予約 status を本 Set に集約 (= 追加時は entry を足すだけ)
 const RESERVED_STATUSES = new Set([
   'phase6-reserved',
 ]);
@@ -108,29 +108,25 @@ function survey(): FileEntry[] {
     .filter(p => p.length > 0)
     .map(p => p.replace(`${GSTACK_SUBTREE}/`, ''));
 
-  // Pass 1: SKILL.md.tmpl の status を cache + 予約 status skill dir 特定
-  // 配下 file は parent dir 経由で (b1) 判定 (= 2-pass で重複 read を回避)
-  const statusCache = new Map<string, string | null>();
+  // Pass 1: SKILL.md.tmpl の exists + status を cache + 予約 status skill dir 特定
+  // 配下 file は parent dir 経由で (b1) 判定 (= 重複 fs call を回避)
+  const tmplExistsCache = new Map<string, boolean>();
+  const statusCache = new Map<string, string>();
   const reservedSkillDirs = new Set<string>();
   for (const gpath of gstackFiles) {
     if (!gpath.endsWith('/SKILL.md.tmpl')) continue;
-    const uzPath = expectedUzustackPath(gpath);
-    const uzAbs = path.join(ROOT, uzPath);
-    if (!fs.existsSync(uzAbs)) continue;
+    const uzAbs = path.join(ROOT, expectedUzustackPath(gpath));
+    const exists = fs.existsSync(uzAbs);
+    tmplExistsCache.set(gpath, exists);
+    if (!exists) continue;
     const status = extractStatus(uzAbs);
-    statusCache.set(gpath, status);
-    if (status && RESERVED_STATUSES.has(status)) {
-      reservedSkillDirs.add(gpath.replace(/\/SKILL\.md\.tmpl$/, ''));
+    if (status) {
+      statusCache.set(gpath, status);
+      if (RESERVED_STATUSES.has(status)) {
+        reservedSkillDirs.add(gpath.replace(/\/SKILL\.md\.tmpl$/, ''));
+      }
     }
   }
-
-  // O(1) lookup: gpath の最上位 directory を抽出して Set check
-  const reservedDirOf = (gpath: string): string | null => {
-    const idx = gpath.indexOf('/');
-    if (idx < 0) return null;
-    const parent = gpath.slice(0, idx);
-    return reservedSkillDirs.has(parent) ? parent : null;
-  };
 
   // Pass 2: per-file 判定
   const entries: FileEntry[] = [];
@@ -138,22 +134,24 @@ function survey(): FileEntry[] {
   for (const gpath of gstackFiles) {
     const uzPath = expectedUzustackPath(gpath);
     const uzAbs = path.join(ROOT, uzPath);
-    const uzExists = fs.existsSync(uzAbs);
+    const uzExists = tmplExistsCache.get(gpath) ?? fs.existsSync(uzAbs);
 
     let category: Category;
     let reason: string;
 
-    const reservedDir = reservedDirOf(gpath);
+    // O(1) lookup: gpath の最上位 directory が予約 skill か
+    const slashIdx = gpath.indexOf('/');
+    const parent = slashIdx >= 0 ? gpath.slice(0, slashIdx) : null;
+    const reservedDir = parent && reservedSkillDirs.has(parent) ? parent : null;
+
     if (reservedDir !== null) {
       category = 'b1';
       reason = gpath === `${reservedDir}/SKILL.md.tmpl`
         ? `意図的 stub (予約 status、 skill: ${reservedDir})`
         : `意図的 stub (予約 skill 配下、 parent: ${reservedDir})`;
     } else if (uzExists) {
-      // SKILL.md.tmpl は Pass 1 で cache 済、 それ以外は status null
-      const status = uzPath.endsWith('SKILL.md.tmpl')
-        ? (statusCache.get(gpath) ?? null)
-        : null;
+      // SKILL.md.tmpl は Pass 1 で cache 済 (= 非 tmpl path は undefined)
+      const status = statusCache.get(gpath);
       category = 'a';
       reason = status
         ? `完璧複製 candidate (uzustack 側存在、 status: ${status})`
@@ -195,12 +193,11 @@ const filterCategory = onlyIdx >= 0 ? (args[onlyIdx + 1] as Category) : null;
 
 const entries = survey();
 const summary = buildSummary(entries);
-const missing = entries.filter(e => e.category === 'c');
-const filtered = filterCategory
-  ? entries.filter(e => e.category === filterCategory)
-  : entries;
 
 if (jsonMode) {
+  const filtered = filterCategory
+    ? entries.filter(e => e.category === filterCategory)
+    : entries;
   console.log(JSON.stringify({ summary, entries: filtered }, null, 2));
 } else {
   console.log('=== subtree coverage summary ===');
@@ -210,10 +207,12 @@ if (jsonMode) {
   console.log(`  (b2) 意図的取り込まない: ${summary.b2}`);
   console.log(`  (c) 漏れ: ${summary.c}`);
   console.log();
-  if (missing.length > 0) {
+  if (summary.c > 0) {
     console.log('=== (c) 漏れ list ===');
-    for (const e of missing) {
-      console.log(`  - ${e.gstack_path}  →  ${e.uzustack_path}`);
+    for (const e of entries) {
+      if (e.category === 'c') {
+        console.log(`  - ${e.gstack_path}  →  ${e.uzustack_path}`);
+      }
     }
   }
 }

--- a/scripts/subtree-coverage.ts
+++ b/scripts/subtree-coverage.ts
@@ -5,12 +5,14 @@
  * `_upstream/gstack/` 配下の全 tracked file について uzustack 側の対応 file 存在を判定し、
  * 4 値に分類する：
  *
- *   (a) 完璧複製       — 両側存在 + frontmatter `status` が phase6-reserved でない
- *   (b1) 意図的 stub   — file 存在 + frontmatter `status: phase6-reserved` (= 14 件 Phase 6 予約)
+ *   (a) 完璧複製       — 両側存在 + frontmatter `status` が「予約 status」 でない
+ *   (b1) 意図的 stub   — file 存在 + frontmatter `status` が「予約 status」 (= 14 件 Phase 6 予約等)
  *   (b2) 意図的取り込まない — 対応 file 不在 + `docs/uzustack/intentionally-excluded-files.md` 記載
  *   (c) 漏れ           — 上記いずれにも該当しない
  *
  * D2 (upstream_sync 自動化) の baseline、月次 subtree pull 後の drift detection に活用。
+ *
+ * 「予約 status」 は将来の phase 拡張で増える前提 (= `RESERVED_STATUSES` Set で集約、 phase7-reserved 等の追加点)。
  *
  * Modes:
  *   default                                — human-readable summary + (c) 一覧
@@ -34,8 +36,8 @@ const GSTACK_SUBTREE = '_upstream/gstack';
 type Category = 'a' | 'b1' | 'b2' | 'c';
 
 interface FileEntry {
-  gstack_path: string;          // gstack subtree 内 path (= _upstream/gstack/ prefix 削除済)
-  uzustack_path: string;        // uzustack 側で期待する path
+  gstack_path: string;
+  uzustack_path: string;
   uzustack_exists: boolean;
   category: Category;
   reason: string;
@@ -49,6 +51,12 @@ interface CoverageSummary {
   c: number;
 }
 
+// ─── 予約 status: (b1) 意図的 stub の source-of-truth ────────────
+// 将来の phase 拡張で増える前提 (= phase7-reserved 等の追加点を本 Set に集約)
+const RESERVED_STATUSES = new Set([
+  'phase6-reserved',
+]);
+
 // ─── upstream signal で「同名 mirror」 確定の例外 file ──────────────
 // `.claude/rules/review.md` 規律: upstream が prefix なしで運用している file は uzustack も同名
 const PREFIX_SWAP_EXCEPTIONS = new Set([
@@ -58,9 +66,10 @@ const PREFIX_SWAP_EXCEPTIONS = new Set([
 ]);
 
 // ─── (b2) 意図的取り込まない list ────────────────────────────
-// docs/uzustack/intentionally-excluded-files.md と sync (= 後続 PR で確立、本 PR では空)
+// docs/uzustack/intentionally-excluded-files.md と sync (= 後続 PR で確立、 本 PR では空)
+// key は gstack_path (= subtree 内 path、 uzustack_path side は内部 fallback で吸収)
 const B2_LIST = new Set<string>([
-  // PR-2 で工藤さん taste call 後に充填
+  // PR-2 で最終判断後に充填
 ]);
 
 // ─── path 変換: gstack 内 path → uzustack 側で期待する path ───
@@ -72,7 +81,7 @@ function expectedUzustackPath(gstackInnerPath: string): string {
     .replace(/(^|\/)open-gstack-browser(\/|$)/g, '$1open-uzustack-browser$2');
 }
 
-// ─── frontmatter status 抽出 (= phase6-reserved 判定用) ─────
+// ─── frontmatter status 抽出 ─────────────────────────────────
 function extractStatus(absPath: string): string | null {
   try {
     const content = fs.readFileSync(absPath, 'utf-8');
@@ -99,25 +108,28 @@ function survey(): FileEntry[] {
     .filter(p => p.length > 0)
     .map(p => p.replace(`${GSTACK_SUBTREE}/`, ''));
 
-  // Pass 1: phase6-reserved skill directory の特定
-  // SKILL.md.tmpl が status: phase6-reserved の skill dir は配下 file 全部 (b1) 扱い
-  const phase6SkillDirs = new Set<string>();
+  // Pass 1: SKILL.md.tmpl の status を cache + 予約 status skill dir 特定
+  // 配下 file は parent dir 経由で (b1) 判定 (= 2-pass で重複 read を回避)
+  const statusCache = new Map<string, string | null>();
+  const reservedSkillDirs = new Set<string>();
   for (const gpath of gstackFiles) {
-    if (!gpath.endsWith('/SKILL.md.tmpl') && gpath !== 'SKILL.md.tmpl') continue;
+    if (!gpath.endsWith('/SKILL.md.tmpl')) continue;
     const uzPath = expectedUzustackPath(gpath);
     const uzAbs = path.join(ROOT, uzPath);
     if (!fs.existsSync(uzAbs)) continue;
-    if (extractStatus(uzAbs) !== 'phase6-reserved') continue;
-    const skillDir = gpath.replace(/\/?SKILL\.md\.tmpl$/, '');
-    if (skillDir) phase6SkillDirs.add(skillDir);
+    const status = extractStatus(uzAbs);
+    statusCache.set(gpath, status);
+    if (status && RESERVED_STATUSES.has(status)) {
+      reservedSkillDirs.add(gpath.replace(/\/SKILL\.md\.tmpl$/, ''));
+    }
   }
 
-  const inPhase6SkillDir = (gpath: string): string | null => {
-    for (const dir of phase6SkillDirs) {
-      if (gpath === `${dir}/SKILL.md.tmpl`) return dir;
-      if (gpath.startsWith(`${dir}/`)) return dir;
-    }
-    return null;
+  // O(1) lookup: gpath の最上位 directory を抽出して Set check
+  const reservedDirOf = (gpath: string): string | null => {
+    const idx = gpath.indexOf('/');
+    if (idx < 0) return null;
+    const parent = gpath.slice(0, idx);
+    return reservedSkillDirs.has(parent) ? parent : null;
   };
 
   // Pass 2: per-file 判定
@@ -131,14 +143,17 @@ function survey(): FileEntry[] {
     let category: Category;
     let reason: string;
 
-    const phase6Dir = inPhase6SkillDir(gpath);
-    if (phase6Dir !== null) {
+    const reservedDir = reservedDirOf(gpath);
+    if (reservedDir !== null) {
       category = 'b1';
-      reason = gpath === `${phase6Dir}/SKILL.md.tmpl`
-        ? `意図的 stub (frontmatter status: phase6-reserved、 skill: ${phase6Dir})`
-        : `意図的 stub (Phase 6 予約 skill 配下、 parent: ${phase6Dir})`;
+      reason = gpath === `${reservedDir}/SKILL.md.tmpl`
+        ? `意図的 stub (予約 status、 skill: ${reservedDir})`
+        : `意図的 stub (予約 skill 配下、 parent: ${reservedDir})`;
     } else if (uzExists) {
-      const status = uzPath.endsWith('SKILL.md.tmpl') ? extractStatus(uzAbs) : null;
+      // SKILL.md.tmpl は Pass 1 で cache 済、 それ以外は status null
+      const status = uzPath.endsWith('SKILL.md.tmpl')
+        ? (statusCache.get(gpath) ?? null)
+        : null;
       category = 'a';
       reason = status
         ? `完璧複製 candidate (uzustack 側存在、 status: ${status})`
@@ -165,14 +180,11 @@ function survey(): FileEntry[] {
   return entries;
 }
 
+// 1-pass counter で summary 構築 (= 4 回 filter scan を避ける)
 function buildSummary(entries: FileEntry[]): CoverageSummary {
-  return {
-    total: entries.length,
-    a: entries.filter(e => e.category === 'a').length,
-    b1: entries.filter(e => e.category === 'b1').length,
-    b2: entries.filter(e => e.category === 'b2').length,
-    c: entries.filter(e => e.category === 'c').length,
-  };
+  const s: CoverageSummary = { total: entries.length, a: 0, b1: 0, b2: 0, c: 0 };
+  for (const e of entries) s[e.category]++;
+  return s;
 }
 
 // ─── CLI ───────────────────────────────────────────────────
@@ -183,6 +195,7 @@ const filterCategory = onlyIdx >= 0 ? (args[onlyIdx + 1] as Category) : null;
 
 const entries = survey();
 const summary = buildSummary(entries);
+const missing = entries.filter(e => e.category === 'c');
 const filtered = filterCategory
   ? entries.filter(e => e.category === filterCategory)
   : entries;
@@ -197,9 +210,9 @@ if (jsonMode) {
   console.log(`  (b2) 意図的取り込まない: ${summary.b2}`);
   console.log(`  (c) 漏れ: ${summary.c}`);
   console.log();
-  if (summary.c > 0) {
+  if (missing.length > 0) {
     console.log('=== (c) 漏れ list ===');
-    for (const e of entries.filter(e => e.category === 'c')) {
+    for (const e of missing) {
       console.log(`  - ${e.gstack_path}  →  ${e.uzustack_path}`);
     }
   }

--- a/scripts/subtree-coverage.ts
+++ b/scripts/subtree-coverage.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 /**
- * Parity audit — gstack subtree vs uzustack top の対応 file 機械判定。
+ * Subtree coverage — gstack subtree vs uzustack top の対応 file 機械判定。
  *
  * `_upstream/gstack/` 配下の全 tracked file について uzustack 側の対応 file 存在を判定し、
  * 4 値に分類する：
@@ -41,7 +41,7 @@ interface FileEntry {
   reason: string;
 }
 
-interface AuditSummary {
+interface CoverageSummary {
   total: number;
   a: number;
   b1: number;
@@ -86,8 +86,8 @@ function extractStatus(absPath: string): string | null {
   }
 }
 
-// ─── main audit ────────────────────────────────────────────
-function audit(): FileEntry[] {
+// ─── main survey ────────────────────────────────────────────
+function survey(): FileEntry[] {
   const rawList = execSync(`git ls-files ${GSTACK_SUBTREE}`, {
     cwd: ROOT,
     encoding: 'utf-8',
@@ -165,7 +165,7 @@ function audit(): FileEntry[] {
   return entries;
 }
 
-function buildSummary(entries: FileEntry[]): AuditSummary {
+function buildSummary(entries: FileEntry[]): CoverageSummary {
   return {
     total: entries.length,
     a: entries.filter(e => e.category === 'a').length,
@@ -181,7 +181,7 @@ const jsonMode = args.includes('--json');
 const onlyIdx = args.indexOf('--only');
 const filterCategory = onlyIdx >= 0 ? (args[onlyIdx + 1] as Category) : null;
 
-const entries = audit();
+const entries = survey();
 const summary = buildSummary(entries);
 const filtered = filterCategory
   ? entries.filter(e => e.category === filterCategory)
@@ -190,7 +190,7 @@ const filtered = filterCategory
 if (jsonMode) {
   console.log(JSON.stringify({ summary, entries: filtered }, null, 2));
 } else {
-  console.log('=== parity audit summary ===');
+  console.log('=== subtree coverage summary ===');
   console.log(`  total: ${summary.total}`);
   console.log(`  (a) 完璧複製: ${summary.a}`);
   console.log(`  (b1) 意図的 stub: ${summary.b1}`);


### PR DESCRIPTION
## Summary

`scripts/subtree-coverage.ts` を新規実装。 gstack subtree (`_upstream/gstack/`) と uzustack top の全 tracked file 単位で対応関係を 4 値判定し、 D2 upstream_sync 自動化の baseline として export する。

Part of #196 (Phase 5 D1 — gstack 機能 stub 以外完全実装 + subtree coverage infra)。 本 PR は scripts/subtree-coverage.ts 実装のみで、 #196 close は (b2)/(c) 振り分け + 漏れ fix 完遂時 (= PR-3 後)。

## 4 値判定 articulation

| category | 判定基準 | 実機 run 件数 |
|---|---|---|
| (a) 完璧複製 | 両側存在 + frontmatter status が phase6-reserved でない | 229 |
| (b1) 意図的 stub | phase6-reserved skill (= SKILL.md.tmpl 14 件) + その skill dir 配下 file | 168 |
| (b2) 意図的取り込まない | 対応 file 不在 + 正典 list 記載 (= `B2_LIST`、 本 PR では空 stub) | 0 |
| (c) 漏れ | 上記いずれにも該当しない gstack 側 file | 237 |

**合計 634 件** (= `git ls-files _upstream/gstack/` baseline)

## 対応 file 検出 rule

- prefix swap: `bin/gstack-*` → `bin/uzustack-*`、 `<gstack-name>/` → `<uzustack-name>/`、 `open-gstack-browser/` → `open-uzustack-browser/`
- 例外: `bin/chrome-cdp` / `bin/dev-setup` / `bin/dev-teardown` (= `.claude/rules/review.md`「upstream は最強の reviewer signal」 規律で同名 mirror)

## scope 拡張の背景

旧 implicit scope (= `bin/` + `scripts/` + `*/SKILL.md.tmpl` のみ) では **root level file (AGENTS.md / TODOS.md / .gitlab-ci.yml / conductor.json 等) が漏れる defect** があった。 本 audit は `git ls-files _upstream/gstack/` で全 tracked file を baseline として、 implicit scope shrink を構造的に防止 (= workflow.md「scope 縮小より機械化を優先」 規律と整合)。

## 使い方

```bash
bun run scripts/subtree-coverage.ts                  # human-readable summary
bun run scripts/subtree-coverage.ts --json           # 全 entries の json
bun run scripts/subtree-coverage.ts --json --only c  # (c) 漏れだけ json
```

## 後続 PR

- **PR-2** (= 別 PR): `docs/uzustack/intentionally-excluded-files.md` 新設 + `B2_LIST` 充填。 振り分け = メンテナー 最終判断、 #201 子 issue (= 13 sub-issue #202..#214) で内容調査完了後。
- **PR-3** (= 別 PR): 真の (c) 漏れ fix (= bin 1 件 = shell 版 `gstack-global-discover` mirror + scripts/ 取り込み判定 結果 fix 等)。

## Test plan

- [x] `bun run scripts/subtree-coverage.ts` で human-readable summary 出力確認 (= round 1 + round 2 後 634/229/168/0/237 確認)
- [x] `bun run scripts/subtree-coverage.ts --json --only c` で (c) 一覧 json export 確認 (= 237 件 ✓)
- [x] `bun run scripts/subtree-coverage.ts --json --only b1` で (b1) 168 件確認 (= summary baseline と一致)
- [x] /simplify を 2 回実行 (= round 1: メンテナー intervention 2 + apply 6 件 / round 2: drift 8 件 fix、 3 周目 skip)